### PR TITLE
CFUX-201 - Updated Toolbar for Blueprint Editor

### DIFF
--- a/client/app/components/blueprints/blueprint-editor/_blueprint-editor.sass
+++ b/client/app/components/blueprints/blueprint-editor/_blueprint-editor.sass
@@ -9,6 +9,10 @@
   display: inline-block
 
 .blueprint-designer-header
+  .actions
+    float: right
+    padding-right: 5px
+
   button
     margin-left: 10px
     vertical-align: top
@@ -41,22 +45,32 @@
   .section-toolbar
     padding: 15px
 
+    a
+      color: $color-mine-shaft-approx
+
     button
       margin-right: 6px
 
     .more-actions
       border-left: solid 2px $color-light-gray-approx
       margin-left: 6px
+      vertical-align: middle
 
     .blueprint-details-btn
       margin-left: 16px
+
+    .pficon
+      font-size: 20px
+      margin-left: 15px
+      margin-top: -4px
+      vertical-align: middle
 
     .show-hide-connectors
       display: block
       float: right
       font-size: 12px
       font-weight: 600
-      padding-right: 80px
+      padding-right: 5px
       padding-top: 2px
       vertical-align: middle
 
@@ -157,10 +171,8 @@
 
       .toolbox-footer
         margin-bottom: 10px
-        margin-left: 2px
-        margin-right: 184px
         margin-top: 10px
-        width: 90%
+        width: 100%
 
         .new-catalog-item
           border: 2px dashed $color-gray-1
@@ -191,7 +203,7 @@
           float: right
           position: relative
           text-decoration: none
-          width: 14%
+          width: 250px
 
         .clear-search-text
           bottom: -6px
@@ -199,7 +211,7 @@
           cursor: pointer
           float: right
           position: relative
-          right: -197px
+          right: -242px
 
           span
             font-size: 20px

--- a/client/app/components/blueprints/blueprint-editor/blueprint-editor.directive.js
+++ b/client/app/components/blueprints/blueprint-editor/blueprint-editor.directive.js
@@ -122,6 +122,14 @@
       vm.toolboxVisible = false;
     };
 
+    vm.toggleToolbox = function() {
+      if (vm.toolboxVisible === true) {
+        vm.hideToolbox();
+      } else {
+        vm.showToolbox();
+      }
+    };
+
     $scope.$on('clickOnChart', function(evt) {
       vm.hideToolbox();
     });

--- a/client/app/components/blueprints/blueprint-editor/blueprint-editor.html
+++ b/client/app/components/blueprints/blueprint-editor/blueprint-editor.html
@@ -28,16 +28,16 @@
             <span class="fa" ng-class="{'fa-angle-double-up': vm.toolboxVisible, 'fa-angle-double-down': !vm.toolboxVisible}"></span>
           </button>
           <span class="more-actions">
-              <a id="duplicateItem" ng-click="vm.duplicateSelectedItem()">
-                <span class="pficon fa fa-copy" ng-class="{'disabled': !vm.onlyOneTtemSelected() || vm.inConnectingMode}"
+              <a ng-click="vm.duplicateSelectedItem()">
+                <span id="duplicateItem" class="pficon fa fa-copy" ng-class="{'disabled': !vm.onlyOneTtemSelected() || vm.inConnectingMode}"
                       tooltip-append-to-body="true" tooltip-placement="bottom"
-                      tooltip="{{'Duplicate Item (Ctrl-D)'|translate}}" translate>
+                      tooltip="{{'Duplicate Item (Ctrl-D)'|translate}}">
                 </span>
               </a>
-              <a id="removeItems" ng-click="vm.removeSelectedItemsFromCanvas()">
-                <span class="pficon pficon-delete" ng-class="{'disabled': !vm.itemsSelected() || vm.inConnectingMode}"
+              <a ng-click="vm.removeSelectedItemsFromCanvas()">
+                <span id="removeItems" class="pficon pficon-delete" ng-class="{'disabled': !vm.itemsSelected() || vm.inConnectingMode}"
                       tooltip-append-to-body="true" tooltip-placement="bottom"
-                      tooltip="{{'Remove Items From Canvas'|translate}}" translate>
+                      tooltip="{{'Remove Items From Canvas'|translate}}">
                 </span>
               </a>
               <span class="show-hide-connectors">
@@ -107,10 +107,6 @@
                   <a ng-click="vm.searchText = ''"><span class="pficon pficon-close clear-search-text"></span></a>
               </div>
               <div class="close-toolbox">
-                  <!--
-                  <a ng-if="vm.toolboxVisible" ng-click="vm.hideToolbox()" style="cursor: pointer"><span
-                          class="fa fa-angle-double-up fa-2x"></span></a>
-                    -->
               </div>
           </div>
 

--- a/client/app/components/blueprints/blueprint-editor/blueprint-editor.html
+++ b/client/app/components/blueprints/blueprint-editor/blueprint-editor.html
@@ -7,32 +7,39 @@
       <li class="active">
           <input id="blueprintName" type="text" class="blueprint-name-input" ng-model="vm.blueprint.name"
                  placeholder="{{'Untitled Blueprint'|translate}}">
-          <button class="btn btn-primary btb-sm" type="button" ng-click="vm.saveBlueprint()" id="saveBtm"
-                  ng-class="{'disabled': !vm.canSave()}" data-toggle="tooltip" data-placement="bottom"
-                  title="{{'Save Blueprint'|translate}}" translate>Save
-          </button>
       </li>
+      <span class="actions">
+        <button class="btn btn-primary btb-sm" type="button" ng-click="vm.saveBlueprint()" id="saveBtm"
+                ng-class="{'disabled': !vm.canSave()}" data-toggle="tooltip" data-placement="bottom"
+                title="{{'Save Blueprint'|translate}}" translate>Save
+        </button>
+        <button class="btn btn-default blueprint-details-btn" type="button" ng-click="vm.editDetails()" data-toggle="tooltip"
+                ng-class="{'disabled': vm.inConnectingMode, 'wait-cursor': vm.loading}"
+                data-placement="bottom" title="{{'Edit Blueprint Details' | translate}}" translate>Blueprint Details
+        </button>
+      </span>
   </ol>
 
   <div class="blueprint-designer-container">
 
       <div class="section-toolbar">
-          <button id="toggleToolbox" class="btn btn-primary" ng-class="{'disabled': vm.inConnectingMode}" type="button" ng-click="vm.showToolbox()"
+          <button id="toggleToolbox" class="btn btn-primary" ng-class="{'disabled': vm.inConnectingMode}" type="button" ng-click="vm.toggleToolbox()"
                   data-toggle="tooltip" data-placement="bottom" title="{{'Add Service Item To Canvas'|translate}}" translate>Add Item
-          </button>
-          <button id="duplicateItem" class="btn" type="button" ng-class="{'disabled': !vm.onlyOneTtemSelected() || vm.inConnectingMode}"
-                  ng-click="vm.duplicateSelectedItem()" data-toggle="tooltip" data-placement="bottom"
-                  title="{{'Duplicate Item (Ctrl-D)'|translate}}" translate>Duplicate
-          </button>
-          <button id="removeItems" class="btn" type="button" ng-class="{'disabled': !vm.itemsSelected() || vm.inConnectingMode}"
-                  ng-click="vm.removeSelectedItemsFromCanvas()" data-toggle="tooltip" data-placement="bottom"
-                  title="{{'Remove Items From Canvas'|translate}}" translate>Remove
+            <span class="fa" ng-class="{'fa-angle-double-up': vm.toolboxVisible, 'fa-angle-double-down': !vm.toolboxVisible}"></span>
           </button>
           <span class="more-actions">
-              <button class="btn blueprint-details-btn" type="button" ng-click="vm.editDetails()" data-toggle="tooltip"
-                      ng-class="{'disabled': vm.inConnectingMode, 'wait-cursor': vm.loading}"
-                      data-placement="bottom" title="{{'Edit Blueprint Details' | translate}}" translate>Blueprint Details
-              </button>
+              <a id="duplicateItem" ng-click="vm.duplicateSelectedItem()">
+                <span class="pficon fa fa-copy" ng-class="{'disabled': !vm.onlyOneTtemSelected() || vm.inConnectingMode}"
+                      tooltip-append-to-body="true" tooltip-placement="bottom"
+                      tooltip="{{'Duplicate Item (Ctrl-D)'|translate}}" translate>
+                </span>
+              </a>
+              <a id="removeItems" ng-click="vm.removeSelectedItemsFromCanvas()">
+                <span class="pficon pficon-delete" ng-class="{'disabled': !vm.itemsSelected() || vm.inConnectingMode}"
+                      tooltip-append-to-body="true" tooltip-placement="bottom"
+                      tooltip="{{'Remove Items From Canvas'|translate}}" translate>
+                </span>
+              </a>
               <span class="show-hide-connectors">
                   <input  ng-class="{'disabled': vm.inConnectingMode}"
                           ng-model="vm.hideConnectors"
@@ -100,8 +107,10 @@
                   <a ng-click="vm.searchText = ''"><span class="pficon pficon-close clear-search-text"></span></a>
               </div>
               <div class="close-toolbox">
+                  <!--
                   <a ng-if="vm.toolboxVisible" ng-click="vm.hideToolbox()" style="cursor: pointer"><span
                           class="fa fa-angle-double-up fa-2x"></span></a>
+                    -->
               </div>
           </div>
 


### PR DESCRIPTION
This PR relocates action buttons in the Blueprint Editor toolbar. It also replaces the "Copy" and "Delete" buttons with Font Awesome icons.

- Replaced the "Copy" and "Delete" buttons with Font Awesome icons.
- Changed "Add Item" button to toggle toolbox open and close.
- Aligned "Blueprint Details" button and "Hide Connections" buttons with masthead.
- Aligned "Filter by name" input with toolbox padding.
- Removed close icon from toolbox per review comments.
- Changed enabled "Copy" and "Delete" icon color per review comments.
- Changed "Blueprint Details" button color per review comments.

JIRA Story: https://patternfly.atlassian.net/browse/CFUX-201

![enabled icons](https://cloud.githubusercontent.com/assets/17481322/20502485/3bf0ba4c-b00c-11e6-8b26-88d7fe2cdfe5.png)
