### PR TITLE
Pull in the real power_state column off of a service

### DIFF
--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -24,58 +24,58 @@
     };
 
     function powerOperationUnknownState(item) {
-      return item.powerState === "" && item.powerStatus === "";
+      return item.power_state === "" && item.options.power_status === "";
     }
 
     function powerOperationInProgressState(item) {
-      return (item.powerState !== "timeout" && item.powerStatus === "starting")
-        || (item.powerState !== "timeout" && item.powerStatus === "stopping")
-        || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+      return (item.power_state !== "timeout" && item.options.power_status === "starting")
+        || (item.power_state !== "timeout" && item.options.power_status === "stopping")
+        || (item.power_state !== "timeout" && item.options.power_status === "suspending");
     }
 
     function powerOperationOnState(item) {
-      return item.powerState === "on" && item.powerStatus === "start_complete";
+      return item.power_state === "on" && item.options.power_status === "start_complete";
     }
 
     function powerOperationOffState(item) {
-      return item.powerState === "off" && item.powerStatus === "stop_complete";
+      return item.power_state === "off" && item.options.power_status === "stop_complete";
     }
 
     function powerOperationSuspendState(item) {
-      return item.powerState === "off" && item.powerStatus === "suspend_complete";
+      return item.power_state === "off" && item.options.power_status === "suspend_complete";
     }
 
     function powerOperationTimeoutState(item) {
-      return item.powerState === "timeout";
+      return item.power_state === "timeout";
     }
 
     function powerOperationStartTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "starting";
+      return item.power_state === "timeout" && item.options.power_status === "starting";
     }
 
     function powerOperationStopTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "stopping";
+      return item.power_state === "timeout" && item.options.power_status === "stopping";
     }
 
     function powerOperationSuspendTimeoutState(item) {
-      return item.powerState === "timeout" && item.powerStatus === "suspending";
+      return item.power_state === "timeout" && item.options.power_status === "suspending";
     }
 
     function startService(item) {
-      item.powerState = '';
-      item.powerStatus = 'starting';
+      item.power_state = '';
+      item.options.power_status = 'starting';
       powerOperation('start', item);
     }
 
     function stopService(item) {
-      item.powerState = '';
-      item.powerStatus = 'stopping';
+      item.power_state = '';
+      item.options.power_status = 'stopping';
       powerOperation('stop', item);
     }
 
     function suspendService(item) {
-      item.powerState = '';
-      item.powerStatus = 'suspending';
+      item.power_state = '';
+      item.options.power_status = 'suspending';
       powerOperation('suspend', item);
     }
 

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -133,16 +133,13 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Power State</label>
                   <div class="col-sm-8">
-                    <i class="fa fa-circle" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState === 'on' && vm.service.powerStatus === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-circle" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState === 'off' && vm.service.powerStatus === 'stop_complete'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-circle" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState === 'off' && vm.service.powerStatus === 'suspend_complete'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState !== 'timeout' && vm.service.powerStatus === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-adjust" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'starting'" tooltip="{{'Power State: Start operation timed out'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-adjust" style="font-size:15px;color:#cc151d;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'stopping'" tooltip="{{'Power State: Stop operation timed out'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-adjust" style="font-size:15px;color:orangered;" ng-if="vm.service.powerState === 'timeout' && vm.service.powerStatus === 'suspending'" tooltip="{{'Power State: Suspend operation timed out'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.powerState === '' && vm.service.powerStatus === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state === 'on' && vm.service.options.power_status === 'start_complete'" tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state === 'off' && vm.service.options.power_status === 'stop_complete'" tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state === 'off' && vm.service.options.power_status === 'suspend_complete'" tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.power_state === '' && vm.service.options.power_status === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'starting'" tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'stopping'" tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'suspending'" tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
                   </div>
                 </div>
               </div>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -43,6 +43,7 @@
       'provision_dialog',
       'service_template',
       'chargeback_report',
+      'power_state',
     ];
     var options = {
       attributes: requestAttributes,
@@ -105,9 +106,6 @@
       vm.retireServiceLater = retireServiceLater;
       vm.ownershipServiceModal = ownershipServiceModal;
       vm.reconfigureService = reconfigureService;
-
-      vm.service.powerState = angular.isDefined(vm.service.options.power_state) ? vm.service.options.power_state : "";
-      vm.service.powerStatus = angular.isDefined(vm.service.options.power_status) ? vm.service.options.power_status : "";
 
       vm.startService = PowerOperations.startService;
       vm.stopService = PowerOperations.stopService;

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -21,24 +21,24 @@ describe('Dashboard', function() {
 
     PowerOperations = {
       powerOperationOnState: function (item) {
-        return item.powerState === "on" && item.powerStatus === "start_complete";
+        return item.power_state === "on" && item.options.power_status === "start_complete";
       },
       powerOperationUnknownState: function (item) {
-        return item.powerState === "" && item.powerStatus === "";
+        return item.power_state === "" && item.options.power_status === "";
       },
       powerOperationInProgressState: function (item) {
-        return (item.powerState !== "timeout" && item.powerStatus === "starting")
-          || (item.powerState !== "timeout" && item.powerStatus === "stopping")
-          || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+        return (item.power_state !== "timeout" && item.options.power_status === "starting")
+          || (item.power_state !== "timeout" && item.options.power_status === "stopping")
+          || (item.power_state !== "timeout" && item.options.power_status === "suspending");
       },
       powerOperationOffState: function (item) {
-        return item.powerState === "off" && item.powerStatus === "stop_complete";
+        return item.power_state === "off" && item.options.power_status === "stop_complete";
       },
       powerOperationSuspendState: function (item) {
-        return item.powerState === "off" && item.powerStatus === "suspend_complete";
+        return item.power_state === "off" && item.options.power_status === "suspend_complete";
       },
       powerOperationTimeoutState: function (item) {
-        return item.powerState === "timeout";
+        return item.power_state === "timeout";
       },
     };
   });
@@ -64,8 +64,8 @@ describe('Dashboard', function() {
     var service = {
       id: 123,
       name: 'foo',
+      power_state: "",
       options: {
-        power_state: "timeout",
         power_status: "starting"
       },
       chargeback_report: {
@@ -110,13 +110,13 @@ describe('Dashboard', function() {
     });
   });
 
-  describe('service detail contains power state in "timeout" and power status in "starting', function() {
+  describe('service detail contains power state in "off" and power status in "stop_complete"', function() {
     var controller;
 
     var service = {
+        power_state: "off",
         options: {
-          power_state: "timeout",
-          power_status: "starting"
+          power_status: "stop_complete"
         },
       chargeback_report: {
         results: []
@@ -126,18 +126,23 @@ describe('Dashboard', function() {
     beforeEach(function() {
       bard.inject('$controller', '$state');
 
-      controller = $controller($state.get('services.details').controller, {service: service, $state: state, Chargeback: Chargeback});
+      controller = $controller($state.get('services.details').controller, 
+          {service: service, 
+           $state: state, 
+           Chargeback: Chargeback,
+           PowerOperations: PowerOperations});
     });
 
-    it('enables the "Start" button when power state is "timeout" and power status is "starting', function() {
+    it('disables the "Stop" button when power state is "OFF"', function() {
+      expect(controller.checkDisabled('stop', controller.service)).to.eq(true);
+      //expect(controller.enableStopButton(controller.service)).to.eq(false);
+    });
+
+    it('enables the "Start" button when power state is "OFF"', function() {
       expect(controller.enableStartButton(controller.service)).to.eq(true);
     });
 
-    it('disables the "Stop" button when power state is "timeout" and power status is "starting', function() {
-      expect(controller.checkDisabled('stop', controller.service)).to.eq(false);
-    });
-
-    it('disables the "Suspend" button when power state is "timeout" and power status is "starting', function() {
+    it('enables the "Suspend" button when power state is "OFF"', function() {
       expect(controller.checkDisabled('suspend', controller.service)).to.eq(false);
     });
   });
@@ -145,8 +150,8 @@ describe('Dashboard', function() {
   describe('service detail contains power state in "on" and power status in "start_complete', function() {
     var controller;
     var service = {
+      power_state: "on",
       options: {
-        power_state: "on",
         power_status: "start_complete"
       },
       chargeback_report: {

--- a/tests/services-list.state.spec.js
+++ b/tests/services-list.state.spec.js
@@ -39,7 +39,7 @@ describe('Dashboard', function() {
     });
   });
 
-  describe('service list contains power state in "timeout" and power status in "starting', function() {
+  describe('service list contains power state in "" and power status in "starting', function() {
     var controller;
     var services = {
       name: 'services',
@@ -47,15 +47,15 @@ describe('Dashboard', function() {
       subcount: 1,
       resources: [
         {
+          power_state: "",
           options: {
-            powerState: "timeout",
-            powerStatus: "starting"
+            power_status: "starting"
           }
         }
       ]
     };
 
-    var serviceItem = services.resources[0].options;
+    var serviceItem = services.resources[0];
 
     var Chargeback = {
       processReports: function() {
@@ -71,21 +71,21 @@ describe('Dashboard', function() {
     });
 
     it('sets the powerState value on the Service', function() {
-      expect(serviceItem.powerState).to.eq('timeout');
+      expect(serviceItem.power_state).to.eq('');
     });
 
     it('sets the powerStatus value on the Service', function() {
-      expect(serviceItem.powerStatus).to.eq('starting');
+      expect(serviceItem.options.power_status).to.eq('starting');
     });
 
-    it('does not hide the kebab menu when "Start" operation times out', function() {
-      expect(controller.hideMenuForItemFn(serviceItem)).to.eq(false);
+    it('does hide the kebab menu when "Start" operation is unknown', function() {
+      expect(controller.hideMenuForItemFn(serviceItem)).to.eq(true);
     });
 
-    it('Shows the "Start" button when "Start" operation times out', function() {
+    it('Disables the "Start" button when "Start" operation is "starting"', function() {
       var action = {actionName: 'start'};
       expect(controller.updateMenuActionForItemFn(action, serviceItem));
-      expect(action.isDisabled).to.eq(false);
+      expect(action.isDisabled).to.eq(true);
     });
 
     it('displays "Stop" button when action is "stop"', function() {
@@ -109,15 +109,15 @@ describe('Dashboard', function() {
       subcount: 1,
       resources: [
         {
+          power_state: "on",
           options: {
-            powerState: "on",
-            powerStatus: "start_complete"
+            power_status: "start_complete"
           }
         }
       ]
     };
 
-    var serviceItem = services.resources[0].options;
+    var serviceItem = services.resources[0];
 
     var Chargeback = {
       processReports: function() {
@@ -128,24 +128,24 @@ describe('Dashboard', function() {
 
     var PowerOperations = {
       powerOperationOnState: function(item) {
-        return item.powerState === "on" && item.powerStatus === "start_complete";
+        return item.power_state === "on" && item.options.power_status === "start_complete";
       },
       powerOperationUnknownState: function(item) {
-        return item.powerState === "" && item.powerStatus === "";
+        return item.power_state === "" && item.options.power_status === "";
       },
       powerOperationInProgressState: function(item) {
-        return (item.powerState !== "timeout" && item.powerStatus === "starting")
-          || (item.powerState !== "timeout" && item.powerStatus === "stopping")
-          || (item.powerState !== "timeout" && item.powerStatus === "suspending");
+        return (item.power_state !== "timeout" && item.options.power_status === "starting")
+          || (item.power_state !== "timeout" && item.options.power_status === "stopping")
+          || (item.power_state !== "timeout" && item.options.power_status === "suspending");
       },
       powerOperationOffState: function(item) {
-        return item.powerState === "off" && item.powerStatus === "stop_complete";
+        return item.power_state === "off" && item.options.power_status === "stop_complete";
       },
       powerOperationSuspendState: function(item) {
-        return item.powerState === "off" && item.powerStatus === "suspend_complete";
+        return item.power_state === "off" && item.options.power_status === "suspend_complete";
       },
       powerOperationTimeoutState: function(item) {
-        return item.powerState === "timeout";
+        return item.power_state === "timeout";
       },
     };
 


### PR DESCRIPTION
This PR pulls in the `service.power_state` directly from the virtual `power_state` column vs the cached version previously exposed in the options hash.

Dependent on: https://github.com/ManageIQ/manageiq/pull/12963


https://bugzilla.redhat.com/show_bug.cgi?id=1396728