### PR TITLE
[WIP] Count retired/retiring services for dashboard client-side

### DIFF
--- a/tests/dashboard.state.spec.js
+++ b/tests/dashboard.state.spec.js
@@ -33,21 +33,15 @@ describe('Dashboard', function() {
 
   describe('controller', function() {
     var controller;
-    var resolveServicesWithDefinedServiceIds = {};
-    var retiredServices = {};
-    var resolveNonRetiredServices = {};
-    var expiringServices = {};
+    var resolveAllServices = {};
     var resolveAllRequests = [];
 
     beforeEach(function() {
       bard.inject('$controller', '$log', '$state', '$rootScope');
 
       var controllerResolves = {
-        definedServiceIdsServices: resolveServicesWithDefinedServiceIds,
-        retiredServices: retiredServices,
-        nonRetiredServices: resolveNonRetiredServices,
-        expiringServices: expiringServices,
-        allRequests: resolveAllRequests
+        allServices: resolveAllServices,
+        allRequests: resolveAllRequests,
       };
 
       controller = $controller($state.get('dashboard').controller, controllerResolves);


### PR DESCRIPTION
This change fixes a bug where the dashboard would fail to render when a
service was scheduled to retire between today and 30 days from today.
The error was due to a request to to service collections API with filter
parameters that are not supported. Currently, filter expressions using
the `>=` and `<=` operators must have numeric operands. The dashboard
has a widget that counts the number of services scheduled to retire soon
and uses filter parameters with datetime strings, causing the issue.