### PR TITLE
Unhide/enable Service Designer and Administration

### DIFF
--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -34,7 +34,6 @@
       $http.defaults.headers.common['X-Miq-Group'] = data.miqGroup || undefined;
       $sessionStorage.token = model.token;
       $sessionStorage.miqGroup = data.miqGroup || null;
-      fetchProductSetting("preview_flag", "service_ui_preview");
     }
 
     function destroy() {
@@ -45,12 +44,6 @@
       delete $http.defaults.headers.common['X-Miq-Group'];
       delete $sessionStorage.miqGroup;
       delete $sessionStorage.token;
-    }
-
-    function fetchProductSetting(keyName, key) {
-      $http.get('/api/settings').then(function(response) {
-        $state[keyName] = response.data.product[key];
-      });
     }
 
     function loadUser() {

--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -178,6 +178,10 @@
         || entitledForServiceCatalogs(productFeatures);
     }
 
+    function entitledForServiceDesigner(productFeatures) {
+      return angular.isDefined(productFeatures.service_create);
+    }
+
     function activeNavigationFeatures() {
       var activeNavFeatures = lodash.find(model.navFeatures, function(o) {
         return o.show === true;

--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -113,8 +113,8 @@
         services: {show: entitledForServices(productFeatures)},
         requests: {show: entitledForRequests(productFeatures)},
         marketplace: {show: entitledForServiceCatalogs(productFeatures)},
-        designer: {show: angular.isDefined($state.preview_flag) ? $state.preview_flag : false},
-        administration: {show: angular.isDefined($state.preview_flag) ? $state.preview_flag : false},
+        designer: {show: entitledForServiceDesigner(productFeatures)},
+        administration: {show: entitledForServiceDesigner(productFeatures)},
       };
       model.navFeatures = features;
 


### PR DESCRIPTION
`Service Designer` and `Administration` would now be enabled by default.

The only check that could possibly block displaying these two features is the RBAC setting for the the logged-in user.

Before:
<img width="1428" alt="screen shot 2016-12-13 at 1 33 01 pm" src="https://cloud.githubusercontent.com/assets/1538216/21160185/babed0c4-c138-11e6-8a3d-acba759a8c7c.png">


After:
<img width="1424" alt="screen shot 2016-12-13 at 1 28 11 pm" src="https://cloud.githubusercontent.com/assets/1538216/21160134/9ba56bd0-c138-11e6-961a-60ac678f0643.png">


PT: https://www.pivotaltracker.com/n/projects/1914499/stories/135955515