### PR TITLE
Added ./images to dev serve path, updated all offensive image paths

### DIFF
--- a/client/app/components/blueprints/blueprint-canvas/_blueprint-canvas.sass
+++ b/client/app/components/blueprints/blueprint-canvas/_blueprint-canvas.sass
@@ -6,12 +6,12 @@
   width: 99%
 
 .canvas
-  background-image: url('/client/assets/images/blueprint-designer/canvas-dot-grid.png')
+  background-image: url('../images/blueprint-designer/canvas-dot-grid.png')
   background-repeat: repeat
   //border: 2px solid brown
   height: 756px
   width: 1396px
 
 .canvas-in-connection-mode
-  background-image: url('/client/assets/images/blueprint-designer/canvas-dot-grid-disabled.png')
+  background-image: url('../images/blueprint-designer/canvas-dot-grid-disabled.png')
   background-repeat: repeat

--- a/client/app/components/blueprints/blueprint-editor/_blueprint-editor.sass
+++ b/client/app/components/blueprints/blueprint-editor/_blueprint-editor.sass
@@ -219,13 +219,13 @@
 
     .canvas
       //border: 2px solid brown
-      background-image: url('/client/assets/images/blueprint-designer/canvas-dot-grid.png')
+      background-image: url('../images/blueprint-designer/canvas-dot-grid.png')
       background-repeat: repeat
       height: 756px
       width: 1396px
 
     .canvas-in-connection-mode
-      background-image: url('/client/assets/images/blueprint-designer/canvas-dot-grid-disabled.png')
+      background-image: url('../images/blueprint-designer/canvas-dot-grid-disabled.png')
       background-repeat: repeat
 
     a

--- a/client/app/services/profiles-state.service.js
+++ b/client/app/services/profiles-state.service.js
@@ -17,12 +17,12 @@
       unknown: 'Unknown',
     };
     var providerImages = {
-      amazon: 'assets/images/providers/vendor-amazon.svg',
-      azure: 'assets/images/providers/vendor-azure.svg',
-      google: 'assets/images/providers/vendor-google.svg',
-      openstack: 'assets/images/providers/vendor-openstack_infra.svg',
-      vmware: 'assets/images/providers/vendor-vmware_cloud.svg',
-      unknown: 'assets/images/providers/vendor-unknown.svg',
+      amazon: 'images/providers/vendor-amazon.svg',
+      azure: 'images/providers/vendor-azure.svg',
+      google: 'images/providers/vendor-google.svg',
+      openstack: 'images/providers/vendor-openstack_infra.svg',
+      vmware: 'images/providers/vendor-vmware_cloud.svg',
+      unknown: 'images/providers/vendor-unknown.svg',
     };
 
     var providerTypeKeys = ['amazon', 'azure', 'google', 'openstack', 'vmware'];

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -202,7 +202,7 @@
                   <i class="fa fa-html5 fa-lg"></i>
                 </button>
                 <button class="btn btn-default open-console-button" ng-if="item['supports_cockpit?'] && item.power_state == 'on'" tooltip="{{'Open Cockpit console for this VM'|translate}}" tooltip-placement="left">
-                  <img src="/client/assets/images/cockpit.png">
+                  <img src="images/cockpit.png">
                 </button>
             </div>
           </div>

--- a/server/utils/serviceApp.js
+++ b/server/utils/serviceApp.js
@@ -8,6 +8,7 @@ var express = require('express');
 var router = express.Router();
 
 router.use(express.static('./client'));
+router.use(express.static('./images'));
 router.use(express.static('./.tmp'));
 router.use(express.static('./node_modules'));
 

--- a/tests/profiles/profiles-details.directive.spec.js
+++ b/tests/profiles/profiles-details.directive.spec.js
@@ -69,7 +69,7 @@ describe('app.components.ProfilesDetailsDirective', function() {
       var title = element.find('.ss-details-header__title-img__logo');
       expect(title.length).to.eq(1);
 
-      expect(angular.element(title[0]).attr('src')).to.eq('assets/images/providers/vendor-amazon.svg');
+      expect(angular.element(title[0]).attr('src')).to.eq('images/providers/vendor-amazon.svg');
     });
 
     it('should have the correct title', function () {


### PR DESCRIPTION
Ends up a few paths hardcoded for dev env slipped through, those have been removed and updated to paths that work for dev and prod

<img width="1759" alt="screen shot 2016-11-04 at 8 44 59 am" src="https://cloud.githubusercontent.com/assets/6640236/20005949/8d4e3b3e-a26b-11e6-813b-a358f2824a71.png">
<img width="957" alt="screen shot 2016-11-04 at 8 42 52 am" src="https://cloud.githubusercontent.com/assets/6640236/20005948/8d4ce05e-a26b-11e6-9237-e45a9432815b.png">
<img width="960" alt="screen shot 2016-11-04 at 8 42 30 am" src="https://cloud.githubusercontent.com/assets/6640236/20005950/8d4fdb6a-a26b-11e6-91e0-9f0f99efb17e.png">
<img width="959" alt="screen shot 2016-11-04 at 8 42 19 am" src="https://cloud.githubusercontent.com/assets/6640236/20005951/8d50cd0e-a26b-11e6-9aaa-f812a25e5350.png">

closes #316

@chriskacerguis 🌮
@dtaylor113  I promise blueprints hasn't been broken 🔒 📿 
@evertmulder can you confirm this to be a satisfactory solution? 