### PR TITLE
Remove "Suspend" Power Operation

### DIFF
--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -74,9 +74,10 @@
                 <li ng-class="{'disabled': vm.checkDisabled('stop', vm.service)}">
                   <a href="#" title="Stop this service" ng-click="vm.handlePowerOperation('stop', vm.service)">{{'Stop'|translate}}</a>
                 </li>
-                <li ng-class="{'disabled': vm.checkDisabled('suspend', vm.service)}">
-                  <a href="#" title="Suspend this service" ng-click="vm.handlePowerOperation('suspend', vm.service)">{{'Suspend'|translate}}</a>
-                </li>
+                <!-- TODO: Pulling out 'Suspend' option for now. We may add it back if/when we have reliable backend support -->
+                <!--<li ng-class="{'disabled': vm.checkDisabled('suspend', vm.service)}">-->
+                  <!--<a href="#" title="Suspend this service" ng-click="vm.handlePowerOperation('suspend', vm.service)">{{'Suspend'|translate}}</a>-->
+                <!--</li>-->
                 <li><a href="#" title="Edit this service" ng-click="vm.editServiceModal()" ng-show="vm.showEditService">{{'Edit'|translate}}</a></li>
                 <li><a href="#" title="Set Ownership" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership">{{'Set Ownership'|translate}}</a></li>
                 <li><a href="#" ng-if="vm.service.reconfigure" ng-click="vm.reconfigureService(vm.service.id)" ng-show="vm.showReconfigureService" translate>Reconfigure</a></li>


### PR DESCRIPTION
`"Start"` and `"Stop"` are the supported Service Power Operations at the moment.
We are pulling out `"Suspend"` operation for now. 
We may add it back if/when we have a reliable backend support for this operation.

Before:
<img width="1225" alt="screen shot 2016-12-07 at 1 13 14 pm" src="https://cloud.githubusercontent.com/assets/1538216/20986821/00abfcec-bc7f-11e6-8484-cff5e131605d.png">

After:
<img width="1224" alt="screen shot 2016-12-07 at 1 09 36 pm" src="https://cloud.githubusercontent.com/assets/1538216/20986771/d8dd95b8-bc7e-11e6-8d9c-34b561ace138.png">



https://bugzilla.redhat.com/show_bug.cgi?id=1391685