### PR TITLE
[WIP] Create tagEditor component and associated service

### DIFF
--- a/client/app/components/tag-editor/tag-editor.component.html
+++ b/client/app/components/tag-editor/tag-editor.component.html
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="col-md-6">
+    <input type="text" class="form-control" placeholder="Select a Category"
+      ng-model=""
+      uib-typeahead=""
+      typeahead-min-length="0">
+  </div>
+  <div class="col-md-6">
+    <select pf-select multiple class="form-control" ng-model="" ng-options="">
+    </select>
+  </div>
+</div>
+<table class="table table-striped table-bordered">
+  <thead>
+    <tr><th>Category</th><th>Assigned Value</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Auto-Approve - Max Retirement</td>
+      <td>
+        <span class="label label-info">Desktop</span>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/client/app/components/tag-editor/tag-editor.component.js
+++ b/client/app/components/tag-editor/tag-editor.component.js
@@ -1,0 +1,25 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .component('tagEditor', {
+      bindings: {},
+      controller: TagEditorController,
+      controllerAs: 'vm',
+      templateUrl: 'app/components/tag-editor/tag-editor.html',
+    });
+
+  /** @ngInject */
+  function TagEditorController(taggingService) {
+    var vm = this;
+    vm.$onInit = function() {
+      vm.assignedTags = [];
+      vm.tagCategories = [];
+
+      taggingService.getTagCategories()
+        .then(function(response) {
+          vm.tagCategories = response;
+        });
+    }
+  }
+})();

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -1,0 +1,17 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('taggingService', taggingService);
+
+  /** @ngInject */
+  function taggingService(CollectionsApi) {
+    return {
+      getTagCategories: getTagCategories,
+    };
+
+    function getTagCategories() {
+      CollectionsApi.query();
+    }
+  }
+})();

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -219,16 +219,7 @@
 <div class="panel panel-default ss-details-panel">
     <div class="panel-body">
       <section class="ss-details-section">
-        <h2 translate>Redhat Tags</h2>
-         <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
-              <div class="form-horizontal">
-                <div class="form-group">
-                  <div ng-repeat="tag in ::vm.tags.resources" class="redhat-tags">
-                    <i class="fa fa-tag pficon"></i>{{tag.category.description}}: {{tag.classification.description}}
-                  </div>
-                </div>
-              </div>
-         </div>
+        <tag-editor></tag-editor>
       </section>
     </div>
   </div>

--- a/tests/components/tag-editor.component.spec.js
+++ b/tests/components/tag-editor.component.spec.js
@@ -1,0 +1,40 @@
+describe.only('tagEditor', function() {
+  var controller;
+  var taggingServiceMock;
+
+  beforeEach(module('app.components', 'gettext'));
+
+  beforeEach(inject(function($componentController) {
+    taggingServiceMock = {
+      getTagCategories: sinon.stub().returns(Promise.resolve()),
+    };
+
+    controller = $componentController('tagEditor', {
+      taggingService: taggingServiceMock,
+    });
+  }));
+
+  describe('#$onInit', function() {
+    it('begins with an empty list of tagCategories', function() {
+      controller.$onInit();
+      expect(controller.tagCategories).to.eql([]);
+    });
+
+    it('begins with an empty list of assignedTags', function() {
+      controller.$onInit();
+      expect(controller.assignedTags).to.eql([]);
+    });
+
+    it('retrieves tagCategories from taggingService', function(done) {
+      var categories = [{ name: 'environment', single_value: true, options: [] }];
+      taggingServiceMock.getTagCategories = function() {
+        return Promise.resolve(categories);
+      }
+
+      controller.$onInit();
+      done();
+
+      expect(controller.tagCategories).to.eql(categories);
+    });
+  });
+});

--- a/tests/services/tagging.service.spec.js
+++ b/tests/services/tagging.service.spec.js
@@ -1,0 +1,19 @@
+describe.only('taggingService', function() {
+  var service;
+  var collectionsApiMock;
+
+  beforeEach(module('app.services', 'app.states', 'app.config', 'gettext'));
+
+  beforeEach(inject(function(taggingService, CollectionsApi) {
+    service = taggingService;
+    collectionsApiMock = sinon.mock(CollectionsApi);
+  }));
+
+  describe('#getTagCategories', function() {
+    it('makes a request for categories using the CollectionsApi', function() {
+      collectionsApiMock.expects('query');
+      service.getTagCategories();
+      collectionsApiMock.verify();
+    });
+  });
+});


### PR DESCRIPTION
 `tagEditor` to be used in modals for single and batch editing of tags.
The component will need to:
- [ ] Have a binding for common tags of resources that need tags edited
- [ ] Manage a tag assignments collection
- [ ] Cache/hold available tag categories and options
- [ ] Provide a callback after dismissing tags from UI
- [ ] Two-way bind tag assignments for both single and multiple value
categories

Add `taggingService` for higher-level interactions with CollectionsApi.
The service will need to:
- [ ] Get all tag categories and associated value options
- [ ] Post tag assignments (involves assigning and unassigning tags)

@miq-bot add_label wip, euwe/no