### PR TITLE
Updated Service Detail screen with new fields

### DIFF
--- a/client/app/states/services/details/_details.sass
+++ b/client/app/states/services/details/_details.sass
@@ -17,3 +17,6 @@
         margin: 0px
         button
           margin-bottom: 4px
+.redhat-tags
+  i 
+    margin-right: 4px

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -145,6 +145,12 @@
                     <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.powerState === '' && vm.service.powerStatus === ''" tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
                   </div>
                 </div>
+                <div class="form-group">
+                  <label class="control-label col-sm-4" translate>Management Engine GUID</label>
+                  <div class="col-sm-8">
+                    <input class="form-control" disabled value="{{ ::vm.service.guid }}"/>
+                  </div>
+                </div>
               </div>
             </div>
             <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
@@ -191,6 +197,40 @@
             </div>
           </div>
         </div>
+      </section>
+    </div>
+  </div>
+
+<div class="panel panel-default ss-details-panel">
+    <div class="panel-body">
+      <section class="ss-details-section">
+        <h2 translate>Relationships</h2>
+         <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
+              <div class="form-horizontal">
+                <div class="form-group">
+                  <label class="control-label col-sm-4" translate>Parent Catalog Item</label>
+                  <div class="col-sm-8">
+                   <a href="#" ng-click="vm.gotoCatalogItem()">{{ ::vm.service.service_template.name }}</a>
+                  </div>
+                </div>
+              </div>
+         </div>
+      </section>
+    </div>
+</div>
+<div class="panel panel-default ss-details-panel">
+    <div class="panel-body">
+      <section class="ss-details-section">
+        <h2 translate>Redhat Tags</h2>
+         <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
+              <div class="form-horizontal">
+                <div class="form-group">
+                  <div ng-repeat="tag in ::vm.tags.resources" class="redhat-tags">
+                    <i class="fa fa-tag pficon"></i>{{tag.category.description}}: {{tag.classification.description}}
+                  </div>
+                </div>
+              </div>
+         </div>
       </section>
     </div>
   </div>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -19,6 +19,7 @@
         title: N_('Service Details'),
         resolve: {
           service: resolveService,
+          tags: resolveTags,
         },
       },
     };
@@ -43,6 +44,10 @@
       'provision_dialog',
       'service_template',
       'chargeback_report',
+      'created_at',
+      'options',
+      'name',
+      'guid',
     ];
     var options = {
       attributes: requestAttributes,
@@ -51,9 +56,23 @@
     };
 
     return CollectionsApi.get('services', $stateParams.serviceId, options);
+  }
+  function resolveTags($stateParams, CollectionsApi) {
+    var requestAttributes = [
+      'classification',
+      'category',
+    ];
+    var options = {
+      attributes: requestAttributes,
+      decorators: [],
+      expand: 'resources',
+    };
+    var serviceUrl = $stateParams.serviceId + '/tags/';
+    
+    return CollectionsApi.get('services', serviceUrl, options);
   }  
   /** @ngInject */
-  function StateController($state, service, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, 
+  function StateController($state, service, tags, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal, 
                            EventNotifications, Consoles, Chargeback, PowerOperations) {
     var vm = this;
     setInitialVars();
@@ -97,7 +116,7 @@
       vm.showSetOwnership = $state.actionFeatures.serviceOwnership.show;
 
       vm.service = service;
-
+      vm.tags = tags;
       vm.activate = activate;
       vm.removeService = removeService;
       vm.editServiceModal = editServiceModal;
@@ -105,6 +124,7 @@
       vm.retireServiceLater = retireServiceLater;
       vm.ownershipServiceModal = ownershipServiceModal;
       vm.reconfigureService = reconfigureService;
+      vm.gotoCatalogItem = gotoCatalogItem;
 
       vm.service.powerState = angular.isDefined(vm.service.options.power_state) ? vm.service.options.power_state : "";
       vm.service.powerStatus = angular.isDefined(vm.service.options.power_status) ? vm.service.options.power_status : "";
@@ -187,6 +207,10 @@
 
     function editServiceModal() {
       EditServiceModal.showModal(vm.service);
+    }
+
+    function gotoCatalogItem() {
+      $state.go('marketplace.details', {serviceTemplateId: service.service_template.id});
     }
 
     function ownershipServiceModal() {

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -73,14 +73,32 @@ describe('Dashboard', function() {
       }
     };
 
+    var tags ={
+      resources: [
+        {
+          category:{
+            description: "sample tag description"
+          },
+          classification: {
+            description: "Tag"
+          }
+        }
+      ]
+    };
+
     beforeEach(function() {
       bard.inject('$controller', '$state', 'CollectionsApi', 'EventNotifications');
 
-      controller = $controller($state.get('services.details').controller, {service: service, $state: state});
+      controller = $controller($state.get('services.details').controller, {service: service, $state: state, tags: tags});
     });
 
     it('should be created successfully', function() {
       expect(controller).to.be.defined;
+    });
+
+    it('Tags should be part of controller object', function (done) {
+        expect(controller.tags).to.eq(tags);
+        done();
     });
 
     describe('removeService', function() {
@@ -123,10 +141,23 @@ describe('Dashboard', function() {
       }
     };
 
+    var tags = {
+      resources: [
+        {
+          category: {
+            description: "sample tag description"
+          },
+          classification: {
+            description: "Tag"
+          }
+        }
+      ]
+    };
+
     beforeEach(function() {
       bard.inject('$controller', '$state');
 
-      controller = $controller($state.get('services.details').controller, {service: service, $state: state, Chargeback: Chargeback});
+      controller = $controller($state.get('services.details').controller, {service: service, $state: state, Chargeback: Chargeback, tags: tags});
     });
 
     it('enables the "Start" button when power state is "timeout" and power status is "starting', function() {
@@ -134,11 +165,11 @@ describe('Dashboard', function() {
     });
 
     it('disables the "Stop" button when power state is "timeout" and power status is "starting', function() {
-      expect(controller.checkDisabled('stop', controller.service)).to.eq(false);
+      expect(controller.checkDisabled('stop', controller.service, controller.tags)).to.eq(false);
     });
 
     it('disables the "Suspend" button when power state is "timeout" and power status is "starting', function() {
-      expect(controller.checkDisabled('suspend', controller.service)).to.eq(false);
+      expect(controller.checkDisabled('suspend', controller.service, controller.tags)).to.eq(false);
     });
   });
 
@@ -153,6 +184,18 @@ describe('Dashboard', function() {
         results: []
       },
     };
+    var tags ={
+      resources: [
+        {
+          category:{
+            description: "sample tag description"
+          },
+          classification: {
+            description: "Tag"
+          }
+        }
+      ]
+    };
 
     beforeEach(function() {
       bard.inject('$controller', '$state');
@@ -161,7 +204,8 @@ describe('Dashboard', function() {
         {service: service,
          $state: state,
          Chargeback: Chargeback,
-         PowerOperations: PowerOperations});
+         PowerOperations: PowerOperations,
+         tags: tags});
     });
 
     it('disables the "Start" button when power state is "ON"', function() {


### PR DESCRIPTION
This PR is for PV ticket https://www.pivotaltracker.com/story/show/133840401 which aims to try and make sure the SUI service detail page has the same fields of info available as the classic UI. 

Fields Added:
Added Management Guid
Added Relationship section
Added Redhat Tags section