### PR TITLE
Update api datetime filter to use acceptable operators

### DIFF
--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -98,10 +98,10 @@
       return undefined;
     }
     var currentDate = new Date();
-    var date1 = 'retires_on>=' + currentDate.toISOString();
+    var date1 = 'retires_on>' + currentDate.toISOString();
 
     var days30 = currentDate.setDate(currentDate.getDate() + 30);
-    var date2 = 'retires_on<=' + new Date(days30).toISOString();
+    var date2 = 'retires_on<' + new Date(days30).toISOString();
     var options = {expand: false, filter: ['retired=false', date1, date2]};
 
     return CollectionsApi.query('services', options);

--- a/tests/dashboard.state.spec.js
+++ b/tests/dashboard.state.spec.js
@@ -72,8 +72,8 @@ describe('Dashboard', function() {
           expand: false,
           filter: [
             'retired=false',
-            'retires_on>=2016-01-01T00:00:00.000Z',
-            'retires_on<=2016-01-31T00:00:00.000Z'
+            'retires_on>2016-01-01T00:00:00.000Z',
+            'retires_on<2016-01-31T00:00:00.000Z'
           ]
         });
 


### PR DESCRIPTION
The filter API was recently updated to support `>` and `<` operators for
datetime filters. The previously used `>=` and `<=` now correctly result
in a bad request.

https://github.com/ManageIQ/manageiq/pull/12660

@miq-bot add_label bug