### PR TITLE
Reload login screen to close the modal dialog

### DIFF
--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -11,7 +11,7 @@
     $httpProvider.interceptors.push(interceptor);
 
     /** @ngInject */
-    function interceptor($injector, $q) {
+    function interceptor($injector, $q, $window) {
       return {
         response: response,
         responseError: responseError,
@@ -50,14 +50,14 @@
           }
 
           Session.destroy();
-          $state.go('login');
+          $window.location.href = $state.href('login');
         }
       }
     }
   }
 
   /** @ngInject */
-  function init($rootScope, $state, Session, $sessionStorage, logger, Language, ServerInfo, ProductInfo) {
+  function init($rootScope, $state, Session, $sessionStorage, logger, Language, ServerInfo, ProductInfo, $window) {
     var unregisterStart = $rootScope.$on('$stateChangeStart', changeStart);
     var unregisterError = $rootScope.$on('$stateChangeError', changeError);
     var unregisterSuccess = $rootScope.$on('$stateChangeSuccess', changeSuccess);
@@ -102,14 +102,14 @@
           $state.go(toState, toParams);
         } else {
           Session.privilegesError = true;
-          $state.go('login');
+          $window.location.href = $state.href('login');
         }
       };
     }
 
     function badUser(error) {
       logger.error(__('Error retrieving user info'), [error]);
-      $state.go('login');
+      $window.location.href = $state.href('login');
     }
 
     function changeError(event, toState, toParams, fromState, fromParams, error) {

--- a/client/app/config/authorization.config.js
+++ b/client/app/config/authorization.config.js
@@ -43,14 +43,8 @@
         var Session = $injector.get('Session');
 
         if ('login' !== $state.current.name) {
-          // prevent multiple instances of the same notification - cleared on login submit
-          if (!Session.timeoutNotified) {
-            Notifications.message('danger', '', __('Your session has timed out.'), true);
-            Session.timeoutNotified = true;
-          }
-
           Session.destroy();
-          $window.location.href = $state.href('login');
+          $window.location.href = $state.href('login') + "?timeout";
         }
       }
     }

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -36,6 +36,10 @@
       password: API_PASSWORD,
     };
 
+    if ($window.location.href.includes("?timeout")) {
+      Notifications.message('danger', '', __('Your session has timed out.'), true);
+    }
+
     if (Session.privilegesError) {
       Notifications.error(__('User does not have privileges to login.'));
     }

--- a/client/app/states/logout/logout.state.js
+++ b/client/app/states/logout/logout.state.js
@@ -21,12 +21,12 @@
   }
 
   /** @ngInject */
-  function StateController($state, Session) {
+  function StateController($state, Session, $window) {
     activate();
 
     function activate() {
       Session.destroy();
-      $state.go('login');
+      $window.location.href = $state.href('login');
     }
   }
 })();


### PR DESCRIPTION
If a modal dialog is left active until the user session times out, we get a login screen with the modal still visible as shown below --
<img width="1428" alt="screen shot 2016-12-14 at 11 38 17 am" src="https://cloud.githubusercontent.com/assets/1538216/21200472/2bf69240-c1fc-11e6-9784-a3a7bec154dc.png">

The PR addresses the above issue. 

https://www.pivotaltracker.com/n/projects/1914499/stories/134431669