### PR TITLE
Allow approver to approve/deny service requests

### DIFF
--- a/client/app/components/blueprints/_blueprints.sass
+++ b/client/app/components/blueprints/_blueprints.sass
@@ -1,14 +1,14 @@
 .blueprints-list
 
   .list-view-pf-checkbox
-    margin-top: 0px
-    margin-bottom: 0px
+    margin-bottom: 0
+    margin-top: 0
 
   .list-view-pf
     padding-bottom: 68px // Adding so dropdown menus on the last row don't get cut off
 
     .list-view-pf-actions
-       margin: 0
+      margin: 0
 
   .dropdown-kebab-pf
     .btn-link

--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -21,4 +21,3 @@
   .logo
     max-height: 200px
     max-width: 200px
-    

--- a/client/app/states/requests/requests/details/details.html
+++ b/client/app/states/requests/requests/details/details.html
@@ -24,6 +24,18 @@
                 <h2>{{ ::vm.request.description }}</h2>
                 <h4>{{ ::vm.request.options.long_description || vm.request.description }}</h4>
               </div>
+
+              <div ng-if="vm.pendingApproval()">
+                <input type="text" ng-model="vm.approvalReason" placeholder="{{'Reason' | translate}}">
+                <div>
+                  <button class="btn btn-primary" type="button"
+                    ng-disabled="!vm.approvalReason"
+                    ng-click="vm.updateApprovalState('approve')" translate>Approve</button>
+                  <button class="btn btn-primary" type="button"
+                    ng-disabled="!vm.approvalReason"
+                    ng-click="vm.updateApprovalState('deny')" translate>Deny</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,7 +3436,7 @@ hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
-"HTML_CodeSniffer@github:squizlabs/HTML_CodeSniffer#2.0.7":
+HTML_CodeSniffer@squizlabs/HTML_CodeSniffer#2.0.7:
   version "2.0.7"
   resolved "https://codeload.github.com/squizlabs/HTML_CodeSniffer/tar.gz/d209ce54876657858a8a01528ad812cd234f37f0"
 


### PR DESCRIPTION
This change adds a couple of buttons to the request details state to
allow for approving or denying the selected request. The buttons should
only be visible if the current user has the correct permissions and when
the `approval_state` for the request is `pending`.

The yarn.lock file is also updated here because for some reason the
dependencies are requiring two versions of node-sass.

Also cleans up a few linting issues.

Currently working on adding tests.