### PR TITLE
Reintroduce npm test, so that travis runs gulp test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "url": "https://github.com/ManageIQ/manageiq-ui-service.git"
   },
   "version": "1.0.1",
-  "scripts": {},
+  "scripts": {
+    "test": "gulp test"
+  },
   "devDependencies": {
     "actioncable": "^5.0.0",
     "angular": "~1.5.8",


### PR DESCRIPTION
Since #296, we haven't been running any tests on travis, because travis is using `npm test` which now "succeeds" with..

```
$ npm test

> manageiq-ui-service@1.0.1 test /home/travis/build/ManageIQ/manageiq-ui-service
> echo 'Error: no test specified'

Error: no test specified

The command "npm test" exited with 0.
```

Adding `npm test` back so that travis runs `gulp test`.

Cc @AllenBW ;)