### PR TITLE
Address gettext on primary and secondary navigation items

### DIFF
--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -154,6 +154,14 @@
     function getNavigationItems(items) {
       vm.items.splice(0, vm.items.length);
       angular.forEach(items, function(nextPrimary) {
+        if (angular.isDefined(nextPrimary.title)) {
+          nextPrimary.title = __(nextPrimary.title);
+        }
+        if (angular.isDefined(nextPrimary.badges)) {
+          angular.forEach(nextPrimary.badges, function(badge) {
+            badge.tooltip = __(badge.tooltip);
+          });
+        }
         vm.items.push(nextPrimary);
         if (nextPrimary.children) {
           nextPrimary.children.splice(0, nextPrimary.children.length);
@@ -163,6 +171,14 @@
             nextPrimary.children = [];
           }
           angular.forEach(nextPrimary.secondary, function(nextSecondary) {
+            if (angular.isDefined(nextSecondary.title)) {
+              nextSecondary.title = __(nextSecondary.title);
+            }
+            if (angular.isDefined(nextSecondary.badges)) {
+              angular.forEach(nextSecondary.badges, function(badge) {
+                badge.tooltip = __(badge.tooltip);
+              });
+            }
             nextPrimary.children.push(nextSecondary);
           });
         }

--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -154,14 +154,7 @@
     function getNavigationItems(items) {
       vm.items.splice(0, vm.items.length);
       angular.forEach(items, function(nextPrimary) {
-        if (angular.isDefined(nextPrimary.title)) {
-          nextPrimary.title = __(nextPrimary.title);
-        }
-        if (angular.isDefined(nextPrimary.badges)) {
-          angular.forEach(nextPrimary.badges, function(badge) {
-            badge.tooltip = __(badge.tooltip);
-          });
-        }
+        getTextForNavigationItems(nextPrimary);
         vm.items.push(nextPrimary);
         if (nextPrimary.children) {
           nextPrimary.children.splice(0, nextPrimary.children.length);
@@ -171,18 +164,22 @@
             nextPrimary.children = [];
           }
           angular.forEach(nextPrimary.secondary, function(nextSecondary) {
-            if (angular.isDefined(nextSecondary.title)) {
-              nextSecondary.title = __(nextSecondary.title);
-            }
-            if (angular.isDefined(nextSecondary.badges)) {
-              angular.forEach(nextSecondary.badges, function(badge) {
-                badge.tooltip = __(badge.tooltip);
-              });
-            }
+            getTextForNavigationItems(nextSecondary);
             nextPrimary.children.push(nextSecondary);
           });
         }
       });
+    }
+
+    function getTextForNavigationItems(navItem) {
+      if (angular.isDefined(navItem.title)) {
+        navItem.title = __(navItem.title);
+      }
+      if (angular.isDefined(navItem.badges)) {
+        angular.forEach(navItem.badges, function(badge) {
+          badge.tooltip = __(badge.tooltip);
+        });
+      }
     }
 
     function activate() {


### PR DESCRIPTION
Navigation text and tooltip for primary and secondary navigation items shows up in English on non `en` locales.

PR https://github.com/ManageIQ/manageiq-ui-service/pull/277 probably meant to resolve this issue, but it did not address it completely.

https://bugzilla.redhat.com/show_bug.cgi?id=1389655

Before:
<img width="1385" alt="screen shot 2016-10-28 at 4 39 36 pm" src="https://cloud.githubusercontent.com/assets/1538216/19825374/2c0ca600-9d2d-11e6-8387-da192aced80c.png">

After:
<img width="1382" alt="screen shot 2016-10-28 at 4 39 11 pm" src="https://cloud.githubusercontent.com/assets/1538216/19825379/394e79d8-9d2d-11e6-8382-f718c2a0feee.png">
