### PR TITLE
[EUWE] Lock is-number-like transient dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "bower": "^1.3.0",
-    "browser-sync": "^2.8.1",
+    "browser-sync": "2.8.3",
     "chai": "^2.1.1",
     "chai-as-promised": "^4.3.0",
     "chalk": "^1.0.0",


### PR DESCRIPTION
This transient dependency is currently released with a broken version and it needs to be locked to a previously working version.