### PR TITLE
Apply 200px height/width bounds on login screen logo

### DIFF
--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -17,3 +17,8 @@
 
   .container
     background-color: transparent
+
+  .logo
+    max-height: 200px
+    max-width: 200px
+    

--- a/client/app/states/login/login.html
+++ b/client/app/states/login/login.html
@@ -1,6 +1,6 @@
 <div class="login-pf">
   <span id="badge">
-    <img src="images/login-screen-logo.png" alt=" logo" />
+    <img class="logo" src="images/login-screen-logo.png" alt=" logo" />
   </span>
   <div class="container">
     <div class="row">


### PR DESCRIPTION
Apply 200px height/width bounds on login screen logo, this prevents unwieldy large icons from upsetting login layout.

No issue associated with this fix. 

@chriskacerguis 