### PR TITLE
EventNotifications service - markAllRead/Unread should update the notification bell icon

### DIFF
--- a/client/app/services/event-notifications.service.js
+++ b/client/app/services/event-notifications.service.js
@@ -220,7 +220,7 @@
         if (resources.length > 0) {
           CollectionsApi.post('notifications', undefined, {}, {action: 'mark_as_seen', resources: resources});
         }
-        group.unreadCount = 0;
+        updateUnreadCount(group);
       }
     }
 
@@ -229,7 +229,7 @@
         group.notifications.forEach(function(notification) {
           notification.unread = true;
         });
-        group.unreadCount = group.notifications.length;
+        updateUnreadCount(group);
       }
     }
 


### PR DESCRIPTION
Marking messages read one by one would update both the count and the icon, but making all read would update just the count.

Fixed to call `updateUnreadCount` which handles both.

Steps to reproduce:

1. have unread notifications
1. click mark all read
1. the blue icon by the bell should disappear

https://bugzilla.redhat.com/show_bug.cgi?id=1386327

Cc @skateman 