### PR TITLE
Blueprint Details Dlg.: show/hide Prov. and Action order tabs

### DIFF
--- a/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -127,7 +127,7 @@
     vm.selectEntryPoint = selectEntryPoint;
     vm.createCatalog = createCatalog;
     vm.toggleAdvOps = toggleAdvOps;
-    vm.disableOrderListTabs = disableOrderListTabs;
+    vm.showOrderListTabs = showOrderListTabs;
     vm.dndServiceItemMoved = dndServiceItemMoved;
     vm.toggleActionEqualsProvOrder = toggleActionEqualsProvOrder;
 
@@ -205,8 +205,8 @@
       angular.element( ".adv-ops" ).toggleClass("in");
     }
 
-    function disableOrderListTabs() {
-      return vm.blueprint.ui_properties.chart_data_model.nodes.length <= 1;
+    function showOrderListTabs() {
+      return vm.blueprint.ui_properties.chart_data_model.nodes.length > 1;
     }
 
     function toggleActionEqualsProvOrder() {

--- a/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal.html
+++ b/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal.html
@@ -119,7 +119,7 @@
             </div>
         </tab>
 
-        <tab active="vm.tabs[2].active" heading="{{vm.tabs[2].title}}" disable="vm.disableOrderListTabs()">
+        <tab active="vm.tabs[2].active" heading="{{vm.tabs[2].title}}" ng-if="vm.showOrderListTabs()">
             <h4 translate>Rearrange Items to set Provision Order</h4>
 
             <div class="dnd-ordered-lists row">
@@ -131,7 +131,7 @@
                 </div>
             </div>
         </tab>
-        <tab active="vm.tabs[3].active" heading="{{vm.tabs[3].title}}"  disable="vm.disableOrderListTabs()">
+        <tab active="vm.tabs[3].active" heading="{{vm.tabs[3].title}}"  ng-if="vm.showOrderListTabs()">
             <h4>{{ 'Rearrange Items to set Action Order' | translate}}
                 <input class="actionOrderCheckbox"
                        ng-model="vm.actionOrderEqualsProvOrder"


### PR DESCRIPTION
Prior to this PR, when there was 1 or no items on the canvas, the provision and action order tabs were disabled:

![image](https://cloud.githubusercontent.com/assets/12733153/20531621/4f07f106-b0a5-11e6-9534-0d8d8c348153.png)

With this PR, when there are 1 or no items on the canvas, the provision and action order tabs will be hidden:

![image](https://cloud.githubusercontent.com/assets/12733153/20531659/6b2e8a7a-b0a5-11e6-95ef-78a47b2b9074.png)

2 or more items on the canvas will show the provision and action order tabs:

![image](https://cloud.githubusercontent.com/assets/12733153/20531692/8237c7e0-b0a5-11e6-96c6-77144b78ab4c.png)

JIRA Story:
https://patternfly.atlassian.net/browse/CFUX-217

@serenamarie125
