### PR TITLE
Service power operations in Service UI

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,7 @@
     "angular-bootstrap": "^0.13.3",
     "angular-dragdrop": "~1.0.12",
     "angular-gettext": "~2.3.7",
-    "angular-patternfly": "^3.11.0",
+    "angular-patternfly": "^3.12.0",
     "angular-drag-and-drop-lists": "~1.4.0",
     "angular-svg-base": "^0.0.3",
     "angular-ui-router": "~0.3.1",

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -22,7 +22,7 @@
       </div>
       <div class="col-lg-2 col-md-4 col-sm-6 col-xs-6">
         <span class="no-wrap">
-          <strong translate>Retirement Date</strong>&nbsp;
+          <strong translate>Retires</strong>&nbsp;
           <span ng-if=(item.retires_on) tooltip="{{ item.retires_on | date }}" tooltip-placement="bottom">
             {{ item.retires_on | date }}
           </span>
@@ -55,9 +55,9 @@
           </span>
         </span>
       </div>
-      <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
+      <div class="col-lg-1 hidden-md hidden-sm hidden-xs">
         <span class="no-wrap">
-          <strong translate>Created On</strong>&nbsp;
+          <strong translate>Created</strong>&nbsp;
           <span tooltip="{{ item.created_at | date }}" tooltip-placement="bottom">
             {{ item.created_at | date }}
           </span>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -69,13 +69,13 @@
           <i class="fa fa-circle green fa-3x fa-fw" ng-if="item.powerState === 'on' && item.powerStatus === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
           <i class="fa fa-circle red fa-3x fa-fw" ng-if="item.powerState === 'off' && item.powerStatus === 'stop_complete'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
           <i class="fa fa-circle orange fa-3x fa-fw" ng-if="item.powerState === 'off' && item.powerStatus === 'suspend_complete'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse green fa-3x fa-fw" ng-if="item.powerStatus === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse red fa-3x fa-fw" ng-if="item.powerStatus === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse orange fa-3x fa-fw" ng-if="item.powerStatus === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse green fa-3x fa-fw" ng-if="item.powerState !== 'timeout' && item.powerStatus === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse red fa-3x fa-fw" ng-if="item.powerState !== 'timeout' && item.powerStatus === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse orange fa-3x fa-fw" ng-if="item.powerState !== 'timeout' && item.powerStatus === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
           <i class="fa fa-question-circle blue fa-3x fa-fw" ng-if="item.powerState === '' && item.powerStatus === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-adjust-circle green fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'starting'" tooltip="{{'Power State: Partially started and timed out'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-adjust-circle red fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'stopping'" tooltip="{{'Power State: Partially stopped and timed out'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-adjust-circle orange fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'suspending'" tooltip="{{'Power State: Partially suspended and timed out'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust green fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'starting'" tooltip="{{'Power State: Start operation timed out'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust red fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'stopping'" tooltip="{{'Power State: Stop operation timed out'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust orange fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'suspending'" tooltip="{{'Power State: Suspend operation timed out'|translate}}" tooltip-placement="bottom"></i>
         </span>
       </div>
     </div>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -66,14 +66,16 @@
       <div class="col-lg-2 hidden-md hidden-sm hidden-xs pull-right">
         <span class="no-wrap">
           <strong translate>Power State</strong>&nbsp;
-          <i class="fa fa-circle green fa-3x fa-fw" ng-if="item.powerState === 'on'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-circle red fa-3x fa-fw" ng-if="item.powerState === 'off'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-circle orange fa-3x fa-fw" ng-if="item.powerState === 'suspended'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-adjust orange fa-3x fa-fw" ng-if="item.powerState === 'on_partial'" tooltip="{{'Power State: Partially processed'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse green fa-3x fa-fw" ng-if="item.powerState === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse red fa-3x fa-fw" ng-if="item.powerState === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-spinner fa-pulse orange fa-3x fa-fw" ng-if="item.powerState === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
-          <i class="fa fa-question-circle blue fa-3x fa-fw" ng-if="item.powerState === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-circle green fa-3x fa-fw" ng-if="item.powerState === 'on' && item.powerStatus === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-circle red fa-3x fa-fw" ng-if="item.powerState === 'off' && item.powerStatus === 'stop_complete'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-circle orange fa-3x fa-fw" ng-if="item.powerState === 'off' && item.powerStatus === 'suspend_complete'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse green fa-3x fa-fw" ng-if="item.powerStatus === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse red fa-3x fa-fw" ng-if="item.powerStatus === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse orange fa-3x fa-fw" ng-if="item.powerStatus === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-question-circle blue fa-3x fa-fw" ng-if="item.powerState === '' && item.powerStatus === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust-circle green fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'starting'" tooltip="{{'Power State: Partially started and timed out'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust-circle red fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'stopping'" tooltip="{{'Power State: Partially stopped and timed out'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust-circle orange fa-3x fa-fw" ng-if="item.powerState === 'timeout' && item.powerStatus === 'suspending'" tooltip="{{'Power State: Partially suspended and timed out'|translate}}" tooltip-placement="bottom"></i>
         </span>
       </div>
     </div>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -20,7 +20,7 @@
           </span>
         </span>
       </div>
-      <div class="col-lg-3 col-md-4 col-sm-6 col-xs-6">
+      <div class="col-lg-2 col-md-4 col-sm-6 col-xs-6">
         <span class="no-wrap">
           <strong translate>Retirement Date</strong>&nbsp;
           <span ng-if=(item.retires_on) tooltip="{{ item.retires_on | date }}" tooltip-placement="bottom">
@@ -61,6 +61,19 @@
           <span tooltip="{{ item.created_at | date }}" tooltip-placement="bottom">
             {{ item.created_at | date }}
           </span>
+        </span>
+      </div>
+      <div class="col-lg-2 hidden-md hidden-sm hidden-xs pull-right">
+        <span class="no-wrap">
+          <strong translate>Power State</strong>&nbsp;
+          <i class="fa fa-circle green fa-3x fa-fw" ng-if="item.powerState === 'on'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-circle red fa-3x fa-fw" ng-if="item.powerState === 'off'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-circle orange fa-3x fa-fw" ng-if="item.powerState === 'suspended'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-adjust orange fa-3x fa-fw" ng-if="item.powerState === 'on_partial'" tooltip="{{'Power State: Partially processed'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse green fa-3x fa-fw" ng-if="item.powerState === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse red fa-3x fa-fw" ng-if="item.powerState === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-spinner fa-pulse orange fa-3x fa-fw" ng-if="item.powerState === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
+          <i class="fa fa-question-circle blue fa-3x fa-fw" ng-if="item.powerState === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
         </span>
       </div>
     </div>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -1,7 +1,12 @@
 <div pf-toolbar id="serviceToolbar" config="vm.toolbarConfig"></div>
 
 <div class="list-view-container">
-  <div pf-list-view id="serviceList" config="vm.listConfig" items="vm.servicesList">
+  <div pf-list-view id="serviceList" class="arbitration-profiles-list" config="vm.listConfig" items="vm.servicesList"
+      action-buttons="vm.actionButtons"
+      enable-button-for-item-fn="vm.enableButtonForItemFn"
+      menu-actions="vm.menuActions"
+      update-menu-action-for-item-fn="vm.updateMenuActionForItemFn"
+      hide-menu-for-item-fn="vm.hideMenuForItemFn">
     <div class="row">
       <div class="col-lg-3 col-md-4 col-sm-6 col-xs-6">
         <span class="no-wrap">
@@ -61,5 +66,10 @@
     </div>
   </div>
 </div>
-
-
+<script>
+  $(function() {
+    setTimeout(function(){
+      $("#serviceList .list-view-pf .list-group-item .list-view-pf-actions .btn-default").addClass("btn-primary");
+    }, 500);
+  });
+</script>

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -46,12 +46,9 @@
     }
 
     angular.forEach(services.resources, function(item) {
-      item.powerState = angular.isDefined(item.options.power_state) ? item.options.power_state : "";
-      item.powerStatus = angular.isDefined(item.options.power_status) ? item.options.power_status : "";
-    });
-
-    angular.forEach(services.resources, function(item) {
       if (angular.isUndefined(item.service_id)) {
+        item.powerState = angular.isDefined(item.options.power_state) ? item.options.power_state : "";
+        item.powerStatus = angular.isDefined(item.options.power_status) ? item.options.power_status : "";
         vm.services.push(item);
       }
     });

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -36,7 +36,11 @@
   }
 
   /** @ngInject */
+<<<<<<< ff484ab23f7cdf6f72829c04136daf04d03e32be
   function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback) {
+=======
+  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, CollectionsApi, EventNotifications) {
+>>>>>>> Add methods for start, stop and suspend
     var vm = this;
 
     vm.services = [];
@@ -147,15 +151,42 @@
     }
 
     function startService(action, item) {
-      console.log("startService");
+      item.powerState = 'starting';
+      CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);
+
+      function startSuccess() {
+        EventNotifications.success(item.name + __(' was started.'));
+      }
+
+      function startFailure() {
+        EventNotifications.error(__('There was an error stopping this service.'));
+      }
     }
 
     function stopService(action, item) {
-      console.log("stopService");
+      item.powerState = 'stopping';
+      CollectionsApi.post('services', item.id, {}, {action: 'stop'}).then(stopSuccess, stopFailure);
+
+      function stopSuccess() {
+        EventNotifications.success(item.name + __(' was stopped.'));
+      }
+
+      function stopFailure() {
+        EventNotifications.error(__('There was an error stopping this service.'));
+      }
     }
 
     function suspendService(action, item) {
-      console.log("suspendService");
+      item.powerState = 'suspending';
+      CollectionsApi.post('services', item.id, {}, {action: 'suspend'}).then(suspendSuccess, suspendFailure);
+
+      function suspendSuccess() {
+        EventNotifications.success(item.name + __(' was suspended.'));
+      }
+
+      function suspendFailure() {
+        EventNotifications.error(__('There was an error suspending this service.'));
+      }
     }
 
     function handleClick(item, e) {

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -150,6 +150,13 @@
       sortChange(ServicesState.getSort().currentField, ServicesState.getSort().isAscending);
     }
 
+    vm.enableButtonForItemFn = function (action, item) {
+      return item.powerState !== "on"
+        && item.powerState !== "starting"
+        && item.powerState !== "stopping"
+        && item.powerState !== "suspending";
+    };
+
     function startService(action, item) {
       item.powerState = 'starting';
       CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -36,11 +36,7 @@
   }
 
   /** @ngInject */
-<<<<<<< ff484ab23f7cdf6f72829c04136daf04d03e32be
-  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback) {
-=======
-  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, CollectionsApi, EventNotifications) {
->>>>>>> Add methods for start, stop and suspend
+  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, CollectionsApi, EventNotifications, sprintf) {
     var vm = this;
 
     vm.services = [];
@@ -176,7 +172,7 @@
       CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);
 
       function startSuccess() {
-        EventNotifications.success(item.name + __(' was started.'));
+        EventNotifications.success(__(sprintf("%s was started", item.name)));
       }
 
       function startFailure() {
@@ -189,7 +185,7 @@
       CollectionsApi.post('services', item.id, {}, {action: 'stop'}).then(stopSuccess, stopFailure);
 
       function stopSuccess() {
-        EventNotifications.success(item.name + __(' was stopped.'));
+        EventNotifications.success(__(sprintf("%s was stopped", item.name)));
       }
 
       function stopFailure() {
@@ -202,7 +198,7 @@
       CollectionsApi.post('services', item.id, {}, {action: 'suspend'}).then(suspendSuccess, suspendFailure);
 
       function suspendSuccess() {
-        EventNotifications.success(item.name + __(' was suspended.'));
+        EventNotifications.success(__(sprintf("%s was suspended", item.name)));
       }
 
       function suspendFailure() {

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -157,6 +157,14 @@
         && item.powerState !== "suspending";
     };
 
+    vm.hideMenuForItemFn = function (item) {
+      return item.powerState === ""
+        || item.powerState === "off"
+        || item.powerState === "starting"
+        || item.powerState === "stopping"
+        || item.powerState === "suspending";
+    };
+
     function startService(action, item) {
       item.powerState = 'starting';
       CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -82,6 +82,30 @@
       sortConfig: serviceSortConfig,
     };
 
+    vm.actionButtons = [
+      {
+        name: __('Start'),
+        title: __('Start this service'),
+        actionFn: startService,
+        isDisabled: false,
+      },
+    ];
+
+    vm.menuActions = [
+      {
+        name: __('Stop'),
+        title: __('Stop this service'),
+        actionFn: stopService,
+        isDisabled: false,
+      },
+      {
+        name: __('Suspend'),
+        title: __('Suspend this service'),
+        actionFn: suspendService,
+        isDisabled: false,
+      },
+    ];
+
     function getServiceFilterFields() {
       var retires = [__('Current'), __('Soon'), __('Retired')];
       var dollars = ['$', '$$', '$$$', '$$$$'];
@@ -116,6 +140,18 @@
 
       /* Make sure sorting direction is maintained */
       sortChange(ServicesState.getSort().currentField, ServicesState.getSort().isAscending);
+    }
+
+    function startService(action, item) {
+      console.log("startService");
+    }
+
+    function stopService(action, item) {
+      console.log("stopService");
+    }
+
+    function suspendService(action, item) {
+      console.log("suspendService");
     }
 
     function handleClick(item, e) {

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -47,6 +47,7 @@
 
     angular.forEach(services.resources, function(item) {
       item.powerState = angular.isDefined(item.options.power_state) ? item.options.power_state : "";
+      item.powerStatus = angular.isDefined(item.options.power_status) ? item.options.power_status : "";
     });
 
     angular.forEach(services.resources, function(item) {
@@ -147,28 +148,28 @@
     }
 
     vm.enableButtonForItemFn = function (action, item) {
-      return item.powerState !== "on"
-        && item.powerState !== "starting"
-        && item.powerState !== "stopping"
-        && item.powerState !== "suspending";
+      return item.powerStatus !== "start_complete"
+        && item.powerStatus !== "starting"
+        && item.powerStatus !== "stopping"
+        && item.powerStatus !== "suspending";
     };
 
     vm.hideMenuForItemFn = function (item) {
-      return item.powerState === ""
-        || item.powerState === "off"
-        || item.powerState === "starting"
-        || item.powerState === "stopping"
-        || item.powerState === "suspending";
+      return item.powerStatus === ""
+        || (item.powerState === "off" && item.powerStatus === "stop_complete")
+        || item.powerStatus === "starting"
+        || item.powerStatus === "stopping"
+        || item.powerStatus === "suspending";
     };
 
     vm.updateMenuActionForItemFn = function(action, item) {
-      if (item.powerState === 'suspended' && action.name === __('Suspend')) {
+      if (item.powerState === "off" && item.powerStatus === "suspend_complete" && action.name === __("Suspend")) {
         action.isDisabled = true;
       }
     };
 
     function startService(action, item) {
-      item.powerState = 'starting';
+      item.powerStatus = 'starting';
       CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);
 
       function startSuccess() {
@@ -181,7 +182,7 @@
     }
 
     function stopService(action, item) {
-      item.powerState = 'stopping';
+      item.powerStatus = 'stopping';
       CollectionsApi.post('services', item.id, {}, {action: 'stop'}).then(stopSuccess, stopFailure);
 
       function stopSuccess() {
@@ -194,7 +195,7 @@
     }
 
     function suspendService(action, item) {
-      item.powerState = 'suspending';
+      item.powerStatus = 'suspending';
       CollectionsApi.post('services', item.id, {}, {action: 'suspend'}).then(suspendSuccess, suspendFailure);
 
       function suspendSuccess() {

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -151,29 +151,63 @@
     }
 
     vm.enableButtonForItemFn = function (action, item) {
-      return item.powerStatus !== "start_complete"
-        && item.powerStatus !== "starting"
-        && item.powerStatus !== "stopping"
-        && item.powerStatus !== "suspending";
+      return powerOperationUnknownState(item)
+        || powerOperationOffState(item)
+        || powerOperationSuspendState(item)
+        || powerOperationTimeoutState(item);
     };
 
     vm.hideMenuForItemFn = function (item) {
-      return item.powerStatus === ""
-        || (item.powerState === "off" && item.powerStatus === "stop_complete")
-        || item.powerStatus === "starting"
-        || item.powerStatus === "stopping"
-        || item.powerStatus === "suspending";
+      return powerOperationUnknownState(item) || powerOperationInProgressState(item);
     };
 
     vm.updateMenuActionForItemFn = function(action, item) {
-      if (item.powerState === "off" && item.powerStatus === "suspend_complete" && action.actionName === "suspend") {
+      if (powerOperationSuspendState(item) && action.actionName === "suspend") {
         action.isDisabled = true;
-      } else if (item.powerState === "off" && item.powerStatus === "stop_complete" && action.actionName === "stop") {
+      } else if (powerOperationOffState(item) && action.actionName === "stop") {
         action.isDisabled = true;
       } else {
         action.isDisabled = false;
       }
     };
+
+    function powerOperationUnknownState(item) {
+      return item.powerState === "" && item.powerStatus === "";
+    }
+
+    function powerOperationInProgressState(item) {
+      return (item.powerState !== "timeout" && item.powerStatus === "starting")
+        || (item.powerState !== "timeout" && item.powerStatus === "stopping")
+        || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+    }
+
+    function powerOperationOnState(item) {
+      return item.powerState === "on" && item.powerStatus === "start_complete";
+    }
+
+    function powerOperationOffState(item) {
+      return item.powerState === "off" && item.powerStatus === "stop_complete";
+    }
+
+    function powerOperationSuspendState(item) {
+      return item.powerState === "off" && item.powerStatus === "suspend_complete";
+    }
+
+    function powerOperationTimeoutState(item) {
+      return item.powerState === "timeout";
+    }
+
+    function powerOperationStartTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "starting";
+    }
+
+    function powerOperationStopTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "stopping";
+    }
+
+    function powerOperationSuspendTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "suspending";
+    }
 
     function startService(action, item) {
       item.powerStatus = 'starting';

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -90,6 +90,7 @@
     vm.actionButtons = [
       {
         name: __('Start'),
+        actionName: 'start',
         title: __('Start this service'),
         actionFn: startService,
         isDisabled: false,
@@ -99,12 +100,14 @@
     vm.menuActions = [
       {
         name: __('Stop'),
+        actionName: 'stop',
         title: __('Stop this service'),
         actionFn: stopService,
         isDisabled: false,
       },
       {
         name: __('Suspend'),
+        actionName: 'suspend',
         title: __('Suspend this service'),
         actionFn: suspendService,
         isDisabled: false,
@@ -163,8 +166,12 @@
     };
 
     vm.updateMenuActionForItemFn = function(action, item) {
-      if (item.powerState === "off" && item.powerStatus === "suspend_complete" && action.name === __("Suspend")) {
+      if (item.powerState === "off" && item.powerStatus === "suspend_complete" && action.actionName === "suspend") {
         action.isDisabled = true;
+      } else if (item.powerState === "off" && item.powerStatus === "stop_complete" && action.actionName === "stop") {
+        action.isDisabled = true;
+      } else {
+        action.isDisabled = false;
       }
     };
 

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -46,6 +46,10 @@
     }
 
     angular.forEach(services.resources, function(item) {
+      item.powerState = angular.isDefined(item.options.power_state) ? item.options.power_state : "";
+    });
+
+    angular.forEach(services.resources, function(item) {
       if (angular.isUndefined(item.service_id)) {
         vm.services.push(item);
       }

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -170,40 +170,40 @@
 
     function startService(action, item) {
       item.powerStatus = 'starting';
-      CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);
-
-      function startSuccess() {
-        EventNotifications.success(__(sprintf("%s was started", item.name)));
-      }
-
-      function startFailure() {
-        EventNotifications.error(__('There was an error stopping this service.'));
-      }
+      powerOperation('start', item);
     }
 
     function stopService(action, item) {
       item.powerStatus = 'stopping';
-      CollectionsApi.post('services', item.id, {}, {action: 'stop'}).then(stopSuccess, stopFailure);
-
-      function stopSuccess() {
-        EventNotifications.success(__(sprintf("%s was stopped", item.name)));
-      }
-
-      function stopFailure() {
-        EventNotifications.error(__('There was an error stopping this service.'));
-      }
+      powerOperation('stop', item);
     }
 
     function suspendService(action, item) {
       item.powerStatus = 'suspending';
-      CollectionsApi.post('services', item.id, {}, {action: 'suspend'}).then(suspendSuccess, suspendFailure);
+      powerOperation('suspend', item);
+    }
 
-      function suspendSuccess() {
-        EventNotifications.success(__(sprintf("%s was suspended", item.name)));
+    function powerOperation(powerAction, item) {
+      CollectionsApi.post('services', item.id, {}, {action: powerAction}).then(actionSuccess, actionFailure);
+
+      function actionSuccess() {
+        if (powerAction === 'start') {
+          EventNotifications.success(__(sprintf("%s was started", item.name)));
+        } else if (powerAction === 'stop') {
+          EventNotifications.success(__(sprintf("%s was stopped", item.name)));
+        } else if (powerAction === 'suspend') {
+          EventNotifications.success(__(sprintf("%s was suspended", item.name)));
+        }
       }
 
-      function suspendFailure() {
-        EventNotifications.error(__('There was an error suspending this service.'));
+      function actionFailure() {
+        if (powerAction === 'start') {
+          EventNotifications.error(__('There was an error starting this service.'));
+        } else if (powerAction === 'stop') {
+          EventNotifications.error(__('There was an error stopping this service.'));
+        } else if (powerAction === 'suspend') {
+          EventNotifications.error(__('There was an error suspending this service.'));
+        }
       }
     }
 

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -165,6 +165,12 @@
         || item.powerState === "suspending";
     };
 
+    vm.updateMenuActionForItemFn = function(action, item) {
+      if (item.powerState === 'suspended' && action.name === __('Suspend')) {
+        action.isDisabled = true;
+      }
+    };
+
     function startService(action, item) {
       item.powerState = 'starting';
       CollectionsApi.post('services', item.id, {}, {action: 'start'}).then(startSuccess, startFailure);

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -44,6 +44,42 @@
       top: 2px
       width: 26px
 
+    .fa-power-off
+      color: $app-color-red
+
+    .fa-pause
+      color: $app-color-orange
+
+    .fa-circle.green
+      color: $app-color-green
+
+    .fa-circle.orange
+      color: $app-color-orange
+
+    .fa-circle.red
+      color: $app-color-red
+
+    .fa-pulse.green
+      color: $app-color-green
+
+    .fa-pulse.orange
+      color: $app-color-orange
+
+    .fa-pulse.red
+      color: $app-color-red
+
+    .fa-question-circle.blue
+      color: $app-color-blue
+
+    .fa-adjust.green
+      color: $app-color-green
+
+    .fa-adjust.orange
+      color: $app-color-orange
+
+    .fa-adjust.red
+      color: $app-color-red
+
   .list-view-pf-main-info
     padding: 0
     margin-left: 15px

--- a/tests/services-list.state.spec.js
+++ b/tests/services-list.state.spec.js
@@ -40,4 +40,118 @@ describe('Dashboard', function() {
       expect(controller).to.be.defined;
     });
   });
+
+  describe('service list contains power state in "timeout" and power status in "starting', function() {
+    var controller;
+    var services = {
+      name: 'services',
+      count: 1,
+      subcount: 1,
+      resources: [
+        {options: {
+        power_state: "timeout",
+        power_status: "starting"
+      }}
+      ]
+    };
+
+    var serviceItem = services.resources[0];
+
+    var Chargeback = {
+      processReports: function(){},
+      adjustRelativeCost: function(){}
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$log', '$state', '$rootScope');
+
+      controller = $controller($state.get('services.list').controller, {services: services, Chargeback: Chargeback});
+      $rootScope.$apply();
+    });
+
+    it('sets the powerState value on the Service', function() {
+      expect(serviceItem.powerState).to.eq('timeout');
+    });
+
+    it('sets the powerStatus value on the Service', function() {
+      expect(serviceItem.powerStatus).to.eq('starting');
+    });
+
+    it('does not hide the kebab menu when "Start" operation times out', function() {
+      expect(controller.hideMenuForItemFn(serviceItem)).to.eq(false);
+    });
+
+    it('Shows the "Start" button when "Start" operation times out', function() {
+      expect(controller.enableButtonForItemFn({}, serviceItem)).to.eq(true);
+    });
+
+    it('displays "Stop" button when action is "stop"', function() {
+      var action = {actionName: 'stop'};
+      controller.updateMenuActionForItemFn(action, serviceItem);
+      expect(action.isDisabled).to.eq(false);
+    });
+
+    it('displays "Suspend" button when action is "suspend"', function() {
+      var action = {actionName: 'suspend'};
+      controller.updateMenuActionForItemFn(action, serviceItem);
+      expect(action.isDisabled).to.eq(false);
+    });
+  });
+
+  describe('service list contains power state in "on" and power status in "start_complete', function() {
+    var controller;
+    var services = {
+      name: 'services',
+      count: 1,
+      subcount: 1,
+      resources: [
+        {options: {
+          power_state: "on",
+          power_status: "start_complete"
+        }}
+      ]
+    };
+
+    var serviceItem = services.resources[0];
+
+    var Chargeback = {
+      processReports: function(){},
+      adjustRelativeCost: function(){}
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$log', '$state', '$rootScope');
+
+      controller = $controller($state.get('services.list').controller, {services: services, Chargeback: Chargeback});
+      $rootScope.$apply();
+    });
+
+    it('sets the powerState value on the Service', function() {
+      expect(serviceItem.powerState).to.eq('on');
+    });
+
+    it('sets the powerStatus value on the Service', function() {
+      expect(serviceItem.powerStatus).to.eq('start_complete');
+    });
+
+    it('does not hide the kebab menu when "Start" operation leads to an "ON" power state', function() {
+      expect(controller.hideMenuForItemFn(serviceItem)).to.eq(false);
+    });
+
+    it('hides the "Start" button when power state is "ON"', function() {
+      expect(controller.enableButtonForItemFn(undefined, serviceItem)).to.eq(false);
+    });
+
+    it('displays "Stop" button when action is "stop"', function() {
+      var action = {actionName: 'stop'};
+      controller.updateMenuActionForItemFn(action, serviceItem);
+      expect(action.isDisabled).to.eq(false);
+    });
+
+    it('displays "Suspend" button when action is "suspend"', function() {
+      var action = {actionName: 'suspend'};
+      controller.updateMenuActionForItemFn(action, serviceItem);
+      expect(action.isDisabled).to.eq(false);
+    });
+  });
 });


### PR DESCRIPTION
Added the Service Power operations for `Start`, `Stop` and `Suspend` in the Service UI.

The buttons for each of the above operations are displayed per service in the Services list view.

Screenshots
------------
<img width="1437" alt="screen shot 2016-10-20 at 2 43 12 pm" src="https://cloud.githubusercontent.com/assets/1538216/19607893/c1a8c7a4-9781-11e6-905d-b2288299308f.png">

<img width="1391" alt="screen shot 2016-10-20 at 2 59 41 pm" src="https://cloud.githubusercontent.com/assets/1538216/19607909/e10260e2-9781-11e6-9bbb-0e84c46da24f.png">

<img width="1435" alt="screen shot 2016-10-21 at 11 29 31 am" src="https://cloud.githubusercontent.com/assets/1538216/19607916/edae2ac4-9781-11e6-941b-b748a4fbeab8.png">

Links
------
https://www.pivotaltracker.com/n/projects/1613907/stories/127218477

Depends On 
-------------
https://github.com/ManageIQ/manageiq/pull/11888
