### PR TITLE
Service chargeback

### DIFF
--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -1,0 +1,64 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('Chargeback', ChargebackFactory);
+
+  /** @ngInject */
+  function ChargebackFactory(lodash) {
+    var service = {
+      addListData: addListData,
+      adjustRelativeCost: adjustRelativeCost,
+      reportUsedCost: reportUsedCost,
+    };
+
+    function addListData(item) {
+      var data = item.chargeback_report.results[0] || {};
+      var sum = reportUsedCost(data);
+
+      item.chargeback = {
+        data: data,
+        sum: sum,
+      };
+      item.chargeback_relative_cost = '?';
+    }
+
+    function reportUsedCost(report) {
+      return lodash.reduce(report, function(sum, v, k) {
+        return sum + k.match(/_used_cost$/) ? v : 0;
+      }, 0);
+    }
+
+    // recomputes items[*].chargeback_relative_cost
+    function adjustRelativeCost(items) {
+      var sums = lodash(items)
+        .pluck(['chargeback', 'sum'])
+        .sort()
+        .filter(angular.identity) // nonzero
+        .value();
+
+      var len = sums.length;
+      var bounds = [ len * 0.25, len * 0.5, len * 0.75 ];
+
+      items.forEach(function(item) {
+        if (!item.chargeback.sum) {
+          item.chargeback_relative_cost = '';
+          return;
+        }
+
+        var idx = lodash.findIndex(sums, item.chargeback.sum);
+        if (idx < bounds[0]) {
+          item.chargeback_relative_cost = '$';
+        } else if (idx < bounds[1]) {
+          item.chargeback_relative_cost = '$$';
+        } else if (idx < bounds[2]) {
+          item.chargeback_relative_cost = '$$$';
+        } else {
+          item.chargeback_relative_cost = '$$$$';
+        }
+      });
+    }
+
+    return service;
+  }
+})();

--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -69,14 +69,22 @@
     }
 
     function processReports(item) {
-      item.chargeback = currentReport(item);
+      item.chargeback = service.currentReport(item);
     }
 
     // sum all *_used_cost fields in the report
     function reportUsedCost(report) {
-      return lodash.reduce(report, function(sum, v, k) {
-        return sum + k.match(/_used_cost$/) ? v : 0;
-      }, 0);
+      var sum = 0;
+
+      lodash.each(report, function(v, k) {
+        if (!k.match(/_used_cost$/)) {
+          return;
+        }
+
+        sum += v;
+      });
+
+      return sum;
     }
 
     return service;

--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -47,24 +47,24 @@
     }
 
     function currentReport(item) {
-      var latest_date = lodash(item.chargeback_report.results || [])
+      var latestDate = lodash(item.chargeback_report.results || [])
         .pluck('start_date')
         .sort()
         .reverse()
         .first();
 
-      var latest_reports = lodash(item.chargeback_report.results || [])
-        .filter({ start_date: latest_date })
+      var latestReports = lodash(item.chargeback_report.results || [])
+        .filter({ start_date: latestDate })
         .value();
 
-      latest_reports.forEach(function(report) {
+      latestReports.forEach(function(report) {
         report.used_cost_sum = reportUsedCost(report);
       });
 
       return {
-        start_date: latest_date,
-        used_cost_sum: lodash.sum(latest_reports, 'used_cost_sum'), // sumBy in lodash4
-        vms: latest_reports,
+        start_date: latestDate,
+        used_cost_sum: lodash.sum(latestReports, 'used_cost_sum'), // sumBy in lodash4
+        vms: latestReports,
       };
     }
 

--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -31,7 +31,9 @@
           return;
         }
 
-        var idx = lodash.findIndex(sums, item.chargeback.used_cost_sum);
+        var idx = sums.findIndex(function(v) {
+          return v === item.chargeback.used_cost_sum;
+        });
         if (idx < bounds[0]) {
           item.chargeback_relative_cost = '$';
         } else if (idx < bounds[1]) {

--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 (function() {
   'use strict';
 

--- a/client/app/states/dashboard/_dashboard.sass
+++ b/client/app/states/dashboard/_dashboard.sass
@@ -3,10 +3,10 @@
 
   +element(card-primary)
     cursor: pointer
-    
+
     .card-pf-body
       padding-bottom: 0
-      
+
     .fa
       font-size: 24px
       border: 2px solid $app-color-medium-blue
@@ -61,6 +61,15 @@
         border-color: $app-color-dark-red
         color: $app-color-dark-red
         width: 44px
+
+      .magic-dollar
+        width: 44px
+        display: inline-block
+        line-height: 1
+        color: $app-color-medium-blue
+        font-weight: 400
+        &:before
+          content: '$'
 
     .card-pf
       box-shadow: none

--- a/client/app/states/dashboard/dashboard.html
+++ b/client/app/states/dashboard/dashboard.html
@@ -27,46 +27,64 @@
     <div class="col-xs-6 col-sm-6 col-md-6" ng-show="vm.servicesFeature">
       <div class="card-pf">
         <div class="row row-cards-pf">
-            <div class="card-pf card-pf-aggregate-status card-divider">
-              <div class="card-pf-body">
-                <h2 class="card-pf-title" translate>
-                  Retiring Soon
-                </h2>
-                <p class="card-pf-aggregate-status-notifications">  
-                  <span class="card-pf-aggregate-status-notification">
-                    <span class="pficon pficon-warning-triangle-o" tooltip="{{'The number of services retiring within the next 30 days'|translate}}" tooltip-placement="bottom"></span>
-                  </span>
-                  <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Soon')">{{ ::vm.servicesCount.soon }}</a></span>
-                </p>
-              </div>
+          <div class="card-pf card-pf-aggregate-status card-divider">
+            <div class="card-pf-body">
+              <h2 class="card-pf-title" translate>
+                Retiring Soon
+              </h2>
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification">
+                  <span class="pficon pficon-warning-triangle-o" tooltip="{{'The number of services retiring within the next 30 days'|translate}}" tooltip-placement="bottom"></span>
+                </span>
+                <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Soon')">{{ ::vm.servicesCount.soon }}</a></span>
+              </p>
             </div>
-            <div class="card-pf card-pf-aggregate-status card-divider">
-              <div class="card-pf-body">
-                <h2 class="card-pf-title" translate>
-                  Current Services
-                </h2>
-                <p class="card-pf-aggregate-status-notifications">    
-                  <span class="card-pf-aggregate-status-notification">
-                    <span class="pficon fa fa-check" tooltip="{{'The number of active services'|translate}}" tooltip-placement="bottom"></span>
-                  </span>
-                  <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Current')">{{ ::vm.servicesCount.current }}</a></span>
-                </p>
-              </div>
+          </div>
+          <div class="card-pf card-pf-aggregate-status card-divider">
+            <div class="card-pf-body">
+              <h2 class="card-pf-title" translate>
+                Current Services
+              </h2>
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification">
+                  <span class="pficon fa fa-check" tooltip="{{'The number of active services'|translate}}" tooltip-placement="bottom"></span>
+                </span>
+                <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Current')">{{ ::vm.servicesCount.current }}</a></span>
+              </p>
             </div>
-            <div class="card-pf card-pf-aggregate-status">
-              <div class="card-pf-body">
-                <h2 class="card-pf-title" translate>
-                  Retired Services
-                </h2>
-                <p class="card-pf-aggregate-status-notifications">    
-                  <span class="card-pf-aggregate-status-notification">
-                    <span class="pficon pficon-close" tooltip="{{'The number of services which have hit their retirement period or been retired'|translate}}" tooltip-placement="bottom"></span>
-                  </span>
-                  <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Retired')">{{ ::vm.servicesCount.retired }}</a>
-                  </span>
-                </p>
-              </div>
+          </div>
+          <div class="card-pf card-pf-aggregate-status card-divider">
+            <div class="card-pf-body">
+              <h2 class="card-pf-title" translate>
+                Retired Services
+              </h2>
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification">
+                  <span class="pficon pficon-close" tooltip="{{'The number of services which have hit their retirement period or been retired'|translate}}" tooltip-placement="bottom"></span>
+                </span>
+                <span class="card-pf-aggregate-status-notification"><a ng-click="vm.navigateToServicesList('Retired')">{{ ::vm.servicesCount.retired }}</a>
+                </span>
+              </p>
             </div>
+          </div>
+          <div class="card-pf card-pf-aggregate-status" ng-class="{ disabled: !vm.chargeback.used_cost_sum }">
+            <div class="card-pf-body">
+              <h2 class="card-pf-title" translate>
+                Monthly Charges - This Month To Date
+              </h2>
+              <p class="card-pf-aggregate-status-notifications">
+                <span class="card-pf-aggregate-status-notification">
+                  <span class="pficon magic-dollar"></span>
+                </span>
+                <span class="card-pf-aggregate-status-notification" ng-if="vm.chargeback.used_cost_sum">
+                  ${{ vm.chargeback.used_cost_sum | number:3 }}
+                </span>
+                <span class="card-pf-aggregate-status-notification" ng-if="!vm.chargeback.used_cost_sum" translate>
+                  $0
+                </span>
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -91,7 +109,7 @@
               <h2 class="card-pf-title" translate>
                 Approved Requests
               </h2>
-              <p class="card-pf-aggregate-status-notifications">  
+              <p class="card-pf-aggregate-status-notifications">
                 <span class="card-pf-aggregate-status-notification">
                   <span class="pficon fa fa-check"></span>
                 </span>
@@ -104,7 +122,7 @@
               <h2 class="card-pf-title" translate>
                 Denied Requests
               </h2>
-              <p class="card-pf-aggregate-status-notifications">  
+              <p class="card-pf-aggregate-status-notifications">
                 <span class="card-pf-aggregate-status-notification">
                   <span class="pficon pficon pficon-close"></span>
                 </span>

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -153,7 +153,7 @@
         services.forEach(Chargeback.processReports);
 
         vm.chargeback = {
-          used_cost_sum: lodash(services).pluck(['chargeback', 'used_cost_sum']).sum(),
+          'used_cost_sum': lodash(services).pluck(['chargeback', 'used_cost_sum']).sum(),
         };
       }
 

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -105,6 +105,12 @@
                     <input class="form-control" disabled value="{{ ::vm.service.created_at | date:'medium' }}"/>
                   </div>
                 </div>
+                <div class="form-group" ng-show="vm.service.chargeback.sum">
+                  <label class="control-label col-sm-4" translate>Monthly Charge</label>
+                  <div class="col-sm-8">
+                    <input class="form-control" disabled value="{{ ::vm.service.chargeback.sum }}"/>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -105,10 +105,10 @@
                     <input class="form-control" disabled value="{{ ::vm.service.created_at | date:'medium' }}"/>
                   </div>
                 </div>
-                <div class="form-group" ng-show="vm.service.chargeback.sum">
+                <div class="form-group" ng-show="vm.service.chargeback.used_cost_sum">
                   <label class="control-label col-sm-4" translate>Monthly Charge</label>
                   <div class="col-sm-8">
-                    <input class="form-control" disabled value="{{ ::vm.service.chargeback.sum }}"/>
+                    <input class="form-control" disabled value="${{ ::vm.service.chargeback.used_cost_sum | number:3 }}"/>
                   </div>
                 </div>
               </div>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -41,6 +41,7 @@
       'custom_actions',
       'provision_dialog',
       'service_template',
+      'chargeback_report',
     ];
     var options = {
       attributes: requestAttributes,
@@ -52,7 +53,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles, Chargeback) {
     var vm = this;
     setInitialVars();
 
@@ -84,6 +85,7 @@
     activate();
 
     function activate() {
+      Chargeback.processReports(vm.service);
     }
 
     function setInitialVars() {

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -37,7 +37,7 @@
       </div>
        <div class="col-lg-1 hidden-md hidden-sm hidden-xs">
         <span class="no-wrap">
-          <b tooltip="{{ 'Relative cost' | translate }}" tooltip-placement="bottom">
+          <b tooltip="{{ 'Relative cost' }}" tooltip-placement="bottom">
             {{ item.chargeback_relative_cost }}
           </b>
         </span>

--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -26,13 +26,20 @@
           </span>
         </span>
       </div>
-       <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">
+       <div class="col-lg-1 col-md-2 hidden-sm hidden-xs">
         <span class="no-wrap">
            <i class="pficon pficon-screen" tooltip="{{'The number of instances running this service'|translate}}" tooltip-placement="bottom"></i>
           <span tooltip="{{ '[[number]] VMs'|translate|substitute:{number: item.v_total_vms} }}" tooltip-placement="bottom">
             <strong>{{ item.v_total_vms}}</strong>
             {{'VMs'|translate}}
           </span>
+        </span>
+      </div>
+       <div class="col-lg-1 hidden-md hidden-sm hidden-xs">
+        <span class="no-wrap">
+          <b tooltip="{{ 'Relative cost' | translate }}" tooltip-placement="bottom">
+            {{ item.chargeback_relative_cost }}
+          </b>
         </span>
       </div>
       <div class="col-lg-2 col-md-2 hidden-sm hidden-xs">

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -28,7 +28,7 @@
   function resolveServices(CollectionsApi) {
     var options = {
       expand: 'resources',
-      attributes: ['picture', 'picture.image_href', 'evm_owner.name', 'v_total_vms'],
+      attributes: ['picture', 'picture.image_href', 'evm_owner.name', 'v_total_vms', 'chargeback_report'],
       filter: ['service_id=nil'],
     };
 
@@ -36,7 +36,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView) {
+  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback) {
     var vm = this;
 
     vm.services = [];
@@ -50,6 +50,9 @@
         vm.services.push(item);
       }
     });
+
+    vm.services.forEach(Chargeback.addListData);
+    Chargeback.adjustRelativeCost(vm.services);
 
     vm.servicesList = angular.copy(vm.services);
 

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -84,23 +84,26 @@
 
     function getServiceFilterFields() {
       var retires = [__('Current'), __('Soon'), __('Retired')];
+      var dollars = ['$', '$$', '$$$', '$$$$'];
 
       return [
-        ListView.createFilterField('name',       __('Name'),            __('Filter by Name'),            'text'),
+        ListView.createFilterField('name', __('Name'), __('Filter by Name'), 'text'),
         ListView.createFilterField('retirement', __('Retirement Date'), __('Filter by Retirement Date'), 'select', retires),
-        ListView.createFilterField('vms',        __('Number of VMs'),   __('Filter by VMs'),             'text'),
-        ListView.createFilterField('owner',      __('Owner'),           __('Filter by Owner'),           'text'),
-        ListView.createFilterField('owner',      __('Created'),         __('Filter by Created On'),      'text'),
+        ListView.createFilterField('vms', __('Number of VMs'), __('Filter by VMs'), 'text'),
+        ListView.createFilterField('owner', __('Owner'), __('Filter by Owner'), 'text'),
+        ListView.createFilterField('owner', __('Created'), __('Filter by Created On'), 'text'),
+        ListView.createFilterField('chargeback_relative_cost', __('Relative Cost'), __('Filter by Relative Cost'), 'select', dollars),
       ];
     }
 
     function getServiceSortFields() {
       return [
-        ListView.createSortField('name',    __('Name'),            'alpha'),
+        ListView.createSortField('name', __('Name'), 'alpha'),
         ListView.createSortField('retires', __('Retirement Date'), 'numeric'),
-        ListView.createSortField('vms',     __('Number of VMs'),   'numeric'),
-        ListView.createSortField('owner',   __('Owner'),           'alpha'),
-        ListView.createSortField('created', __('Created'),         'numeric'),
+        ListView.createSortField('vms', __('Number of VMs'), 'numeric'),
+        ListView.createSortField('owner', __('Owner'), 'alpha'),
+        ListView.createSortField('created', __('Created'), 'numeric'),
+        ListView.createSortField('chargeback_relative_cost', __('Relative Cost'), 'alpha'),
       ];
     }
 
@@ -149,6 +152,8 @@
         compValue = new Date(item1.created_at) - new Date(item2.created_at);
       } else if (vm.toolbarConfig.sortConfig.currentField.id === 'retires') {
         compValue = getRetirementDate(item1.retires_on) - getRetirementDate(item2.retires_on);
+      } else if (vm.toolbarConfig.sortConfig.currentField.id === 'chargeback_relative_cost') {
+        compValue = item1.chargeback_relative_cost.length - item2.chargeback_relative_cost.length;
       }
 
       if (!vm.toolbarConfig.sortConfig.isAscending) {
@@ -190,6 +195,8 @@
         return checkRetirementDate(item, filter.value.toLowerCase());
       } else if (filter.id === 'created') {
         return $filter('date')(item.created_at).toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
+      } else if (filter.id === 'chargeback_relative_cost') {
+        return item.chargeback_relative_cost === filter.value;
       }
 
       return false;

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -51,7 +51,7 @@
       }
     });
 
-    vm.services.forEach(Chargeback.addListData);
+    vm.services.forEach(Chargeback.processReports);
     Chargeback.adjustRelativeCost(vm.services);
 
     vm.servicesList = angular.copy(vm.services);

--- a/tests/chargeback.service.spec.js
+++ b/tests/chargeback.service.spec.js
@@ -1,0 +1,137 @@
+describe('Chargeback', function() {
+  beforeEach(function() {
+    module('app.core', 'gettext');
+    bard.inject('Chargeback');
+  });
+
+  describe('adjustRelativeCost', function() {
+    var items = [
+      {
+        chargeback: {
+          used_cost_sum: 4,
+        },
+      },
+      {
+        chargeback: {
+          used_cost_sum: 1,
+        },
+      },
+      {
+        chargeback: {
+          used_cost_sum: 3,
+        },
+      },
+      {
+        chargeback: {
+          used_cost_sum: 2,
+        },
+      },
+      {
+        chargeback: {
+          used_cost_sum: 0,
+        },
+      },
+    ];
+
+    it('assigns chargeback_relative_cost correctly', function() {
+      Chargeback.adjustRelativeCost(items);
+
+      items.forEach(function(item) {
+        expect(item).to.have.property('chargeback_relative_cost');
+      });
+
+      expect(items[0].chargeback_relative_cost).to.equal('$$$$');
+      expect(items[1].chargeback_relative_cost).to.equal('$');
+      expect(items[2].chargeback_relative_cost).to.equal('$$$');
+      expect(items[3].chargeback_relative_cost).to.equal('$$');
+      expect(items[4].chargeback_relative_cost).to.equal('');
+    });
+  });
+
+  describe('currentReport', function() {
+    var item = {
+      chargeback: null,
+      chargeback_report: {
+        results: [
+          {
+            start_date: '2016-10-01T00:00:00.000Z',
+            vm_name: "foo",
+            random_used_cost: 123,
+          },
+          {
+            start_date: '2016-10-01T00:00:00.000Z',
+            vm_name: "bar",
+            random_used_cost: 456,
+          },
+          {
+            start_date: '2016-09-01T00:00:00.000Z',
+            vm_name: "bar",
+            random_used_cost: 789,
+          },
+        ],
+      },
+    };
+
+    it('picks only the latest start_date', function() {
+      var report = Chargeback.currentReport(item);
+
+      expect(report.start_date).to.equal('2016-10-01T00:00:00.000Z');
+      expect(report.used_cost_sum).to.equal(579);
+      expect(report.vms).to.have.length(2);
+    });
+  });
+
+  describe('processReports', function() {
+    var item = {
+      chargeback: null,
+      chargeback_report: {
+        results: [
+          {},
+          {},
+        ],
+      },
+    };
+    var currentReportSpy;
+
+    beforeEach(function() {
+      currentReportSpy = sinon.stub(Chargeback, 'currentReport').returns({});
+    });
+
+    it('calls currentReport', function() {
+      Chargeback.processReports(item);
+      expect(currentReportSpy).to.have.been.calledWith(item);
+    });
+
+    it('assigns to item.chargeback', function() {
+      Chargeback.processReports(item);
+      expect(item.chargeback).to.be.a('object');
+    });
+  });
+
+  describe('reportUsedCost', function() {
+    var report = {
+      "start_date": "2016-10-01T00:00:00.000Z",
+      "display_range": "Oct 2016",
+      "vm_name": "ansible",
+      "cpu_allocated_cost": 743.9999999999998,
+      "cpu_used_metric": 1567.4222693677066,
+      "cpu_used_cost": 23323.243368191466,
+      "memory_allocated_cost": 0,
+      "memory_used_metric": 493.88106349984287,
+      "memory_used_cost": 7348.95022487766,
+      "disk_io_used_metric": 0,
+      "disk_io_used_cost": 0,
+      "net_io_used_metric": 1.5441550960835662,
+      "net_io_used_cost": 371.9999999999999,
+      "storage_allocated_metric": 85899345920,
+      "storage_allocated_cost": 0,
+      "storage_used_metric": 5971099648,
+      "storage_used_cost": 0.011122039794921875,
+    };
+
+    it('sums used costs', function() {
+      var sum = Chargeback.reportUsedCost(report);
+      expect(sum).to.equal(31044.20471510892);
+    });
+  });
+});


### PR DESCRIPTION
This adds basic support for displaying chargeback report data in Service UI. Using the API changes introduced in https://github.com/ManageIQ/manageiq/pull/11687, this should add the following features:

   * [x] dashboard - total charges since the beginning of month
![ssui-cb-dashboard](https://cloud.githubusercontent.com/assets/289743/19646153/b4ab5086-99e7-11e6-832c-44da1384aa57.png)

   * [x] services.list - relative cost indicators
   * [x] services.list - sort & filter by $$$
![ssui-cb-list](https://cloud.githubusercontent.com/assets/289743/19646160/b820815a-99e7-11e6-99ed-3b63a638ab6f.png)

   * [x] services.detail - chargeback since the beginning of month
![ssui-cb-detail](https://cloud.githubusercontent.com/assets/289743/19646166/bbe77d84-99e7-11e6-9ded-eeaf3bf878c0.png)

More in a separate PR:

   * services.detail - per-VM cost split - [waiting](https://github.com/ManageIQ/manageiq/pull/11687#issuecomment-255687694) for `vm_id` in the data so as not to match by name
   * dashboard - total charges last month - need data for more than 1 month
   * dashboard - chart charges last months - need data for more than 1 month

---

Generating the necessary data via rails console:

```
cfg = VMDB::Config.new("vmdb")
cfg.config[:product][:report_sync] = true
cfg.save

Service.all.each { |s| s.generate_chargeback_report }
```