### PR TITLE
Power operations in Service Detail view

### DIFF
--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -20,7 +20,7 @@
       powerOperationTimeoutState: powerOperationTimeoutState,
       powerOperationStartTimeoutState: powerOperationStartTimeoutState,
       powerOperationStopTimeoutState: powerOperationStopTimeoutState,
-      powerOperationSuspendTimeoutState: powerOperationSuspendTimeoutState
+      powerOperationSuspendTimeoutState: powerOperationSuspendTimeoutState,
     };
 
     function powerOperationUnknownState(item) {

--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -1,0 +1,108 @@
+/* eslint-disable camelcase */
+
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('PowerOperations', PowerOperationsFactory);
+
+  /** @ngInject */
+  function PowerOperationsFactory(CollectionsApi, EventNotifications, sprintf) {
+    var service = {
+      startService: startService,
+      stopService: stopService,
+      suspendService: suspendService,
+      powerOperationUnknownState: powerOperationUnknownState,
+      powerOperationInProgressState: powerOperationInProgressState,
+      powerOperationOnState: powerOperationOnState,
+      powerOperationOffState: powerOperationOffState,
+      powerOperationSuspendState: powerOperationSuspendState,
+      powerOperationTimeoutState: powerOperationTimeoutState,
+      powerOperationStartTimeoutState: powerOperationStartTimeoutState,
+      powerOperationStopTimeoutState: powerOperationStopTimeoutState,
+      powerOperationSuspendTimeoutState: powerOperationSuspendTimeoutState
+    };
+
+    function powerOperationUnknownState(item) {
+      return item.powerState === "" && item.powerStatus === "";
+    }
+
+    function powerOperationInProgressState(item) {
+      return (item.powerState !== "timeout" && item.powerStatus === "starting")
+        || (item.powerState !== "timeout" && item.powerStatus === "stopping")
+        || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+    }
+
+    function powerOperationOnState(item) {
+      return item.powerState === "on" && item.powerStatus === "start_complete";
+    }
+
+    function powerOperationOffState(item) {
+      return item.powerState === "off" && item.powerStatus === "stop_complete";
+    }
+
+    function powerOperationSuspendState(item) {
+      return item.powerState === "off" && item.powerStatus === "suspend_complete";
+    }
+
+    function powerOperationTimeoutState(item) {
+      return item.powerState === "timeout";
+    }
+
+    function powerOperationStartTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "starting";
+    }
+
+    function powerOperationStopTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "stopping";
+    }
+
+    function powerOperationSuspendTimeoutState(item) {
+      return item.powerState === "timeout" && item.powerStatus === "suspending";
+    }
+
+    function startService(item) {
+      item.powerState = '';
+      item.powerStatus = 'starting';
+      powerOperation('start', item);
+    }
+
+    function stopService(item) {
+      item.powerState = '';
+      item.powerStatus = 'stopping';
+      powerOperation('stop', item);
+    }
+
+    function suspendService(item) {
+      item.powerState = '';
+      item.powerStatus = 'suspending';
+      powerOperation('suspend', item);
+    }
+
+    function powerOperation(powerAction, item) {
+      CollectionsApi.post('services', item.id, {}, {action: powerAction}).then(actionSuccess, actionFailure);
+
+      function actionSuccess() {
+        if (powerAction === 'start') {
+          EventNotifications.success(__(sprintf("%s was started", item.name)));
+        } else if (powerAction === 'stop') {
+          EventNotifications.success(__(sprintf("%s was stopped", item.name)));
+        } else if (powerAction === 'suspend') {
+          EventNotifications.success(__(sprintf("%s was suspended", item.name)));
+        }
+      }
+
+      function actionFailure() {
+        if (powerAction === 'start') {
+          EventNotifications.error(__('There was an error starting this service.'));
+        } else if (powerAction === 'stop') {
+          EventNotifications.error(__('There was an error stopping this service.'));
+        } else if (powerAction === 'suspend') {
+          EventNotifications.error(__('There was an error suspending this service.'));
+        }
+      }
+    }
+
+    return service;
+  }
+})();

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -35,6 +35,7 @@
               </custom-button>
               <button class="btn btn-default" type="button" tooltip="{{'Permanently delete the service'|translate}}" tooltip-placement="bottom"
                     ng-show="vm.showRemoveService"
+                    ng-disabled="vm.powerOperationInProgressState(vm.service)"
                     confirmation
                     confirmation-title="{{'Remove Service'|translate}}"
                     confirmation-message="{{'Confirm, would you like to remove this service?'|translate}}"
@@ -45,6 +46,7 @@
               </button>
               <div class="btn-group" dropdown>
                 <button id="single-button" type="button" class="btn btn-default"
+                  ng-disabled="vm.powerOperationInProgressState(vm.service)"
                   dropdown-toggle tooltip="{{'Inactivate the service'|translate}}"
                   tooltip-placement="bottom"
                   ng-show="vm.showRetireService || vm.showScheduleRetirementService">

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -26,7 +26,7 @@
               </div>
             </div>
             <div class="col-lg-7 col-md-6 col-sm-6 col-xs-6 ss-details-header__actions">
-              <div class="ss-details-header__actions__inner">
+              <div class="ss-details-header__actions__inner dropdown dropdown-kebab-pf">
               <custom-button
                 service-template-catalog-id="vm.service.service_template.service_template_catalog_id"
                 service-id="vm.service.id"
@@ -67,6 +67,17 @@
               <button class="btn btn-primary" type="button" ng-click="vm.editServiceModal()" ng-show="vm.showEditService" translate>Edit Service</button>
               <button class="btn btn-primary" type="button" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership" translate>Set Ownership</button>
               <button class="btn btn-primary" type="button" ng-if="vm.service.reconfigure" ng-click="vm.reconfigureService(vm.service.id)" ng-show="vm.showReconfigureService" translate>Reconfigure</button>
+              <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="fa fa-ellipsis-v"></span>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-right 2" aria-labelledby="dropdownKebabRight">
+                <li>
+                  <a href="#" title="Stop this service">{{'Stop'|translate}}</a>
+                </li>
+                <li>
+                  <a href="#" title="Suspend this service">{{'Suspend'|translate}}</a>
+                </li>
+              </ul>
             </div>
             </div>
           </div>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -69,11 +69,11 @@
                 <span class="fa fa-ellipsis-v"></span>
               </button>
               <ul class="dropdown-menu dropdown-menu-right 2" aria-labelledby="dropdownKebabRight">
-                <li>
-                  <a href="#" title="Stop this service">{{'Stop'|translate}}</a>
+                <li ng-class="{'disabled': vm.checkDisabled('stop', vm.service)}">
+                  <a href="#" title="Stop this service" ng-click="vm.handlePowerOperation('stop', vm.service)">{{'Stop'|translate}}</a>
                 </li>
-                <li>
-                  <a href="#" title="Suspend this service">{{'Suspend'|translate}}</a>
+                <li ng-class="{'disabled': vm.checkDisabled('suspend', vm.service)}">
+                  <a href="#" title="Suspend this service" ng-click="vm.handlePowerOperation('suspend', vm.service)">{{'Suspend'|translate}}</a>
                 </li>
                 <li><a href="#" title="Edit this service" ng-click="vm.editServiceModal()" ng-show="vm.showEditService">{{'Edit'|translate}}</a></li>
                 <li><a href="#" title="Set Ownership" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership">{{'Set Ownership'|translate}}</a></li>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -128,6 +128,21 @@
                     <input class="form-control" disabled value="${{ ::vm.service.chargeback.used_cost_sum | number:3 }}"/>
                   </div>
                 </div>
+                <div class="form-group">
+                  <label class="control-label col-sm-4" translate>Power State</label>
+                  <div class="col-sm-8">
+                    <i class="fa fa-circle" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState === 'on' && vm.service.powerStatus === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState === 'off' && vm.service.powerStatus === 'stop_complete'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState === 'off' && vm.service.powerStatus === 'suspend_complete'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-adjust" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'starting'" tooltip="{{'Power State: Start operation timed out'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-adjust" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'stopping'" tooltip="{{'Power State: Stop operation timed out'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-adjust" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'suspending'" tooltip="{{'Power State: Suspend operation timed out'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.powerState === '' && vm.service.powerStatus === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -64,9 +64,7 @@
                   <li role="menuitem"><a href="#" ng-click="vm.retireServiceLater()" ng-show="vm.showScheduleRetirementService" translate>Schedule Retirement</a></li>
                 </ul>
               </div>
-              <button class="btn btn-primary" type="button" ng-click="vm.editServiceModal()" ng-show="vm.showEditService" translate>Edit Service</button>
-              <button class="btn btn-primary" type="button" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership" translate>Set Ownership</button>
-              <button class="btn btn-primary" type="button" ng-if="vm.service.reconfigure" ng-click="vm.reconfigureService(vm.service.id)" ng-show="vm.showReconfigureService" translate>Reconfigure</button>
+              <button class="btn btn-primary" type="button" translate>Start</button>
               <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="fa fa-ellipsis-v"></span>
               </button>
@@ -77,6 +75,9 @@
                 <li>
                   <a href="#" title="Suspend this service">{{'Suspend'|translate}}</a>
                 </li>
+                <li><a href="#" title="Edit this service" ng-click="vm.editServiceModal()" ng-show="vm.showEditService">{{'Edit'|translate}}</a></li>
+                <li><a href="#" title="Set Ownership" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership">{{'Set Ownership'|translate}}</a></li>
+                <li><a href="#" ng-if="vm.service.reconfigure" ng-click="vm.reconfigureService(vm.service.id)" ng-show="vm.showReconfigureService" translate>Reconfigure</a></li>
               </ul>
             </div>
             </div>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -64,7 +64,7 @@
                   <li role="menuitem"><a href="#" ng-click="vm.retireServiceLater()" ng-show="vm.showScheduleRetirementService" translate>Schedule Retirement</a></li>
                 </ul>
               </div>
-              <button class="btn btn-primary" type="button" translate>Start</button>
+                <button class="btn btn-primary" type="button" ng-click="vm.startService(vm.service)" ng-disabled="!vm.enableStartButton(vm.service)" translate>Start</button>
               <button class="btn btn-link dropdown-toggle" type="button" id="dropdownKebabRight" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="fa fa-ellipsis-v"></span>
               </button>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -53,7 +53,8 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles, Chargeback, PowerOperations) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal,
+                           EventNotifications, Consoles, Chargeback, PowerOperations) {
     var vm = this;
     setInitialVars();
 
@@ -200,9 +201,9 @@
     vm.checkDisabled = function (action, item) {
       if (action === 'stop') {
         return disableStopButton(item);
-        } else if (action === 'suspend') {
+      } else if (action === 'suspend') {
         return disableSuspendButton(item);
-        }
+      }
     };
 
     vm.handlePowerOperation = function (action, item) {
@@ -210,7 +211,7 @@
         vm.stopService(item);
       } else if (action === 'suspend' && !vm.checkDisabled(action, item)) {
         vm.suspendService(item);
-        }
+      }
     };
   }
 })();

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -110,6 +110,8 @@
       vm.service.powerStatus = angular.isDefined(vm.service.options.power_status) ? vm.service.options.power_status : "";
 
       vm.startService = PowerOperations.startService;
+      vm.stopService = PowerOperations.stopService;
+      vm.suspendService = PowerOperations.suspendService;
       vm.powerOperationOffState = PowerOperations.powerOperationOffState;
       vm.powerOperationUnknownState = PowerOperations.powerOperationUnknownState;
       vm.powerOperationInProgressState = PowerOperations.powerOperationInProgressState;
@@ -172,6 +174,20 @@
 
     function retireServiceLater() {
       RetireServiceModal.showModal(vm.service);
+    }
+
+    function disableStopButton(item) {
+      return (vm.powerOperationOffState(item)
+        || vm.powerOperationUnknownState(item)
+        || vm.powerOperationInProgressState(item))
+        && !vm.powerOperationTimeoutState(item);
+    }
+
+    function disableSuspendButton(item) {
+      return (vm.powerOperationSuspendState(item)
+        || vm.powerOperationUnknownState(item)
+        || vm.powerOperationInProgressState(item))
+        && !vm.powerOperationTimeoutState(item);
     }
 
     vm.enableStartButton = function(item) {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -53,7 +53,7 @@
   }
 
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles, Chargeback) {
+  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, EventNotifications, Consoles, Chargeback, PowerOperations) {
     var vm = this;
     setInitialVars();
 
@@ -105,6 +105,16 @@
       vm.retireServiceLater = retireServiceLater;
       vm.ownershipServiceModal = ownershipServiceModal;
       vm.reconfigureService = reconfigureService;
+
+      vm.service.powerState = angular.isDefined(vm.service.options.power_state) ? vm.service.options.power_state : "";
+      vm.service.powerStatus = angular.isDefined(vm.service.options.power_status) ? vm.service.options.power_status : "";
+
+      vm.startService = PowerOperations.startService;
+      vm.powerOperationOffState = PowerOperations.powerOperationOffState;
+      vm.powerOperationUnknownState = PowerOperations.powerOperationUnknownState;
+      vm.powerOperationInProgressState = PowerOperations.powerOperationInProgressState;
+      vm.powerOperationTimeoutState = PowerOperations.powerOperationTimeoutState;
+      vm.powerOperationSuspendState = PowerOperations.powerOperationSuspendState;
     }
 
     function removeService() {
@@ -163,5 +173,28 @@
     function retireServiceLater() {
       RetireServiceModal.showModal(vm.service);
     }
+
+    vm.enableStartButton = function(item) {
+      return vm.powerOperationUnknownState(item)
+        || vm.powerOperationOffState(item)
+        || vm.powerOperationSuspendState(item)
+        || vm.powerOperationTimeoutState(item);
+    };
+
+    vm.checkDisabled = function (action, item) {
+      if (action === 'stop') {
+        return disableStopButton(item);
+        } else if (action === 'suspend') {
+        return disableSuspendButton(item);
+        }
+    };
+
+    vm.handlePowerOperation = function (action, item) {
+      if (action === 'stop' && !vm.checkDisabled(action, item)) {
+        vm.stopService(item);
+      } else if (action === 'suspend' && !vm.checkDisabled(action, item)) {
+        vm.suspendService(item);
+        }
+    };
   }
 })();

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -36,8 +36,21 @@
   }
 
   /** @ngInject */
-  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, CollectionsApi, EventNotifications, sprintf) {
+  function StateController($state, services, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, PowerOperations) {
     var vm = this;
+
+    vm.startService = PowerOperations.startService;
+    vm.stopService = PowerOperations.stopService;
+    vm.suspendService = PowerOperations.suspendService;
+    vm.powerOperationUnknownState = PowerOperations.powerOperationUnknownState;
+    vm.powerOperationInProgressState = PowerOperations.powerOperationInProgressState;
+    vm.powerOperationOnState = PowerOperations.powerOperationOnState;
+    vm.powerOperationOffState = PowerOperations.powerOperationOffState;
+    vm.powerOperationSuspendState = PowerOperations.powerOperationSuspendState;
+    vm.powerOperationTimeoutState = PowerOperations.powerOperationTimeoutState;
+    vm.powerOperationStartTimeoutState = PowerOperations.powerOperationStartTimeoutState;
+    vm.powerOperationStopTimeoutState = PowerOperations.powerOperationStopTimeoutState;
+    vm.powerOperationSuspendTimeoutState = PowerOperations.powerOperationSuspendTimeoutState;
 
     vm.services = [];
 
@@ -148,101 +161,36 @@
     }
 
     vm.enableButtonForItemFn = function (action, item) {
-      return powerOperationUnknownState(item)
-        || powerOperationOffState(item)
-        || powerOperationSuspendState(item)
-        || powerOperationTimeoutState(item);
+      return vm.powerOperationUnknownState(item)
+        || vm.powerOperationOffState(item)
+        || vm.powerOperationSuspendState(item)
+        || vm.powerOperationTimeoutState(item);
     };
 
     vm.hideMenuForItemFn = function (item) {
-      return powerOperationUnknownState(item) || powerOperationInProgressState(item);
+      return vm.powerOperationUnknownState(item) || vm.powerOperationInProgressState(item);
     };
 
     vm.updateMenuActionForItemFn = function(action, item) {
-      if (powerOperationSuspendState(item) && action.actionName === "suspend") {
+      if (vm.powerOperationSuspendState(item) && action.actionName === "suspend") {
         action.isDisabled = true;
-      } else if (powerOperationOffState(item) && action.actionName === "stop") {
+      } else if (vm.powerOperationOffState(item) && action.actionName === "stop") {
         action.isDisabled = true;
       } else {
         action.isDisabled = false;
       }
     };
-
-    function powerOperationUnknownState(item) {
-      return item.powerState === "" && item.powerStatus === "";
-    }
-
-    function powerOperationInProgressState(item) {
-      return (item.powerState !== "timeout" && item.powerStatus === "starting")
-        || (item.powerState !== "timeout" && item.powerStatus === "stopping")
-        || (item.powerState !== "timeout" && item.powerStatus === "suspending");
-    }
-
-    function powerOperationOnState(item) {
-      return item.powerState === "on" && item.powerStatus === "start_complete";
-    }
-
-    function powerOperationOffState(item) {
-      return item.powerState === "off" && item.powerStatus === "stop_complete";
-    }
-
-    function powerOperationSuspendState(item) {
-      return item.powerState === "off" && item.powerStatus === "suspend_complete";
-    }
-
-    function powerOperationTimeoutState(item) {
-      return item.powerState === "timeout";
-    }
-
-    function powerOperationStartTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "starting";
-    }
-
-    function powerOperationStopTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "stopping";
-    }
-
-    function powerOperationSuspendTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "suspending";
-    }
-
+    
     function startService(action, item) {
-      item.powerStatus = 'starting';
-      powerOperation('start', item);
+      vm.startService(item);
     }
 
     function stopService(action, item) {
-      item.powerStatus = 'stopping';
-      powerOperation('stop', item);
+      vm.stopService(item);
     }
 
     function suspendService(action, item) {
-      item.powerStatus = 'suspending';
-      powerOperation('suspend', item);
-    }
-
-    function powerOperation(powerAction, item) {
-      CollectionsApi.post('services', item.id, {}, {action: powerAction}).then(actionSuccess, actionFailure);
-
-      function actionSuccess() {
-        if (powerAction === 'start') {
-          EventNotifications.success(__(sprintf("%s was started", item.name)));
-        } else if (powerAction === 'stop') {
-          EventNotifications.success(__(sprintf("%s was stopped", item.name)));
-        } else if (powerAction === 'suspend') {
-          EventNotifications.success(__(sprintf("%s was suspended", item.name)));
-        }
-      }
-
-      function actionFailure() {
-        if (powerAction === 'start') {
-          EventNotifications.error(__('There was an error starting this service.'));
-        } else if (powerAction === 'stop') {
-          EventNotifications.error(__('There was an error stopping this service.'));
-        } else if (powerAction === 'suspend') {
-          EventNotifications.error(__('There was an error suspending this service.'));
-        }
-      }
+      vm.suspendService(item);
     }
 
     function handleClick(item, e) {

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -1,0 +1,151 @@
+describe('Dashboard', function() {
+  beforeEach(function() {
+    module('app.states', 'app.config', 'gettext', bard.fakeToastr);
+    bard.inject('$state', '$templateCache', 'Session');
+
+    state = {
+      actionFeatures: {
+        serviceDelete: {show: true},
+        serviceRetireNow: {show: true},
+        serviceRetire: {show: true},
+        serviceEdit: {show: true},
+        serviceReconfigure: {show: true},
+        serviceOwnership: {show: true},
+      }
+    };
+
+    Chargeback = {
+      processReports: function(){},
+      adjustRelativeCost: function(){}
+    };
+
+    PowerOperations = {
+      powerOperationOnState: function (item) {
+        return item.powerState === "on" && item.powerStatus === "start_complete";
+      },
+      powerOperationUnknownState: function (item) {
+        return item.powerState === "" && item.powerStatus === "";
+      },
+      powerOperationInProgressState: function (item) {
+        return (item.powerState !== "timeout" && item.powerStatus === "starting")
+          || (item.powerState !== "timeout" && item.powerStatus === "stopping")
+          || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+      },
+      powerOperationOffState: function (item) {
+        return item.powerState === "off" && item.powerStatus === "stop_complete";
+      },
+      powerOperationSuspendState: function (item) {
+        return item.powerState === "off" && item.powerStatus === "suspend_complete";
+      },
+      powerOperationTimeoutState: function (item) {
+        return item.powerState === "timeout";
+      },
+    };
+  });
+
+  describe('route', function() {
+    var views = {
+      list: 'app/states/services/details/details.html'
+    };
+
+    beforeEach(function() {
+      bard.inject('$state', '$templateCache');
+    });
+
+    it('should work with $state.go', function() {
+      $state.go('services.details');
+      expect($state.is('services.details'));
+    });
+  });
+
+  describe('controller', function() {
+    var controller;
+
+    var service = {
+      options: {
+        power_state: "timeout",
+        power_status: "starting"
+      },
+      chargeback_report: {
+        results: []
+      }
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$state');
+
+      controller = $controller($state.get('services.details').controller, {service: service, $state: state});
+    });
+
+    it('should be created successfully', function() {
+      expect(controller).to.be.defined;
+    });
+  });
+
+  describe('service detail contains power state in "timeout" and power status in "starting', function() {
+    var controller;
+
+    var service = {
+        options: {
+          power_state: "timeout",
+          power_status: "starting"
+        },
+      chargeback_report: {
+        results: []
+      }
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$state');
+
+      controller = $controller($state.get('services.details').controller, {service: service, $state: state, Chargeback: Chargeback});
+    });
+
+    it('enables the "Start" button when power state is "timeout" and power status is "starting', function() {
+      expect(controller.enableStartButton(controller.service)).to.eq(true);
+    });
+
+    it('disables the "Stop" button when power state is "timeout" and power status is "starting', function() {
+      expect(controller.checkDisabled('stop', controller.service)).to.eq(false);
+    });
+
+    it('disables the "Suspend" button when power state is "timeout" and power status is "starting', function() {
+      expect(controller.checkDisabled('suspend', controller.service)).to.eq(false);
+    });
+  });
+
+  describe('service detail contains power state in "on" and power status in "start_complete', function() {
+    var controller;
+    var service = {
+      options: {
+        power_state: "on",
+        power_status: "start_complete"
+      },
+      chargeback_report: {
+        results: []
+      },
+    };
+
+    beforeEach(function() {
+      bard.inject('$controller', '$state');
+
+      controller = $controller($state.get('services.details').controller,
+        {service: service,
+         $state: state,
+         Chargeback: Chargeback,
+         PowerOperations: PowerOperations});
+    });
+
+    it('disables the "Start" button when power state is "ON"', function() {
+      expect(controller.enableStartButton(controller.service)).to.eq(false);
+    });
+
+    it('enables the "Stop" button when power state is "ON"', function() {
+      expect(controller.checkDisabled('stop', controller.service)).to.eq(false);
+    });
+
+    it('enables the "Suspend" button when power state is "ON"', function() {
+      expect(controller.checkDisabled('suspend', controller.service)).to.eq(false);
+    });
+  });
+});

--- a/tests/services-list.state.spec.js
+++ b/tests/services-list.state.spec.js
@@ -116,18 +116,40 @@ describe('Dashboard', function() {
       adjustRelativeCost: function(){}
     };
 
+    var PowerOperations = {
+      powerOperationOnState: function (item) {
+        return item.powerState === "on" && item.powerStatus === "start_complete";
+      },
+      powerOperationUnknownState: function (item) {
+        return item.powerState === "" && item.powerStatus === "";
+      },
+      powerOperationInProgressState: function (item) {
+        return (item.powerState !== "timeout" && item.powerStatus === "starting")
+          || (item.powerState !== "timeout" && item.powerStatus === "stopping")
+          || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+      },
+      powerOperationOffState: function (item) {
+        return item.powerState === "off" && item.powerStatus === "stop_complete";
+      },
+      powerOperationSuspendState: function (item) {
+        return item.powerState === "off" && item.powerStatus === "suspend_complete";
+      },
+      powerOperationTimeoutState: function (item) {
+        return item.powerState === "timeout";
+      },
+    };
+
     beforeEach(function() {
       bard.inject('$controller', '$log', '$state', '$rootScope');
 
-      controller = $controller($state.get('services.list').controller, {services: services, Chargeback: Chargeback});
+      controller = $controller($state.get('services.list').controller,
+        {services: services,
+         Chargeback: Chargeback,
+         PowerOperations: PowerOperations});
     });
 
     it('sets the powerState value on the Service', function() {
-      expect(serviceItem.powerState).to.eq('on');
-    });
-
-    it('sets the powerStatus value on the Service', function() {
-      expect(serviceItem.powerStatus).to.eq('start_complete');
+      expect(controller.powerOperationOnState(serviceItem)).to.eq(true);
     });
 
     it('does not hide the kebab menu when "Start" operation leads to an "ON" power state', function() {


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-ui-service/pull/271 added the Service Power Operation feature in the Services List view.

This PR adds the same feature in the Service Detail view.

- A new Service `PowerOperations` was created that would be injected in both the Service list controller as well as the Service detail controller.
- Buttons in the top right corner were rearranged to avoid making the page look overly busy (with too many buttons). 
- Also added a `Power State` field to indicate the current Power status

Screenshots
-------------
Before:
<img width="1356" alt="screen shot 2016-11-10 at 11 02 30 am" src="https://cloud.githubusercontent.com/assets/1538216/20194623/f024a028-a747-11e6-8d45-28fa69b7bc89.png">

After:
<img width="1353" alt="screen shot 2016-11-10 at 11 00 28 am" src="https://cloud.githubusercontent.com/assets/1538216/20194656/1a8fc0ea-a748-11e6-93b6-232a4cb772bd.png">

<img width="1358" alt="screen shot 2016-11-10 at 10 57 08 am" src="https://cloud.githubusercontent.com/assets/1538216/20194669/329f72ca-a748-11e6-9b76-ba051573517a.png">

<img width="1403" alt="screen shot 2016-11-10 at 10 59 20 am" src="https://cloud.githubusercontent.com/assets/1538216/20194642/03cc60fc-a748-11e6-871e-fd0d88ed85a5.png">
