### PR TITLE
Remove eot fontawesome webfonts

### DIFF
--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -14,7 +14,7 @@ $modal-about-pf-bg-color:  #083c5a // sets background color of 'About' modal
   font-family: 'FontAwesome'
   font-style: normal
   font-weight: normal
-  src: url('../fonts/fontawesome-webfont.eot?v=4.4.0'), url('../fonts/fontawesome-webfont.eot?#iefix&v=4.4.0') format('embedded-opentype'), url('../fonts/fontawesome-webfont.woff2?v=4.4.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg')
+  src: url('../fonts/fontawesome-webfont.woff2?v=4.4.0') format('woff2'), url('../fonts/fontawesome-webfont.woff?v=4.4.0') format('woff'), url('../fonts/fontawesome-webfont.ttf?v=4.4.0') format('truetype'), url('../fonts/fontawesome-webfont.svg?v=4.4.0#fontawesomeregular') format('svg')
 
 
 body


### PR DESCRIPTION
The Embedded OpenType (EOT) font file type is only used by IE versions 8
and up. However, IE10 and higher support the same open format that other
browsers use. Because we support IE10 and higher these fonts do not need
to be loaded.

This removes the console warning message for attempting to download
an unknown font file type on both Chrome and Firefox.

@miq-bot add_label euwe/no, bug