### PR TITLE
Prevent selecting invalid warn options

### DIFF
--- a/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -8,6 +8,7 @@
   function RetireServiceFactory($modal) {
     var modalService = {
       showModal: showModal,
+      FactoryController: RetireServiceModalController,
     };
 
     return modalService;
@@ -33,7 +34,7 @@
   }
 
   /** @ngInject */
-  function RetireServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications) {
+  function RetireServiceModalController($scope, serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications, moment) {
     var vm = this;
 
     vm.service = serviceDetails;
@@ -62,10 +63,18 @@
       { value: 21, label: __('3 Weeks') },
       { value: 28, label: __('4 Weeks') },
     ];
+    vm.visibleOptions = [];
 
     activate();
 
     function activate() {
+      $scope.$watch('vm.modalData.resource.date', function(date) {
+        var daysBetween = moment(date).diff(moment(), 'days');
+
+        vm.visibleOptions = vm.warningOptions.filter(function(option) {
+          return option.value <= daysBetween;
+        });
+      });
     }
 
     function retireService() {

--- a/client/app/components/retire-service-modal/retire-service-modal.html
+++ b/client/app/components/retire-service-modal/retire-service-modal.html
@@ -7,7 +7,7 @@
 <div class="modal-body">
   <form class="form-horizontal">
       <div pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Retirement Warning'|translate}}">
-        <select pf-select ng-model="vm.modalData.resource.warn" ng-options="opt.value as opt.label for opt in vm.warningOptions">
+        <select pf-select ng-model="vm.modalData.resource.warn" ng-options="opt.value as opt.label for opt in vm.visibleOptions">
         </select>
       </div>
     <div pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Retirement Date'|translate}}">

--- a/client/app/core/constants.js
+++ b/client/app/core/constants.js
@@ -1,4 +1,4 @@
-/* global toastr:false, _:false, ActionCable:false, $:false, sprintf: false */
+/* global toastr:false, _:false, ActionCable:false, $:false, sprintf: false, moment: false */
 (function() {
   'use strict';
 
@@ -6,5 +6,6 @@
     .constant('lodash', _)
     .constant('ActionCable', ActionCable)
     .constant('toastr', toastr)
-    .constant('sprintf', sprintf);
+    .constant('sprintf', sprintf)
+    .constant('moment', moment);
 })();

--- a/tests/retire-service-modal.spec.js
+++ b/tests/retire-service-modal.spec.js
@@ -1,0 +1,30 @@
+describe('Retire Service Modal', function() {
+  beforeEach(module('app.components', 'gettext'));
+
+  describe('controller', function() {
+    var controller;
+    var $scope;
+
+    beforeEach(inject(function($rootScope, $injector, $controller) {
+      state = $injector.get('RetireServiceModal');
+      $scope = $rootScope.$new();
+
+      controller = $controller(state.FactoryController, {
+        $scope: $scope,
+        serviceDetails: angular.noop,
+        $modalInstance: angular.noop,
+        CollectionsApi: angular.noop,
+        EventNotifications: angular.noop,
+      });
+    }));
+
+    it('changes visible options when date is changed', function() {
+      expect(controller.visibleOptions.length).to.eq(0);
+
+      // Initial digest populates visibleOptions with 'No warning' option
+      $scope.$digest();
+
+      expect(controller.visibleOptions.length).to.eq(1);
+    });
+  });
+});


### PR DESCRIPTION
When scheduling a retirement date in the future, a group of options are
available for selecting when a warning event should trigger (1, 2, 3, or
4) weeks prior the scheduled retirement date.

This change limits the selectable options to only values that make
sense. For example, you should not be able to select a warning 4 weeks
prior to retirement if you set retirement to tomorrow.

@miq-bot add_label enhancement, euwe/no