### PR TITLE
Lock travis build yarn version for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - node_modules
 before_install:
-- npm install -g yarn gulp
+- npm install -g yarn@0.16.1 gulp
 install:
 - yarn install --force
 - gulp build


### PR DESCRIPTION
Version 0.17.0 breaks installing dependencies from repos https://github.com/yarnpkg/yarn/issues/1818

Gonna lock this down till things calm down. 🐱 🐈 

@chriskacerguis @himdel 