### PR TITLE
Set it to where Documentation link opens up in new window

### DIFF
--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -40,7 +40,7 @@
           </a>
           <ul class ="dropdown-menu" aria-labelledby="aboutModal">
             <li>
-              <a href="/support/index?support_tab=about">
+              <a href="/support/index?support_tab=about" target="_blank">
                 {{ 'Documentation' | translate}}
               </a>
             </li>


### PR DESCRIPTION
Updated documentation link to open in new browser tab.   Requested by https://bugzilla.redhat.com/show_bug.cgi?id=1384740