### PR TITLE
Cleanup vm console button markup, resolve issue of missing button img

### DIFF
--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -189,7 +189,7 @@
                 <strong tooltip="{{'The last heartbeat received from the instances'|translate}}" tooltip-placement="bottom" translate>Last Scan</strong>&nbsp;{{ item.last_scan_on | date:'medium' }}
               </span>
             </div>
-            <div class="col-1 col-md-2 hidden-sm hidden-xs">
+            <div class="col-lg-1 col-md-2 hidden-sm hidden-xs">
               <span class="no-wrap">
                 <i class="fa pficon fa-power-off" ng-if="item.power_state == 'off'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
                 <i class="pficon pficon-ok" ng-if="item.power_state == 'on'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom"></i>
@@ -197,15 +197,13 @@
                 <strong ng-if="item.power_state == 'never' || item.power_state == 'unknown'" tooltip="{{'Power State'|translate}}" tooltip-placement="bottom" translate>Power State</strong>&nbsp;{{ item.power_state }}
               </span>
             </div>
-            <div class="col-lg-1 col-md-1 hidden-sm hidden-xs">
-              <span class="no-wrap">
+            <div class="col-lg-1 col-md-1 hidden-sm hidden-xs ">
                 <button class="btn btn-default open-console-button" ng-if="item['supports_console?'] && item.power_state == 'on'" tooltip="{{'Open a HTML5 console for this VM'|translate}}" tooltip-placement="left">
                   <i class="fa fa-html5 fa-lg"></i>
                 </button>
                 <button class="btn btn-default open-console-button" ng-if="item['supports_cockpit?'] && item.power_state == 'on'" tooltip="{{'Open Cockpit console for this VM'|translate}}" tooltip-placement="left">
-                  <img src="/client/assets/images/cockpit.png"></img>
+                  <img src="/client/assets/images/cockpit.png">
                 </button>
-              </span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
addresses [bugzilla 1389462](https://bugzilla.redhat.com/show_bug.cgi?id=1389462#h2)
tldr; 
* image for cockpit.png doesn't render, offender, likely a combination of incorrect markup and browser persnicketyness
* buttons got cut off at md viewport, the larger issue, removed the nowrap, so yes, they are now stacked but its better than them being cut off 🌮 🎉 
 
## Before
<img width="1021" alt="screen shot 2016-11-01 at 2 18 53 pm" src="https://cloud.githubusercontent.com/assets/6640236/19902506/6cbf189c-a041-11e6-8b09-f5c4ca615464.png">

## After
<img width="1022" alt="screen shot 2016-11-01 at 2 18 36 pm" src="https://cloud.githubusercontent.com/assets/6640236/19902526/82d39a40-a041-11e6-85ca-dcadda484418.png">
<img width="1774" alt="screen shot 2016-11-01 at 2 16 46 pm" src="https://cloud.githubusercontent.com/assets/6640236/19902560/aa6980ba-a041-11e6-84ab-da6f5b6c3043.png">

@chriskacerguis 