### PR TITLE
Fix for Issue #105: Tag Control fields not working in SSUI

### DIFF
--- a/client/app/components/dialog-content/dialog-content.html
+++ b/client/app/components/dialog-content/dialog-content.html
@@ -67,6 +67,15 @@
                       ng-options="fieldValue[0] as fieldValue[1] for fieldValue in dialogField.values">
                     </select>
 
+                    <select
+                      ng-switch-when="DialogFieldTagControl"
+                      ng-model="dialogField.default_value"
+                      ng-disabled="dialogField.read_only || vm.inputDisabled"
+                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      class="form-control"
+                      ng-options="fieldValue.id as fieldValue.description for fieldValue in dialogField.values">
+                    </select>
+
                     <span
                       ng-switch-when="DialogFieldRadioButton"
                       class="btn-group">


### PR DESCRIPTION
Now able to see Tab Control dropdown in SUI:

![tagcontrol](https://cloud.githubusercontent.com/assets/12733153/19492232/dfd8b922-9543-11e6-868a-fa1b2a1adb78.png)

@chriskacerguis @serenamarie125 