### PR TITLE
Blueprint List: Row vert. middle alignment fix

### DIFF
--- a/client/app/components/blueprints/_blueprints.sass
+++ b/client/app/components/blueprints/_blueprints.sass
@@ -1,14 +1,19 @@
 .blueprints-list
 
+  .list-view-pf-checkbox
+    margin-top: 0px
+    margin-bottom: 0px
+
   .list-view-pf
     padding-bottom: 68px // Adding so dropdown menus on the last row don't get cut off
 
-    .list-group-item
-      line-height: 1.66666667
-      padding-bottom: 0
-      padding-top: 0
+    .list-view-pf-actions
+       margin: 0
 
   .dropdown-kebab-pf
+    .btn-link
+      margin-top: -7px
+
     .fa,
     img
       font-size: 18px
@@ -22,4 +27,4 @@
       overflow: visible
 
       &.dropdown-menu-right
-        right: -5px
+        right: 0


### PR DESCRIPTION
Just rebased and noticed the Blueprint List row alignment was off, possibly due to some recent css changes.  This PR fixes the alignment issues.

Before:

![image](https://cloud.githubusercontent.com/assets/12733153/19811119/1cb5a0fa-9cfe-11e6-943c-39542e3836d8.png)

After:

![image](https://cloud.githubusercontent.com/assets/12733153/19811126/23ea424a-9cfe-11e6-9296-10bde047ca1b.png)

@jeff-phillips-18 @serenamarie125 