### PR TITLE
Reload the whole page after switching the language

### DIFF
--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -52,7 +52,9 @@
       vm.switch = function(code) {
         Language.setLocale(code);
         Language.save(code);
-        $state.reload();
+
+        // FIXME(#328) this should be $state.reload(), once we refactor Navigation.items so that we can work with a translated copy and still get badge count updates
+        window.document.location.href = window.document.location.href;
       };
     }
   }

--- a/client/app/components/language-switcher/language-switcher.directive.js
+++ b/client/app/components/language-switcher/language-switcher.directive.js
@@ -20,7 +20,7 @@
     return directive;
 
     /** @ngInject */
-    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state) {
+    function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state, $window) {
       var vm = this;
       vm.mode = vm.mode || 'menu';
 
@@ -54,7 +54,7 @@
         Language.save(code);
 
         // FIXME(#328) this should be $state.reload(), once we refactor Navigation.items so that we can work with a translated copy and still get badge count updates
-        window.document.location.href = window.document.location.href;
+        $window.document.location.href = $window.document.location.href;
       };
     }
   }

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -26,7 +26,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, Session, $rootScope, Notifications, Language, ServerInfo, ProductInfo) {
+  function StateController($state, Text, API_LOGIN, API_PASSWORD, AuthenticationApi, Session, $rootScope, Notifications, Language, ServerInfo, ProductInfo, $window) {
     var vm = this;
 
     vm.text = Text.login;
@@ -61,7 +61,7 @@
 
             // FIXME(#328) this should be $state.go('dashboard')
             var url = $state.href('dashboard');
-            window.document.location.href = url;
+            $window.document.location.href = url;
           } else {
             Session.privilegesError = true;
             Notifications.error(__('User does not have privileges to login.'));

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -58,7 +58,10 @@
             if (angular.isDefined($rootScope.notifications) && $rootScope.notifications.data.length > 0) {
               $rootScope.notifications.data.splice(0, $rootScope.notifications.data.length);
             }
-            $state.go('dashboard');
+
+            // FIXME(#328) this should be $state.go('dashboard')
+            var url = $state.href('dashboard');
+            window.document.location.href = url;
           } else {
             Session.privilegesError = true;
             Notifications.error(__('User does not have privileges to login.'));


### PR DESCRIPTION
When moving to vertical menu, we've lost the ability to translate menu items on the fly, the patternfly component can't do it by itself.

This got fixed by #299, but it only works once, because it mutates the original object, so changing from language A to language B tries to find the language A string in the catalog (and thus only works if A=English). (Steps to reproduce - have the language set to English, switch to German (the menu changes), switch to French (the menu stays in German without this PR).)

Unfortunately we can't really *not* mutate the original object and show a copy, because then it stops getting the badge count updates every minute (only the original gets updated).

So.. triggering a full browser reload after switching the language, meaning the state gets recreated anew, in English, and is only ever translated once. The side effect is that switching the language takes a bit longer because the whole page reloads, but..

https://bugzilla.redhat.com/show_bug.cgi?id=1391742