### PR TITLE
Add reset button to edit service modal

### DIFF
--- a/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
+++ b/client/app/components/edit-service-modal/edit-service-modal-service.factory.js
@@ -33,37 +33,22 @@
   }
 
   /** @ngInject */
-  function EditServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications) {
+  function EditServiceModalController(serviceDetails, $controller, $modalInstance, sprintf) {
     var vm = this;
-
-    vm.service = serviceDetails;
-    vm.saveServiceDetails = saveServiceDetails;
+    var base = $controller('BaseModalController', {
+      $modalInstance: $modalInstance,
+    });
+    angular.extend(vm, base);
 
     vm.modalData = {
-      'action': 'edit',
-      'resource': {
-        'name': vm.service.name || '',
-        'description': vm.service.description || '',
-      },
+      id: serviceDetails.id,
+      name: serviceDetails.name,
+      description: serviceDetails.description,
     };
 
-    activate();
-
-    function activate() {
-    }
-
-    function saveServiceDetails() {
-      CollectionsApi.post('services', vm.service.id, {}, vm.modalData).then(saveSuccess, saveFailure);
-
-      function saveSuccess() {
-        $modalInstance.close();
-        EventNotifications.success(vm.service.name + __(' was edited.'));
-        $state.go($state.current, {}, {reload: true});
-      }
-
-      function saveFailure() {
-        EventNotifications.error(__('There was an error editing this service.'));
-      }
-    }
+    vm.action = 'edit';
+    vm.collection = 'services';
+    vm.onSuccessMessage = sprintf(__("%s was edited."), serviceDetails.name);
+    vm.onFailureMessage = __('There was an error editing this service.');
   }
 })();

--- a/client/app/components/edit-service-modal/edit-service-modal.html
+++ b/client/app/components/edit-service-modal/edit-service-modal.html
@@ -7,22 +7,18 @@
 <div class="modal-body">
   <form class="form-horizontal">
     <div pf-form-group pf-label="{{'Name'|translate}}" required>
-      <input id="name" name="name"
-             ng-model="vm.modalData.resource.name" type="text" required/>
+      <input id="name" name="name" ng-model="vm.modalData.name" type="text" required/>
     </div>
     <div pf-form-group pf-input-class="col-sm-9" pf-label="{{'Description'|translate}}">
-        <textarea id="description" name="description" ng-model="vm.modalData.resource.description">
-          {{ vm.modalData.resource.description }}
+        <textarea id="description" name="description" ng-model="vm.modalData.description">
+          {{ vm.modalData.description }}
         </textarea>
     </div>
+    <modal-actions
+      modal-data="vm.modalData"
+      on-cancel="vm.cancel()"
+      on-reset="vm.reset($event)"
+      on-save="vm.save()">
+    </modal-actions>
   </form>
-</div>
-<div class="modal-footer">
-  <button type="button" class="btn btn-default" ng-click="$dismiss()" translate>Cancel</button>
-  <button type="button"
-          class="btn btn-primary"
-          ng-click="vm.saveServiceDetails()"
-          ng-disabled="vm.modalData.resource.name == vm.service.name &&
-          vm.modalData.resource.description == vm.service.description" translate>Save
-  </button>
 </div>

--- a/client/app/components/modal-actions/modal-actions.component.js
+++ b/client/app/components/modal-actions/modal-actions.component.js
@@ -1,0 +1,49 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .component('modalActions', {
+      controller: ComponentController,
+      controllerAs: 'vm',
+      bindings: {
+        modalData: '<',
+        onCancel: '&',
+        onReset: '&',
+        onSave: '&',
+      },
+      templateUrl: 'app/components/modal-actions/modal-actions.html',
+    });
+
+  /** @ngInject */
+  function ComponentController() {
+    var vm = this;
+    vm.isPristine = isPristine;
+    vm.cancelAction = cancelAction;
+    vm.emitOriginal = emitOriginal;
+    vm.saveResource = saveResource;
+
+    vm.$onInit = function() {
+      vm.original = angular.copy(vm.modalData);
+    };
+
+    function cancelAction() {
+      vm.onCancel();
+    }
+
+    function isPristine() {
+      return angular.equals(vm.modalData, vm.original);
+    }
+
+    function emitOriginal() {
+      vm.onReset({
+        $event: {
+          original: vm.original,
+        },
+      });
+    }
+
+    function saveResource() {
+      vm.onSave();
+    }
+  }
+})();

--- a/client/app/components/modal-actions/modal-actions.html
+++ b/client/app/components/modal-actions/modal-actions.html
@@ -1,0 +1,19 @@
+<div class="modal-footer">
+  <button type="button"
+          class="btn btn-default"
+          ng-click="vm.cancelAction()"
+          translate>Cancel
+  </button>
+  <button type="button"
+          class="btn btn-default"
+          ng-click="vm.emitOriginal()"
+          ng-disabled="vm.isPristine()"
+          translate>Reset
+  </button>
+  <button type="button"
+          class="btn btn-primary"
+          ng-click="vm.saveResource()"
+          ng-disabled="vm.isPristine()"
+          translate>Save
+  </button>
+</div>

--- a/client/app/components/modals/base-modal-controller.js
+++ b/client/app/components/modals/base-modal-controller.js
@@ -1,0 +1,42 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .controller('BaseModalController', BaseModalController);
+
+  /** @ngInject */
+  function BaseModalController($modalInstance, $state, CollectionsApi, EventNotifications) {
+    var vm = this;
+    vm.cancel = cancel;
+    vm.reset = reset;
+    vm.save = save;
+
+    function cancel() {
+      $modalInstance.dismiss();
+    }
+
+    function reset(event) {
+      angular.copy(event.original, this.modalData); // eslint-disable-line angular/controller-as-vm
+    }
+
+    function save() {
+      var vm = this;
+      var data = {
+        action: vm.action,
+        resource: vm.modalData,
+      };
+
+      CollectionsApi.post(vm.collection, vm.modalData.id, {}, data).then(saveSuccess, saveFailure);
+
+      function saveSuccess() {
+        $modalInstance.close();
+        EventNotifications.success(vm.onSuccessMessage);
+        $state.go($state.current, {}, {reload: true});
+      }
+
+      function saveFailure() {
+        EventNotifications.error(vm.onFailureMessage);
+      }
+    }
+  }
+})();

--- a/tests/components/base-modal-controller.spec.js
+++ b/tests/components/base-modal-controller.spec.js
@@ -1,0 +1,53 @@
+describe('BaseModalController', function() {
+  beforeEach(module('app.components', 'app.config', 'gettext'));
+
+  var base;
+  var controller;
+  var CollectionsApi;
+  var EventNotifications;
+  var mockModalInstance = { close: angular.noop, dismiss: angular.noop };
+
+  beforeEach(inject(function($controller, $injector) {
+    CollectionsApi = $injector.get('CollectionsApi');
+    EventNotifications = $injector.get('EventNotifications');
+
+    base = $controller('BaseModalController', {
+      $modalInstance: mockModalInstance,
+    });
+
+    controller = angular.extend(angular.copy(base), base);
+    controller.modalData = {
+      id: '1',
+      name: 'bar',
+      description: 'Your Service',
+    }
+  }));
+
+  it('delegates dismiss to the local $modalInstance when cancel called', function() {
+    var spy = sinon.spy(mockModalInstance, 'dismiss');
+
+    controller.cancel();
+
+    expect(spy).to.have.been.called;
+  });
+
+  it('resets the modal data to the original data emitted by the reset', function() {
+    var payload = { original: { name: 'foo', description: 'My Service' }};
+
+    controller.reset(payload);
+
+    expect(controller.modalData.name).to.equal('foo');
+    expect(controller.modalData.description).to.equal('My Service');
+  });
+
+  it('makes a POST request when save is triggered', function() {
+    var spy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve());
+    var payload = { action: 'edit', resource: controller.modalData };
+
+    controller.action = 'edit';
+    controller.collection = 'services';
+    controller.save();
+
+    expect(spy).to.have.been.calledWith('services', '1', {}, payload);
+  });
+});

--- a/tests/components/modal-actions.spec.js
+++ b/tests/components/modal-actions.spec.js
@@ -1,0 +1,62 @@
+describe('modalActions component', function() {
+  beforeEach(module('app.components', 'gettext'));
+
+  describe('controller', function() {
+    var controller;
+    var mockData = { name: 'foo', description: 'My service' };
+    var mockCancel = angular.noop;
+    var mockReset = angular.noop;
+    var mockSave = angular.noop;
+
+    beforeEach(inject(function($componentController) {
+      controller = $componentController('modalActions', {}, {
+        modalData: mockData,
+        onCancel: mockCancel,
+        onReset: mockReset,
+        onSave: mockSave
+      });
+    }));
+
+    it('holds a copy of the original modal data', function() {
+      controller.$onInit();
+
+      expect(controller.original.name).to.equal('foo');
+      expect(controller.original.description).to.equal('My service');
+    });
+
+    it('calls onCancel when cancelAction is called', function() {
+      var spy = sinon.spy(controller, 'onCancel');
+
+      controller.cancelAction();
+
+      expect(spy).to.have.been.called;
+    });
+
+    it('calls onReset when emitOriginal is called', function() {
+      var payload = { $event: { original: mockData } };
+      var spy = sinon.stub(controller, 'onReset');
+
+      controller.$onInit();
+      controller.emitOriginal();
+
+      expect(spy).to.have.been.calledWith(payload);
+    });
+
+    it('calls onSave when saveResource is called', function() {
+      var spy = sinon.spy(controller, 'onSave');
+
+      controller.saveResource();
+
+      expect(spy).to.have.been.called;
+    });
+
+    it('delegates to angular.equals when checking if pristine', function() {
+      var spy = sinon.spy(angular, 'equals');
+
+      controller.$onInit();
+      controller.isPristine();
+
+      expect(spy).to.have.been.calledWith(mockData, mockData);
+    });
+  });
+});


### PR DESCRIPTION
Include a reset button on the edit service modal to match the OpsUI. The
save and reset buttons are disabled unless the original values have been
changed.