### PR TITLE
Hide upcoming features from navigation menu unless flagged

### DIFF
--- a/client/app/components/navigation/navigation-contoller.js
+++ b/client/app/components/navigation/navigation-contoller.js
@@ -154,19 +154,23 @@
     function getNavigationItems(items) {
       vm.items.splice(0, vm.items.length);
       angular.forEach(items, function(nextPrimary) {
-        getTextForNavigationItems(nextPrimary);
-        vm.items.push(nextPrimary);
-        if (nextPrimary.children) {
-          nextPrimary.children.splice(0, nextPrimary.children.length);
-        }
-        if (nextPrimary.secondary) {
-          if (angular.isUndefined(nextPrimary.children)) {
-            nextPrimary.children = [];
+        if (nextPrimary.show !== false) {
+          getTextForNavigationItems(nextPrimary);
+          vm.items.push(nextPrimary);
+          if (nextPrimary.children) {
+            nextPrimary.children.splice(0, nextPrimary.children.length);
           }
-          angular.forEach(nextPrimary.secondary, function(nextSecondary) {
-            getTextForNavigationItems(nextSecondary);
-            nextPrimary.children.push(nextSecondary);
-          });
+          if (nextPrimary.secondary) {
+            if (angular.isUndefined(nextPrimary.children)) {
+              nextPrimary.children = [];
+            }
+            angular.forEach(nextPrimary.secondary, function(nextSecondary) {
+              if (nextSecondary.show !== false) {
+                getTextForNavigationItems(nextSecondary);
+                nextPrimary.children.push(nextSecondary);
+              }
+            });
+          }
         }
       });
     }

--- a/client/app/config/layouts.config.js
+++ b/client/app/config/layouts.config.js
@@ -28,11 +28,11 @@
   function enterApplication(Polling, lodash, $state, NavCounts, Navigation) {
     // Application layout displays the navigation which might have items that require polling to update the counts
     angular.forEach(NavCounts.counts, updateCount);
-    angular.forEach(Navigation.items.primary, function(value, key) {
+    angular.forEach(Navigation.items, function(value, key) {
       lodash.merge(value, $state.navFeatures[key]);
-    });
-    angular.forEach(Navigation.items.secondary, function(value, key) {
-      lodash.merge(value, $state.actionFeatures[key]);
+      angular.forEach(value.secondary, function(secondaryValue, secondaryKey) {
+        lodash.merge(secondaryValue, $state.actionFeatures[secondaryKey]);
+      });
     });
 
     function updateCount(count, key) {

--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -34,7 +34,7 @@
       $http.defaults.headers.common['X-Miq-Group'] = data.miqGroup || undefined;
       $sessionStorage.token = model.token;
       $sessionStorage.miqGroup = data.miqGroup || null;
-      fetchProductSetting("blueprints_flag", "blueprints");
+      fetchProductSetting("preview_flag", "service_ui_preview");
     }
 
     function destroy() {
@@ -113,7 +113,8 @@
         services: {show: entitledForServices(productFeatures)},
         requests: {show: entitledForRequests(productFeatures)},
         marketplace: {show: entitledForServiceCatalogs(productFeatures)},
-        blueprints: {show: entitledForCatalogItems(productFeatures) && $state.blueprints_flag},
+        designer: {show: angular.isDefined($state.preview_flag) ? $state.preview_flag : false},
+        administration: {show: angular.isDefined($state.preview_flag) ? $state.preview_flag : false},
       };
       model.navFeatures = features;
 


### PR DESCRIPTION
This fixes Bug 1392103.

Unless the ‘service_ui_preview’ setting is set to true in the product
settings, the upcoming features (currently Designer and Administration)
are hidden from the navigation menu.

@dtaylor113 @chriskacerguis 