### PR TITLE
Updates package.json to use spice-html5-bower published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "request": "^2.75.0",
     "sinon": "^1.15.4",
     "sinon-chai": "^2.7.0",
-    "spice-html5-bower": "himdel/spice-html5-bower#1.6.2",
+    "spice-html5-bower": "~1.6.2",
     "sprintf-js": "~1.0.3",
     "toastr": "^2.1.2",
     "yargs": "^5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,7 +3436,7 @@ hosted-git-info@^2.1.4:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.1.5.tgz#0ba81d90da2e25ab34a332e6ec77936e1598118b"
 
-"HTML_CodeSniffer@github:squizlabs/HTML_CodeSniffer#2.0.7":
+HTML_CodeSniffer@squizlabs/HTML_CodeSniffer#2.0.7:
   version "2.0.7"
   resolved "https://codeload.github.com/squizlabs/HTML_CodeSniffer/tar.gz/d209ce54876657858a8a01528ad812cd234f37f0"
 
@@ -6501,9 +6501,9 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
-spice-html5-bower@himdel/spice-html5-bower#1.6.2:
+spice-html5-bower@~1.6.2:
   version "1.6.2"
-  resolved "https://codeload.github.com/himdel/spice-html5-bower/tar.gz/2e159e9d48e7f9588cbd8465591f5972ca69c355"
+  resolved "https://registry.yarnpkg.com/spice-html5-bower/-/spice-html5-bower-1.6.2.tgz#d902214efa51850e65e0610fe22dcf87a26f7985"
 
 split@0.3:
   version "0.3.3"


### PR DESCRIPTION
As per https://github.com/ManageIQ/manageiq-ui-service/pull/337#issuecomment-260594457, updated dependency `spice-html5-bower` to use npm

🙇  🌮 ❤️ @himdel 

@chriskacerguis 