### PR TITLE
[EUWE] Hide Power Status and Power Operation buttons in the List View

### DIFF
--- a/client/app/states/services/list/list.html
+++ b/client/app/states/services/list/list.html
@@ -1,12 +1,14 @@
 <div pf-toolbar id="serviceToolbar" config="vm.toolbarConfig"></div>
 
 <div class="list-view-container">
+  <!-- TODO: The Power Operation buttons would be hidden
+       TODO: while we wait on a robust backend solution on how to retrieve Power Status for Services in the List View-->
   <div pf-list-view id="serviceList" class="arbitration-profiles-list" config="vm.listConfig" items="vm.servicesList"
-      action-buttons="vm.actionButtons"
-      enable-button-for-item-fn="vm.enableButtonForItemFn"
-      menu-actions="vm.menuActions"
-      update-menu-action-for-item-fn="vm.updateMenuActionForItemFn"
-      hide-menu-for-item-fn="vm.hideMenuForItemFn">
+      action-buttons_hide="vm.actionButtons"
+      enable-button-for-item-fn_hide="vm.enableButtonForItemFn"
+      menu-actions_hide="vm.menuActions"
+      update-menu-action-for-item-fn_hide="vm.updateMenuActionForItemFn"
+      hide-menu-for-item-fn_hide="vm.hideMenuForItemFn">
     <div class="row">
       <div class="col-lg-3 col-md-4 col-sm-6 col-xs-6">
         <span class="no-wrap">
@@ -55,7 +57,7 @@
           </span>
         </span>
       </div>
-      <div class="col-lg-1 hidden-md hidden-sm hidden-xs">
+      <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
         <span class="no-wrap">
           <strong translate>Created</strong>&nbsp;
           <span tooltip="{{ item.created_at | date }}" tooltip-placement="bottom">
@@ -63,7 +65,9 @@
           </span>
         </span>
       </div>
-      <div class="col-lg-2 hidden-md hidden-sm hidden-xs pull-right">
+      <!-- TODO: The Power State field would be hidden
+           TODO: while we wait on a robust backend solution on how to retrieve Power Status for Services in the List View-->
+      <div class="col-lg-2 hidden-md hidden-sm hidden-xs pull-right" ng-hide="true">
         <span class="no-wrap">
           <strong translate>Power State</strong>&nbsp;
           <i class="fa fa-circle green fa-3x fa-fw" ng-if="item.powerState === 'on' && item.powerStatus === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>


### PR DESCRIPTION
Hide Power Status and Power Operation buttons in the List View until we have a robust backend solution to display the Power Status and the Power Op buttons.

Before:
<img width="1418" alt="screen shot 2016-12-01 at 10 46 04 am" src="https://cloud.githubusercontent.com/assets/1538216/20807365/7013b1e0-b7b3-11e6-9b5a-3d02bb1ecc9d.png">

After:
<img width="1422" alt="screen shot 2016-12-01 at 10 44 27 am" src="https://cloud.githubusercontent.com/assets/1538216/20807376/7e6618aa-b7b3-11e6-9202-d4ca34f4dd35.png">

While I was at it (hiding Power Op status & buttons), I have restored the `Created` field width back to 2 so it does not get truncated, like it did before with the Power Op buttons displayed.


https://bugzilla.redhat.com/show_bug.cgi?id=1402993