### PR TITLE
Enhancement/135033517 Explorer Action Buttons: Configuration

### DIFF
--- a/client/app/components/_components.sass
+++ b/client/app/components/_components.sass
@@ -12,6 +12,7 @@
 @import 'toasts/toasts'
 @import 'confirmation/confirmation'
 @import 'custom-button/custom-button'
+@import 'custom-dropdown/custom-dropdown'
 @import 'footer/footer'
 @import 'flowchart/flowchart'
 @import 'blueprints/blueprints'

--- a/client/app/components/custom-dropdown/custom-dropdown.directive.js
+++ b/client/app/components/custom-dropdown/custom-dropdown.directive.js
@@ -6,35 +6,36 @@
       controller: ComponentController,
       controllerAs: 'vm',
       bindings: {
-        config: '<'
+        config: '<',
+        items: '<',
+        itemsCount: '<',
+        onUpdate: '&',
       },
       templateUrl: 'app/components/custom-dropdown/custom-dropdown.html',
     });
 
   /** @ngInject */
   function ComponentController() {
-    var vm = this;
+    let vm = this;
+
     angular.extend(vm, {
       handleAction: handleAction,
     });
 
-    vm.$onInit = function() {
-
+    vm.$onChanges = function() {
+      updateDisabled();
     };
-
-    vm.$onChanges = function(changes) {
-
-    };
-
-
     // Public
 
     // Private
-    function handleAction(option) {
-      if (!option.isDisabled) {
-        option.actionFn();
-      }
+    function updateDisabled() {
+      vm.onUpdate({$config:vm.config, $changes:vm.items});
     }
 
+    function handleAction(option) {
+      if (!option.isDisabled) {
+        option.actionFn(option);
+      }
+    }
   }
 })();

--- a/client/app/components/custom-dropdown/custom-dropdown.directive.js
+++ b/client/app/components/custom-dropdown/custom-dropdown.directive.js
@@ -16,7 +16,7 @@
 
   /** @ngInject */
   function ComponentController() {
-    let vm = this;
+    const vm = this;
 
     angular.extend(vm, {
       handleAction: handleAction,
@@ -29,7 +29,7 @@
 
     // Private
     function updateDisabled() {
-      vm.onUpdate({$config:vm.config, $changes:vm.items});
+      vm.onUpdate({$config: vm.config, $changes: vm.items});
     }
 
     function handleAction(option) {

--- a/client/app/components/custom-dropdown/custom-dropdown.directive.js
+++ b/client/app/components/custom-dropdown/custom-dropdown.directive.js
@@ -1,0 +1,40 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .component('customDropdown', {
+      controller: ComponentController,
+      controllerAs: 'vm',
+      bindings: {
+        config: '<'
+      },
+      templateUrl: 'app/components/custom-dropdown/custom-dropdown.html',
+    });
+
+  /** @ngInject */
+  function ComponentController() {
+    var vm = this;
+    angular.extend(vm, {
+      handleAction: handleAction,
+    });
+
+    vm.$onInit = function() {
+
+    };
+
+    vm.$onChanges = function(changes) {
+
+    };
+
+
+    // Public
+
+    // Private
+    function handleAction(option) {
+      if (!option.isDisabled) {
+        option.actionFn();
+      }
+    }
+
+  }
+})();

--- a/client/app/components/custom-dropdown/custom-dropdown.directive.js
+++ b/client/app/components/custom-dropdown/custom-dropdown.directive.js
@@ -16,7 +16,7 @@
 
   /** @ngInject */
   function ComponentController() {
-    const vm = this;
+    var vm = this;
 
     angular.extend(vm, {
       handleAction: handleAction,

--- a/client/app/components/custom-dropdown/custom-dropdown.html
+++ b/client/app/components/custom-dropdown/custom-dropdown.html
@@ -1,0 +1,16 @@
+<span class="dropdown primary-action pull-left" dropdown>
+  <button type="button" class="btn dropdown-toggle btn-default" dropdown-toggle type="button"
+          ng-disabled="vm.config.isDisabled" tooltip=" {{vm.config.name}} " tooltip-placement="left">
+    <i class="{{vm.config.icon}}"></i>
+    <span class="caret"></span>
+  </button>
+    <ul class="dropdown-menu">
+      <li role="menuitem" ng-repeat="option in vm.config.actions"
+          ng-class="{'disabled': (option.isDisabled === true)}">
+        <a ng-click="vm.handleAction(option)" >
+          <i class="{{option.icon}}"></i>
+          {{ option.name }}
+        </a>
+      </li>
+    </ul>
+</span>

--- a/client/app/components/edit-service-modal/edit-service-modal.html
+++ b/client/app/components/edit-service-modal/edit-service-modal.html
@@ -14,11 +14,13 @@
           {{ vm.modalData.description }}
         </textarea>
     </div>
-    <modal-actions
-      modal-data="vm.modalData"
-      on-cancel="vm.cancel()"
-      on-reset="vm.reset($event)"
-      on-save="vm.save()">
-    </modal-actions>
   </form>
+</div>
+<div class="modal-footer">
+  <modal-actions
+    modal-data="vm.modalData"
+    on-cancel="vm.cancel()"
+    on-reset="vm.reset($event)"
+    on-save="vm.save()">
+  </modal-actions>
 </div>

--- a/client/app/components/explorer/_explorer.sass
+++ b/client/app/components/explorer/_explorer.sass
@@ -6,10 +6,10 @@
   margin-bottom: 2px
   margin-top: 2px
 
-.toolbar-actions
-  margin-top: 10px
-
 .service-explorer-footer
+  .toolbar-actions
+    margin-top: 10px
+
   .toolbar-pf-actions
     border-top: 1px solid $app-color-light-gray-5
     margin-left: -26px

--- a/client/app/components/explorer/_explorer.sass
+++ b/client/app/components/explorer/_explorer.sass
@@ -14,3 +14,6 @@
     border-top: 1px solid $app-color-light-gray-5
     margin-left: -26px
     width: 105%
+
+.toolbar-pf-include-actions
+  margin: 0

--- a/client/app/components/explorer/explorer.component.js
+++ b/client/app/components/explorer/explorer.component.js
@@ -13,7 +13,7 @@
 
   /** @ngInject */
   function ComponentController($state, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, pfViewUtils,
-                               CollectionsApi, EventNotifications, EditServiceModal, PowerOperations, lodash) {
+                               CollectionsApi, EventNotifications, OwnershipServiceModal, EditServiceModal, PowerOperations, lodash) {
     var vm = this;
     vm.$onInit = activate();
     function activate() {
@@ -405,9 +405,21 @@
         expand: 'resources',
         limit: limit,
         offset: String(offset),
-        attributes: ['picture', 'picture.image_href', 'chargeback_report',
-          'v_total_vms', 'aggregate_all_vm_cpus', 'aggregate_all_vm_memory', 'aggregate_all_vm_disk_count', 'aggregate_all_vm_disk_space_allocated',
-          'aggregate_all_vm_disk_space_used', 'aggregate_all_vm_memory_on_disk', 'region_number', 'region_description'],
+        attributes: [
+          'picture',
+          'picture.image_href',
+          'chargeback_report',
+          'evm_owner.userid',
+          'miq_group.description',
+          'v_total_vms',
+          'aggregate_all_vm_cpus',
+          'aggregate_all_vm_memory',
+          'aggregate_all_vm_disk_count',
+          'aggregate_all_vm_disk_space_allocated',
+          'aggregate_all_vm_disk_space_used',
+          'aggregate_all_vm_memory_on_disk',
+          'region_number',
+          'region_description'],
         filter: ['ancestry=null'],
       };
       vm.loading = true;
@@ -468,17 +480,18 @@
       EditServiceModal.showModal(vm.selectedItemsList[0]);
     }
 
-    function removeServices(option) {
+    function removeServices() {
 
     }
 
-    function setOwnership(option) {
+    function setOwnership() {
+      OwnershipServiceModal.showModal(vm.selectedItemsList);
     }
 
-    function setServiceRetirement(option) {
+    function setServiceRetirement() {
     }
 
-    function retireService(option) {
+    function retireService() {
     }
 
     Language.fixState(ServicesState, vm.headerConfig);

--- a/client/app/components/explorer/explorer.component.js
+++ b/client/app/components/explorer/explorer.component.js
@@ -441,7 +441,7 @@
     function listActionDisable(config, items) {
       items.length <= 0 ? config.isDisabled = true : config.isDisabled = false;
       if (items.length > 1 && config.actionName === "configuration") {
-        lodash.forEach(config.actions, disableItems)
+        lodash.forEach(config.actions, disableItems);
       } else if (items.length <= 1 && config.actionName === "configuration") {
         lodash.forEach(config.actions, enableItems);
       }

--- a/client/app/components/explorer/explorer.component.js
+++ b/client/app/components/explorer/explorer.component.js
@@ -13,7 +13,7 @@
 
   /** @ngInject */
   function ComponentController($state, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, pfViewUtils,
-                               CollectionsApi, EventNotifications, sprintf, PowerOperations, lodash) {
+                               CollectionsApi, EventNotifications, EditServiceModal, PowerOperations, lodash) {
     var vm = this;
     vm.$onInit = activate();
     function activate() {
@@ -123,7 +123,7 @@
             icon: 'fa fa-clock-o',
             name: __('Set Retirement Dates'),
             actionName: 'setServiceRetirement',
-            title: __('Set Retirement Dates'),
+            title: __('Set Retirement'),
             actionFn: setServiceRetirement,
             isDisabled: false,
           }, {
@@ -464,7 +464,8 @@
       vm.selectedItemsListCount = vm.selectedItemsList.length;
     }
 
-    function editService(option) {
+    function editService() {
+      EditServiceModal.showModal(vm.selectedItemsList[0]);
     }
 
     function removeServices(option) {

--- a/client/app/components/explorer/explorer.component.js
+++ b/client/app/components/explorer/explorer.component.js
@@ -69,6 +69,77 @@
       onClick: vm.viewService,
     };
 
+    vm.listActions = [
+      {
+        name: __('Configuration'),
+        actionName: 'configuration',
+        icon: 'fa fa-cog',
+        actions: [
+          {
+            icon: 'pf pficon-edit',
+            name: __('Edit Selected'),
+            actionName: 'edit',
+            title: __('Edit Selected'),
+            actionFn: editService,
+            isDisabled: false,
+          }, {
+            icon: 'pf pficon-delete',
+            name: __('Remove Selected'),
+            actionName: 'remove',
+            title: __('Remove Selected'),
+            actionFn: removeServices,
+            isDisabled: false,
+          }, {
+            icon: 'pf pficon-user',
+            name: __('Set Ownership'),
+            actionName: 'ownership',
+            title: __('Set Ownership'),
+            actionFn: setOwnership,
+            isDisabled: false,
+          },
+        ],
+        isDisabled: false,
+      }, {
+        name: __('Policy'),
+        actionName: 'policy',
+        icon: 'fa fa-shield',
+        actions: [
+          {
+            icon: 'pf pficon-edit',
+            name: __('Edit Tags'),
+            actionName: 'editTags',
+            title: __('Edit Tags'),
+            actionFn: editService,
+            isDisabled: false,
+          },
+        ],
+        isDisabled: false,
+      }, {
+        name: __('Lifecycle'),
+        actionName: 'lifecycle',
+        icon: 'fa fa-recycle',
+        actions: [
+          {
+            icon: 'fa fa-clock-o',
+            name: __('Set Retirement Dates'),
+            actionName: 'setServiceRetirement',
+            title: __('Set Retirement Dates'),
+            actionFn: setServiceRetirement,
+            isDisabled: false,
+          }, {
+            icon: 'fa fa-clock-o',
+            name: __('Retire Selected'),
+            actionName: 'retireService',
+            title: __('Retire Selected'),
+            actionFn: retireService,
+            isDisabled: false,
+          },
+        ],
+        isDisabled: false,
+      },
+    ];
+
+
     var serviceFilterConfig = {
       fields: getServiceFilterFields(),
       resultsCount: vm.servicesList.length,
@@ -101,6 +172,9 @@
       sortConfig: serviceSortConfig,
       viewsConfig: viewsConfig,
       filterConfig: serviceFilterConfig,
+      actionsConfig: {
+        actionsInclude: true,
+      },
     };
 
 
@@ -360,6 +434,19 @@
     function queryFailure(error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading the services.'));
+    }
+
+
+    function editService(option) {
+      console.log(option)
+    }
+
+    function removeServices(option) {
+      console.log(option)
+    }
+
+    function setOwnership(option) {
+      console.log(option)
     }
 
     Language.fixState(ServicesState, vm.headerConfig);

--- a/client/app/components/explorer/explorer.component.js
+++ b/client/app/components/explorer/explorer.component.js
@@ -13,7 +13,7 @@
 
   /** @ngInject */
   function ComponentController($state, ServicesState, $filter, $rootScope, Language, ListView, Chargeback, pfViewUtils,
-                               CollectionsApi, EventNotifications, OwnershipServiceModal, EditServiceModal, PowerOperations, lodash) {
+                               CollectionsApi, EventNotifications, RemoveServiceModal, OwnershipServiceModal, EditServiceModal, PowerOperations, lodash) {
     var vm = this;
     vm.$onInit = activate();
     function activate() {
@@ -481,7 +481,7 @@
     }
 
     function removeServices() {
-
+      RemoveServiceModal.showModal(vm.selectedItemsList);
     }
 
     function setOwnership() {

--- a/client/app/components/explorer/explorer.html
+++ b/client/app/components/explorer/explorer.html
@@ -1,4 +1,8 @@
-<div pf-toolbar class="service-explorer-header" config="vm.headerConfig"></div>
+<div pf-toolbar class="service-explorer-header" config="vm.headerConfig">
+  <actions>
+    <custom-dropdown config="item" ng-repeat="item in vm.listActions"></custom-dropdown>
+  </actions>
+</div>
 
 <div ng-if="vm.viewType == 'cardView'" class="col-md-12 list-view-container">
   <loading status="vm.loading"></loading>

--- a/client/app/components/explorer/explorer.html
+++ b/client/app/components/explorer/explorer.html
@@ -1,9 +1,9 @@
 <div pf-toolbar class="service-explorer-header" config="vm.headerConfig">
   <actions>
-    <custom-dropdown config="item" ng-repeat="item in vm.listActions"></custom-dropdown>
+    <custom-dropdown config="item" items="vm.selectedItemsList" items-count="vm.selectedItemsListCount" ng-repeat="item in vm.listActions"
+                     on-update="vm.listActionDisable($config, $changes)"></custom-dropdown>
   </actions>
 </div>
-
 <div ng-if="vm.viewType == 'cardView'" class="col-md-12 list-view-container">
   <loading status="vm.loading"></loading>
   <div ng-if="!vm.loading" pf-card-view id="cardView" config="vm.cardConfig" items="vm.servicesList">

--- a/client/app/components/modal-actions/modal-actions.component.js
+++ b/client/app/components/modal-actions/modal-actions.component.js
@@ -7,9 +7,11 @@
       controllerAs: 'vm',
       bindings: {
         modalData: '<?',
+        confirmationModal: '<?',
         onCancel: '&',
         onReset: '&',
         onSave: '&',
+        onOk: '&',
       },
       templateUrl: 'app/components/modal-actions/modal-actions.html',
     });
@@ -17,10 +19,15 @@
   /** @ngInject */
   function ComponentController() {
     var vm = this;
-    vm.isPristine = isPristine;
-    vm.cancelAction = cancelAction;
-    vm.emitOriginal = emitOriginal;
-    vm.saveResource = saveResource;
+
+    angular.extend(vm, {
+      isPristine: isPristine,
+      cancelAction: cancelAction,
+      emitOriginal: emitOriginal,
+      saveResource: saveResource,
+      affirmConfirmation: affirmConfirmation,
+    });
+
 
     vm.$onInit = function() {
       vm.original = angular.copy(vm.modalData);
@@ -44,6 +51,10 @@
 
     function saveResource() {
       vm.onSave();
+    }
+
+    function affirmConfirmation() {
+      vm.onOk();
     }
   }
 })();

--- a/client/app/components/modal-actions/modal-actions.component.js
+++ b/client/app/components/modal-actions/modal-actions.component.js
@@ -6,7 +6,7 @@
       controller: ComponentController,
       controllerAs: 'vm',
       bindings: {
-        modalData: '<',
+        modalData: '<?',
         onCancel: '&',
         onReset: '&',
         onSave: '&',

--- a/client/app/components/modal-actions/modal-actions.html
+++ b/client/app/components/modal-actions/modal-actions.html
@@ -1,19 +1,25 @@
-<div class="modal-footer">
   <button type="button"
           class="btn btn-default"
           ng-click="vm.cancelAction()"
           translate>Cancel
   </button>
-  <button type="button"
+  <button ng-if="vm.modalData"
+          type="button"
           class="btn btn-default"
           ng-click="vm.emitOriginal()"
           ng-disabled="vm.isPristine()"
           translate>Reset
   </button>
-  <button type="button"
+  <button ng-if="!vm.confirmationModal"
+          type="button"
           class="btn btn-primary"
           ng-click="vm.saveResource()"
           ng-disabled="vm.isPristine()"
           translate>Save
   </button>
-</div>
+  <button ng-if="vm.confirmationModal"
+          type="button"
+          class="btn btn-primary"
+          ng-click="vm.affirmConfirmation()"
+          translate>OK
+  </button>

--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -57,6 +57,14 @@
     var isService = services.length === 1;
 
     angular.extend(vm, {
+      modalData: {
+        'owner': {
+          'userid': '',
+        },
+        'group': {
+          'description': '',
+        },
+      },
       services: services,
       users: users,
       groups: groups,
@@ -111,15 +119,9 @@
     // Private
     function activate() {
       if (isService) {
-        vm.modalData = {
-          'id': vm.services[0].id,
-          'owner': {
-            'userid': vm.services[0].evm_owner && vm.services[0].evm_owner.userid || '',
-          },
-          'group': {
-            'description': vm.services[0].miq_group && vm.services[0].miq_group.description || '',
-          },
-        };
+        vm.modalData.id = vm.services[0].id;
+        vm.modalData.owner.userid = vm.services[0].evm_owner && vm.services[0].evm_owner.userid || '';
+        vm.modalData.group.description = vm.services[0].miq_group && vm.services[0].miq_group.description || '';
       }
     }
   }

--- a/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
+++ b/client/app/components/ownership-service-modal/ownership-service-modal-service.factory.js
@@ -1,4 +1,5 @@
 /* eslint camelcase: "off" */
+
 (function() {
   'use strict';
 
@@ -13,14 +14,14 @@
 
     return modalService;
 
-    function showModal(serviceDetails) {
+    function showModal(services) {
       var modalOptions = {
         templateUrl: 'app/components/ownership-service-modal/ownership-service-modal.html',
         controller: OwnershipServiceModalController,
         controllerAs: 'vm',
         size: 'lg',
         resolve: {
-          serviceDetails: resolveServiceDetails,
+          services: resolveServiceDetails,
           users: resolveUsers,
           groups: resolveGroups,
         },
@@ -30,14 +31,8 @@
       return modal.result;
 
       /** @ngInject */
-      function resolveServiceDetails(CollectionsApi) {
-        var requestAttributes = [
-          'evm_owner.userid',
-          'miq_group.description',
-        ];
-        var options = {attributes: requestAttributes};
-
-        return CollectionsApi.get('services', serviceDetails.id, options);
+      function resolveServiceDetails() {
+        return services;
       }
     }
   }
@@ -57,41 +52,74 @@
   }
 
   /** @ngInject */
-  function OwnershipServiceModalController(serviceDetails, $state, $modalInstance, CollectionsApi, EventNotifications, users, groups, sprintf) {
+  function OwnershipServiceModalController($state, $modalInstance, lodash, CollectionsApi, EventNotifications, users, groups, services) {
     var vm = this;
+    var isService = services.length === 1;
 
-    vm.service = serviceDetails;
-    vm.saveOwnership = saveOwnership;
-    vm.users = users;
-    vm.groups = groups;
-
-    vm.modalData = {
-      'action': 'set_ownership',
-      'resource': {
-        'owner': {
-          'userid': vm.service.evm_owner && vm.service.evm_owner.userid || '',
-        },
-        'group': {
-          'description': vm.service.miq_group && vm.service.miq_group.description || '',
-        },
-      },
-    };
+    angular.extend(vm, {
+      services: services,
+      users: users,
+      groups: groups,
+      save: save,
+      cancel: cancel,
+      reset: reset,
+    });
     activate();
 
-    function activate() {
+
+    function cancel() {
+      $modalInstance.dismiss();
     }
 
-    function saveOwnership() {
-      CollectionsApi.post('services', vm.service.id, {}, vm.modalData).then(saveSuccess, saveFailure);
+    function reset(event) {
+      angular.copy(event.original, this.modalData); // eslint-disable-line angular/controller-as-vm
+    }
+
+    function save() {
+      var data = {
+        action: 'set_ownership',
+        resources: null,
+      };
+
+      if (isService) {
+        data.resources = [vm.modalData];
+      } else {
+        var resources = [];
+        angular.copy(vm.services, resources);
+        lodash.forEach(resources, setOwnership);
+        data.resources = resources;
+      }
+
+      CollectionsApi.post('services', '', {}, data).then(saveSuccess, saveFailure);
 
       function saveSuccess() {
         $modalInstance.close();
-        EventNotifications.success(sprintf(__("%s ownership was saved."), vm.service.name));
+        EventNotifications.success(__("Ownership was saved."));
         $state.go($state.current, {}, {reload: true});
       }
 
       function saveFailure() {
         EventNotifications.error(__('There was an error saving ownership of this service.'));
+      }
+
+      function setOwnership(service) {
+        service.owner = {userid: vm.modalData.owner.userid};
+        service.group = {description: vm.modalData.group.description};
+      }
+    }
+
+    // Private
+    function activate() {
+      if (isService) {
+        vm.modalData = {
+          'id': vm.services[0].id,
+          'owner': {
+            'userid': vm.services[0].evm_owner && vm.services[0].evm_owner.userid || '',
+          },
+          'group': {
+            'description': vm.services[0].miq_group && vm.services[0].miq_group.description || '',
+          },
+        };
       }
     }
   }

--- a/client/app/components/ownership-service-modal/ownership-service-modal.html
+++ b/client/app/components/ownership-service-modal/ownership-service-modal.html
@@ -7,9 +7,10 @@
 <div class="modal-body">
   <form class="form-horizontal">
     <div pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Select an Owner'|translate}}">
-      <select ng-model="vm.modalData.resource.owner.userid" class="form-control">
+      <select ng-model="vm.modalData.owner.userid" class="form-control">
+        <option ng-if="vm.services.length > 1" value="" translate>Don't Change</option>
         <option ng-repeat="user in vm.users.resources"
-                ng-selected="user.userid == vm.modalData.resource.owner.userid ? 'selected' : ''"
+                ng-selected="user.userid == vm.modalData.owner.userid ? 'selected' : ''"
                 value="{{user.userid}}">
           {{user.name}}
         </option>
@@ -17,10 +18,11 @@
     </div>
 
     <div pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Select a Group'|translate}}">
-      <select ng-model="vm.modalData.resource.group.description"
+      <select ng-model="vm.modalData.group.description"
               class="form-control">
+        <option ng-if="vm.services.length > 1" value="" translate>Don't Change</option>
         <option ng-repeat="group in vm.groups.resources | orderBy:'description'"
-                ng-selected="group.description == vm.modalData.resource.group ? 'selected' : ''"
+                ng-selected="group.description == vm.modalData.group ? 'selected' : ''"
                 value="{{group.description}}">
           {{group.description}}
         </option>
@@ -29,11 +31,10 @@
   </form>
 </div>
 <div class="modal-footer">
-  <button type="button" class="btn btn-default" ng-click="$dismiss()" translate>Cancel</button>
-  <button type="button"
-          class="btn btn-primary"
-          ng-click="vm.saveOwnership()"
-          ng-disabled="vm.service.evm_owner.userid == vm.modalData.resource.owner.userid &&
-            vm.service.miq_group.description == vm.modalData.resource.group.description" translate>Save
-  </button>
+  <modal-actions
+    modal-data="vm.modalData"
+    on-cancel="vm.cancel()"
+    on-reset="vm.reset($event)"
+    on-save="vm.save()">
+  </modal-actions>
 </div>

--- a/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
+++ b/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
@@ -6,12 +6,8 @@
 
   /** @ngInject */
   function Factory($modal) {
-    var removeServiceModal = {
-      showModal: showModal,
-    };
-
-    return removeServiceModal;
-
+    return {showModal: showModal};
+    
     function showModal(services) {
       var modalOptions = {
         templateUrl: 'app/components/remove-service-modal/remove-service-modal.html',

--- a/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
+++ b/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
@@ -6,11 +6,11 @@
 
   /** @ngInject */
   function Factory($modal) {
-    var modalService = {
+    var removeServiceModal = {
       showModal: showModal,
     };
 
-    return modalService;
+    return removeServiceModal;
 
     function showModal(services) {
       var modalOptions = {

--- a/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
+++ b/client/app/components/remove-service-modal/remove-service-modal-service.factory.js
@@ -1,0 +1,68 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .factory('RemoveServiceModal', Factory);
+
+  /** @ngInject */
+  function Factory($modal) {
+    var modalService = {
+      showModal: showModal,
+    };
+
+    return modalService;
+
+    function showModal(services) {
+      var modalOptions = {
+        templateUrl: 'app/components/remove-service-modal/remove-service-modal.html',
+        controller: ModalController,
+        controllerAs: 'vm',
+        size: 'md',
+        resolve: {
+          services: resolveServices,
+        },
+      };
+      var modal = $modal.open(modalOptions);
+
+      return modal.result;
+
+      /** @ngInject */
+      function resolveServices() {
+        return services;
+      }
+    }
+  }
+
+  /** @ngInject */
+  function ModalController($state, $modalInstance, lodash, CollectionsApi, EventNotifications, services) {
+    var vm = this;
+
+    angular.extend(vm, {
+      services: services,
+      confirm: confirm,
+      cancel: cancel,
+    });
+
+    function cancel() {
+      $modalInstance.dismiss();
+    }
+
+    function confirm() {
+      var data = {
+        action: 'delete',
+        resources: vm.services,
+      };
+      CollectionsApi.post('services', '', {}, data).then(saveSuccess, saveFailure);
+
+      function saveSuccess() {
+        $modalInstance.close();
+        EventNotifications.success(__("Services removed"));
+        $state.go($state.current, {}, {reload: true});
+      }
+
+      function saveFailure() {
+        EventNotifications.error(__('There was an error removing one or more services.'));
+      }
+    }
+  }
+})();

--- a/client/app/components/remove-service-modal/remove-service-modal.html
+++ b/client/app/components/remove-service-modal/remove-service-modal.html
@@ -1,0 +1,17 @@
+<div class="modal-header">
+  <button type="button" class="close" ng-click="$dismiss()" aria-hidden="true">
+    <span class="pficon pficon-close"></span>
+  </button>
+  <h4 class="modal-title" id="myModalLabel" translate>Remove Services</h4>
+</div>
+<div class="modal-body">
+  <i class="pf pficon-warning-triangle-o"></i>
+  {{ "Warning: The selected Services and ALL of their components will be permanently removed!" | translate }}
+</div>
+<div class="modal-footer">
+  <modal-actions
+    confirmation-modal="true"
+    on-cancel="vm.cancel()"
+    on-ok="vm.confirm()">
+  </modal-actions>
+</div>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -30,6 +30,7 @@
       'picture',
       'picture.image_href',
       'evm_owner.name',
+      'evm_owner.userid',
       'miq_group.description',
       'aggregate_all_vm_cpus',
       'aggregate_all_vm_memory',
@@ -187,7 +188,7 @@
     }
 
     function ownershipServiceModal() {
-      OwnershipServiceModal.showModal(vm.service);
+      OwnershipServiceModal.showModal([vm.service]);
     }
 
     function retireServiceNow() {


### PR DESCRIPTION
Satisfies: https://www.pivotaltracker.com/story/show/135033517
## What this pr does: 
* Buttons to explore for **all** actions of the OPSUI
* Functionality to the the configuration button subbuttons
* Adds extensible *custom-dropdown* component
* Adds multi-use ownership-service-modal, edit-service-modal and remove-service modal factories

## What this pr does not do  (other stories capture this work):
* Displays an icon list of services affected by the requested action
* Functionality for the policy and life cycle buttons

## Glamor Shot 💅 
<img width="1106" alt="screen shot 2016-12-01 at 3 50 30 pm" src="https://cloud.githubusercontent.com/assets/6640236/20812157/8d01148e-b7de-11e6-9621-da2bd0fc0fe9.png">

## In Action
![config-buttons](https://cloud.githubusercontent.com/assets/6640236/20812240/d35a8794-b7de-11e6-8472-2a93f517f964.gif)

@chriskacerguis @himdel @jjlangholtz 🌮 

@miq-bot remove_label wip
@miq-bot add_label euwe/no

