### PR TITLE
Set retirement datepicker options to start at current date

### DIFF
--- a/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -52,6 +52,7 @@
       autoclose: true,
       todayBtn: 'linked',
       todayHighlight: true,
+      startDate: new Date(),
     };
 
     vm.warningOptions = [


### PR DESCRIPTION
Set an additional configuration option on the bootstrap datepicker so
that dates in the past are disabled. This will prevent invalid
retirement scheduling from happening through the UI.

This will match the OpsUI behavior of allowing services to be scheduled
for the current day and any day in the future, but not a day that has
already passed.