### PR TITLE
Fix links in dashboard for service counts and filters

### DIFF
--- a/client/app/states/dashboard/_dashboard.sass
+++ b/client/app/states/dashboard/_dashboard.sass
@@ -43,6 +43,9 @@
       border-left: 0
       margin: 0
 
+      a
+        cursor: pointer
+
       .pficon
         border: 2px solid $app-color-medium-blue
         border-radius: 100px

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -93,16 +93,16 @@
   }
 
   /** @ngInject */
-  function resolveExpiringServices(CollectionsApi, $filter, $state) {
+  function resolveExpiringServices(CollectionsApi, $state) {
     if (!$state.navFeatures.services.show) {
       return undefined;
     }
     var currentDate = new Date();
-    var date1 = 'retires_on>=' + $filter('date')(currentDate, 'yyyy-MM-dd');
+    var date1 = 'retires_on>=' + currentDate.toISOString();
 
     var days30 = currentDate.setDate(currentDate.getDate() + 30);
-    var date2 = 'retires_on<=' + $filter('date')(days30, 'yyyy-MM-dd');
-    var options = {expand: false, filter: ['service_id=nil', date1, date2]};
+    var date2 = 'retires_on<=' + new Date(days30).toISOString();
+    var options = {expand: false, filter: ['retired=false', date1, date2]};
 
     return CollectionsApi.query('services', options);
   }

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -335,7 +335,7 @@
       if (filterValue === 'retired' && angular.isDefined(item.retires_on)) {
         return angular.isDefined(item.retired) && item.retired === true;
       } else if (filterValue === 'current') {
-        return angular.isUndefined(item.retired) || item.retired === false;
+        return angular.isUndefined(item.retired);
       } else if (filterValue === 'soon' && angular.isDefined(item.retires_on)) {
         return new Date(item.retires_on) >= currentDate
           && new Date(item.retires_on) <= currentDate.setDate(currentDate.getDate() + 30);


### PR DESCRIPTION
Fixes a bug for the dashboard view caused by a 500 error when making a
request to the API using an unsupported filter expression. An issue is
already filed with the ManageIQ repo. In addition, this change includes
various enhancements to the dashboard for services.

* Make links to filtered service views more apparent with a cursor
* Request services retiring soon in UTC time to prevent inconsistencies
across time zones
* Fix `current` services filter by removing `retired === false` check.
Services retiring soon are `retired = false` and would show up with that
check.

https://github.com/ManageIQ/manageiq/issues/12648