### PR TITLE
Update remove service to use delete request

### DIFF
--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -121,8 +121,7 @@
     }
 
     function removeService() {
-      var removeAction = {action: 'retire'};
-      CollectionsApi.post('services', vm.service.id, {}, removeAction).then(removeSuccess, removeFailure);
+      CollectionsApi.delete('services', vm.service.id).then(removeSuccess, removeFailure);
 
       function removeSuccess() {
         EventNotifications.success(vm.service.name + __(' was removed.'));

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -62,6 +62,8 @@ describe('Dashboard', function() {
     var controller;
 
     var service = {
+      id: 123,
+      name: 'foo',
       options: {
         power_state: "timeout",
         power_status: "starting"
@@ -72,13 +74,39 @@ describe('Dashboard', function() {
     };
 
     beforeEach(function() {
-      bard.inject('$controller', '$state');
+      bard.inject('$controller', '$state', 'CollectionsApi', 'EventNotifications');
 
       controller = $controller($state.get('services.details').controller, {service: service, $state: state});
     });
 
     it('should be created successfully', function() {
       expect(controller).to.be.defined;
+    });
+
+    describe('removeService', function() {
+      it('DELETEs to the services API', function() {
+        collectionsApiSpy = sinon.stub(CollectionsApi, 'delete').returns(Promise.resolve());
+
+        controller.removeService();
+
+        expect(collectionsApiSpy).to.have.been.calledWith('services', 123);
+      });
+
+      it('sends a success message to the notification center', function(done) {
+        notificationSpy = sinon.stub(EventNotifications, 'success');
+
+        controller.removeService();
+        done();
+
+        expect(notificationSpy).to.have.been.calledWith('foo was removed.');
+      });
+
+      it('goes to the service list state', function(done) {
+        controller.removeService();
+        done();
+
+        expect($state.is('services.list')).to.be.true;
+      });
     });
   });
 


### PR DESCRIPTION
Fix the service delete action in the service detail view. Instead of
making a post request with the `retire` action, use the delete request
for the associated resource.