### PR TITLE
Hide Power Status and Power Operation buttons in the List View

### DIFF
--- a/client/app/components/explorer/explorer.html
+++ b/client/app/components/explorer/explorer.html
@@ -21,10 +21,12 @@
 
 <div ng-if="vm.viewType == 'listView'" class="col-md-12 list-view-container">
   <loading status="vm.loading"></loading>
+  <!-- TODO: The Power Operation buttons would be hidden
+       TODO: while we wait on a robust backend solution on how to retrieve Power Status for Services in the List View-->
   <div ng-if="!vm.loading" pf-list-view id="serviceList" class="arbitration-profiles-list" config="vm.listConfig"
        items="vm.servicesList"
-       menu-actions="vm.menuActions"
-       update-menu-action-for-item-fn="vm.updateMenuActionForItemFn">
+       menu-actions_hide="vm.menuActions"
+       update-menu-action-for-item-fn_hide="vm.updateMenuActionForItemFn">
     <div class="row">
       <div class="col-lg-3 col-md-3 col-sm-4 col-xs-8">
         <span class="no-wrap" tooltip=" {{item.description}} " tooltip-placement="bottom">

--- a/client/app/components/power-state/power-state.html
+++ b/client/app/components/power-state/power-state.html
@@ -1,4 +1,6 @@
-<span class="no-wrap power-state">
+<!-- TODO: The Power State field would be hidden
+     TODO: while we wait on a robust backend solution on how to retrieve Power Status for Services in the List View-->
+<span class="no-wrap power-state" ng-hide="true">
 <span class="fa fa-plug"></span>&nbsp;
 <i class="fa fa-circle green fa-fw"
    ng-if="vm.item.powerState === 'on' && vm.item.powerStatus === 'start_complete'"


### PR DESCRIPTION
Hide Power Status and Power Operation buttons in the List View until we have a robust backend solution to display the Power Status and the Power Op buttons.

Before:
<img width="1416" alt="screen shot 2016-12-01 at 2 20 55 pm" src="https://cloud.githubusercontent.com/assets/1538216/20815177/b307a952-b7d1-11e6-99bd-4f93546209af.png">

After:
<img width="1421" alt="screen shot 2016-12-01 at 1 56 13 pm" src="https://cloud.githubusercontent.com/assets/1538216/20815185/bc8f3b2a-b7d1-11e6-8f98-59b06f7bc2bb.png">


https://bugzilla.redhat.com/show_bug.cgi?id=1391685