### PR TITLE
Tag editor modal

### DIFF
--- a/client/app/blocks/exception/exception.js
+++ b/client/app/blocks/exception/exception.js
@@ -13,8 +13,14 @@
     return service;
 
     function catcher(message) {
-      return function(reason) {
-        logger.error(message, reason);
+      return function(error) {
+        if (error.data && error.data.description) {
+          message += '\n' + error.data.description;
+          error.data.description = message;
+        }
+        logger.error(message, error);
+
+        return Promise.reject(error);
       };
     }
   }

--- a/client/app/components/service-explorer/explorer.component.js
+++ b/client/app/components/service-explorer/explorer.component.js
@@ -475,11 +475,11 @@
     }
 
     function editTags() {
-      var extractSharedTagsFromSelectedServices =
-        lodash.partial(taggingService.findSharedTags, vm.selectedItemsList);
+      var extractSharedTagsFromSelectedServices
+        = lodash.partial(taggingService.findSharedTags, vm.selectedItemsList);
 
-      var launchTagEditorForSelectedServices =
-        lodash.partial(TagEditorModal.showModal, vm.selectedItemsList);
+      var launchTagEditorForSelectedServices
+        = lodash.partial(TagEditorModal.showModal, vm.selectedItemsList);
 
       return taggingService.queryAvailableTags()
         .then(extractSharedTagsFromSelectedServices)

--- a/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
+++ b/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
@@ -17,7 +17,7 @@
         templateUrl: 'app/components/tag-editor-modal/tag-editor-modal.html',
         controller: TagEditorModalController,
         controllerAs: 'vm',
-        size: 'lg',
+        size: 'md',
         resolve: {
           services: resolveServices,
           tags: resolveTags,

--- a/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
+++ b/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
@@ -47,7 +47,7 @@
     angular.extend(vm, base);
 
     vm.save = save;
-    vm.services = Array.isArray(services) ? services : [services];
+    vm.services = angular.isArray(services) ? services : [services];
     vm.modalData = { tags: angular.copy(tags) };
 
     // Override

--- a/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
+++ b/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
@@ -5,7 +5,7 @@
     .factory('TagEditorModal', TagEditorFactory);
 
   /** @ngInject */
-  function TagEditorFactory($uibModal, taggingService) {
+  function TagEditorFactory($uibModal) {
     var modalService = {
       showModal: showModal,
     };
@@ -32,7 +32,7 @@
       }
 
       function resolveTags() {
-        return tags.map(taggingService.parseTag);
+        return tags;
       }
     }
   }

--- a/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
+++ b/client/app/components/tag-editor-modal/tag-editor-modal-service.factory.js
@@ -1,0 +1,106 @@
+(function() {
+  'use strict';
+
+  angular.module('app.components')
+    .factory('TagEditorModal', TagEditorFactory);
+
+  /** @ngInject */
+  function TagEditorFactory($uibModal) {
+    var modalService = {
+      showModal: showModal,
+    };
+
+    return modalService;
+
+    function showModal(service, tags) {
+      var modalOptions = {
+        templateUrl: 'app/components/tag-editor-modal/tag-editor-modal.html',
+        controller: TagEditorModalController,
+        controllerAs: 'vm',
+        size: 'lg',
+        resolve: {
+          service: resolveService,
+          tags: resolveTags,
+        },
+      };
+      var modal = $uibModal.open(modalOptions);
+
+      return modal.result;
+
+      function resolveService() {
+        return service;
+      }
+
+      function resolveTags() {
+        // taggingWidget needs tagsOfItems to have this shape
+        return tags.resources.map(function(resource) {
+          return {
+            id: resource.id,
+            name: resource.name,
+            category: { id: resource.category.id },
+            categorization: {
+              displayName: resource.category.description + ': ' + resource.classification.description,
+            },
+          };
+        });
+      }
+    }
+  }
+
+  /** @ngInject */
+  function TagEditorModalController(service, tags, $controller, $uibModalInstance,
+                                    $state, CollectionsApi, EventNotifications) {
+    var vm = this;
+    var base = $controller('BaseModalController', {
+      $uibModalInstance: $uibModalInstance,
+    });
+    angular.extend(vm, base);
+
+    vm.save = save;
+    vm.modalData = { tags: angular.copy(tags) };
+
+    // Override
+    function save() {
+      var tagNames = vm.modalData.tags.map(function(tag) {
+        return tag.name;
+      });
+
+      var assignData = {
+        action: 'assign',
+        resources: tagNames.map(function(name) {
+          return { name: name };
+        }),
+      };
+
+      var unassignData = {
+        action: 'unassign',
+        resources: tags.filter(function(tag) {
+          return tagNames.indexOf(tag.name) < 0;
+        }).map(function(tag) {
+          return { name: tag.name };
+        }),
+      };
+
+      return CollectionsApi.post('services', service.id + '/tags', {}, assignData)
+        .then(function(data) {
+          if (unassignData.resources.length > 0) {
+            return CollectionsApi.post('services', service.id + '/tags', {}, unassignData);
+          } else {
+            return data;
+          }
+        })
+        .then(saveSuccess)
+        .catch(saveFailure);
+
+      function saveSuccess() {
+        $uibModalInstance.close();
+        EventNotifications.success(__('Tagging successful.'));
+        $state.go($state.current, {}, {reload: true});
+      }
+
+      function saveFailure() {
+        EventNotifications.error(__('There was an error tagging this service.'));
+      }
+    }
+  }
+})();

--- a/client/app/components/tag-editor-modal/tag-editor-modal.html
+++ b/client/app/components/tag-editor-modal/tag-editor-modal.html
@@ -1,0 +1,16 @@
+<div class="modal-header">
+  <button type="button" class="close" ng-click="$dismiss()" aria-hidden="true">
+    <span class="pficon pficon-close"></span>
+  </button>
+  <h4 class="modal-title" id="myModalLabel" translate>Edit Tags</h4>
+</div>
+<tagging-widget tags-of-item="vm.modalData.tags"></tagging-widget>
+<div class="modal-footer">
+  <modal-actions
+    modal-data="vm.modalData"
+    reset-modal="true"
+    on-cancel="vm.cancel()"
+    on-reset="vm.reset($event)"
+    on-save="vm.save()">
+  </modal-actions>
+</div>

--- a/client/app/components/tag-editor-modal/tag-editor-modal.html
+++ b/client/app/components/tag-editor-modal/tag-editor-modal.html
@@ -5,6 +5,7 @@
   <h4 class="modal-title" id="myModalLabel" translate>Edit Tags</h4>
 </div>
 <tagging-widget tags-of-item="vm.modalData.tags"></tagging-widget>
+<icon-list items="vm.services"></icon-list>
 <div class="modal-footer">
   <modal-actions
     modal-data="vm.modalData"

--- a/client/app/components/tag-editor-modal/tag-editor-modal.html
+++ b/client/app/components/tag-editor-modal/tag-editor-modal.html
@@ -4,8 +4,23 @@
   </button>
   <h4 class="modal-title" id="myModalLabel" translate>Edit Tags</h4>
 </div>
-<tagging-widget tags-of-item="vm.modalData.tags"></tagging-widget>
-<icon-list items="vm.services"></icon-list>
+
+<div class="modal-body">
+  <form name="tagEditorForm" class="form-horizontal">
+    <div
+      pf-form-group
+      pf-input-class="col-sm-10"
+      pf-label="{{'Tags'|translate}}">
+        <tagging-widget tags-of-item="vm.modalData.tags"></tagging-widget>
+    </div>
+  </form>
+
+  <hr>
+
+  <h4 translate>Affected Services</h4>
+  <icon-list items="vm.services"></icon-list>
+</div>
+
 <div class="modal-footer">
   <modal-actions
     modal-data="vm.modalData"

--- a/client/app/components/tagging/tagging.component.js
+++ b/client/app/components/tagging/tagging.component.js
@@ -139,6 +139,7 @@
     function getSmTagObj(tag) {
       return {
         id: tag.id,
+        name: tag.name,
         category: {id: tag.category.id},
         categorization: {
           displayName: tag.categorization.display_name,

--- a/client/app/components/tagging/tagging.component.js
+++ b/client/app/components/tagging/tagging.component.js
@@ -13,7 +13,7 @@
     });
 
   /** @ngInject */
-  function TaggingController($scope, $filter, $q, $log, CollectionsApi) {
+  function TaggingController($scope, $filter, $q, $log, CollectionsApi, taggingService) {
     var vm = this;
 
     vm.tags = {};
@@ -132,19 +132,9 @@
 
       // Add Selected Tag
       if (!matchingTag.length) {
-        vm.tagsOfItem.push(getSmTagObj(vm.tags.selectedTag));
+        var parsedTag = taggingService.parseTag(vm.tags.selectedTag);
+        vm.tagsOfItem.push(parsedTag);
       }
     };
-
-    function getSmTagObj(tag) {
-      return {
-        id: tag.id,
-        name: tag.name,
-        category: {id: tag.category.id},
-        categorization: {
-          displayName: tag.categorization.display_name,
-        },
-      };
-    }
   }
 })();

--- a/client/app/services/session.service.js
+++ b/client/app/services/session.service.js
@@ -118,6 +118,7 @@
       var features = {
         serviceView: {show: angular.isDefined(productFeatures.service_view)},
         serviceEdit: {show: angular.isDefined(productFeatures.service_edit)},
+        serviceTag: {show: angular.isDefined(productFeatures.service_tag)},
         serviceDelete: {show: angular.isDefined(productFeatures.service_delete)},
         serviceReconfigure: {show: angular.isDefined(productFeatures.service_reconfigure)},
         serviceRetireNow: {show: angular.isDefined(productFeatures.service_retire_now)},
@@ -125,7 +126,7 @@
         serviceOwnership: {show: angular.isDefined(productFeatures.service_ownership)},
       };
       model.actionFeatures = features;
-      
+
       return model.actionFeatures;
     }
 

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -15,6 +15,9 @@
 
     return service;
 
+    // High-level method to declaratively assign tags to resource(s). Current
+    // tagging APIs require separate requests for assignment of new tags and
+    // unassignment of existing tags.
     function assignTags(collection, selectedResources, originalTags, tagsToAssign) {
       var assignPayload = {
         action: 'assign',
@@ -28,6 +31,11 @@
         resources: tagsToUnassign.map(toTagObject),
       };
 
+      // Resolve when all assignment and unassignment requests resolve or reject
+      // if/when the first request rejects. This ensures that from the UI only a
+      // single notification is given for success/failure and keeps the
+      // assignment as an implementation detail.
+      //
       // TODO: Swap out with more efficient implementation after API update
       return Promise.all(selectedResources.reduce(function(allPromises, resource) {
         allPromises.push(postTagPayload(resource, assignPayload));
@@ -51,6 +59,7 @@
       }
     }
 
+    // Returns the common list of tags between all selected resources.
     function findSharedTags(selectedResources, availableTags) {
       return availableTags.filter(function(tag) {
         return selectedResources.every(function(resource) {
@@ -61,6 +70,7 @@
       });
     }
 
+    // Ensures that tags have the correct shape to be processed.
     function parseTag(tagResponse) {
       return {
         id: tagResponse.id,
@@ -74,6 +84,9 @@
       };
     }
 
+    // With no arguments query all available tags, with a single resource url
+    // queries all available tags for that resource. The result is filtered of
+    // invalid tags (missing required properties).
     function queryAvailableTags(resourceUrl) {
       var queryOptions = {
         expand: 'resources',

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -32,11 +32,12 @@
       return Promise.all(selectedResources.reduce(function(allPromises, resource) {
         allPromises.push(postTagPayload(resource, assignPayload));
         allPromises.push(postTagPayload(resource, unassignPayload));
+
         return allPromises;
       }, []));
 
       function tagName(tag) {
-        return tag.name
+        return tag.name;
       }
 
       function toTagObject(tag) {
@@ -89,11 +90,11 @@
       }
 
       function isValidTag(tagResponse) {
-        return tagResponse.categorization &&
-          tagResponse.categorization.display_name &&
-          tagResponse.category &&
-          tagResponse.category.id &&
-          tagResponse.category.description;
+        return tagResponse.categorization
+          && tagResponse.categorization.display_name
+          && tagResponse.category
+          && tagResponse.category.id
+          && tagResponse.category.description;
       }
     }
   }

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -74,13 +74,13 @@
       };
     }
 
-    function queryAvailableTags() {
+    function queryAvailableTags(resourceUrl) {
       var queryOptions = {
         expand: 'resources',
         attributes: ['categorization', 'category'],
       };
 
-      return CollectionsApi.query('tags', queryOptions)
+      return CollectionsApi.query(resourceUrl || 'tags', queryOptions)
         .then(filterValidTags);
 
       function filterValidTags(response) {

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -1,0 +1,100 @@
+(function() {
+  'use strict';
+
+  angular.module('app.services')
+    .factory('taggingService', taggingService);
+
+  /** @ngInject */
+  function taggingService(CollectionsApi, lodash) {
+    var service = {
+      assignTags: assignTags,
+      findSharedTags: findSharedTags,
+      parseTag: parseTag,
+      queryAvailableTags: queryAvailableTags,
+    };
+
+    return service;
+
+    function assignTags(collection, selectedResources, originalTags, tagsToAssign) {
+      var assignPayload = {
+        action: 'assign',
+        resources: tagsToAssign.map(toTagObject),
+      };
+
+      var tagsToUnassign = lodash.difference(originalTags.map(tagName), tagsToAssign.map(tagName));
+
+      var unassignPayload = {
+        action: 'unassign',
+        resources: tagsToUnassign.map(toTagObject),
+      };
+
+      // TODO: Swap out with more efficient implementation after API update
+      return Promise.all(selectedResources.reduce(function(allPromises, resource) {
+        allPromises.push(postTagPayload(resource, assignPayload));
+        allPromises.push(postTagPayload(resource, unassignPayload));
+        return allPromises;
+      }, []));
+
+      function tagName(tag) {
+        return tag.name
+      }
+
+      function toTagObject(tag) {
+        return { name: tag.name || tag };
+      }
+
+      function postTagPayload(resource, payload) {
+        if (payload.resources.length > 0) {
+          return CollectionsApi.post(collection, resource.id + '/tags', {}, payload);
+        }
+      }
+    }
+
+    function findSharedTags(selectedResources, availableTags) {
+      return availableTags.filter(function(tag) {
+        return selectedResources.every(function(resource) {
+          return resource.tags.some(function(resourceTag) {
+            return tag.name === resourceTag.name;
+          });
+        });
+      });
+    }
+
+    function parseTag(tagResponse) {
+      return {
+        id: tagResponse.id,
+        name: tagResponse.name,
+        category: {
+          id: tagResponse.category.id,
+        },
+        categorization: {
+          displayName: tagResponse.categorization.display_name,
+        },
+      };
+    }
+
+    function queryAvailableTags() {
+      var queryOptions = {
+        expand: 'resources',
+        attributes: ['categorization', 'category'],
+      };
+
+      return CollectionsApi.query('tags', queryOptions)
+        .then(filterValidTags);
+
+      function filterValidTags(response) {
+        return response.resources
+          .filter(isValidTag)
+          .map(service.parseTag);
+      }
+
+      function isValidTag(tagResponse) {
+        return tagResponse.categorization &&
+          tagResponse.categorization.display_name &&
+          tagResponse.category &&
+          tagResponse.category.id &&
+          tagResponse.category.description;
+      }
+    }
+  }
+})();

--- a/client/app/services/tagging.service.js
+++ b/client/app/services/tagging.service.js
@@ -5,7 +5,7 @@
     .factory('taggingService', taggingService);
 
   /** @ngInject */
-  function taggingService(CollectionsApi, lodash) {
+  function taggingService(CollectionsApi, lodash, exception) {
     var service = {
       assignTags: assignTags,
       findSharedTags: findSharedTags,
@@ -94,7 +94,8 @@
       };
 
       return CollectionsApi.query(resourceUrl || 'tags', queryOptions)
-        .then(filterValidTags);
+        .then(filterValidTags)
+        .catch(exception.catcher('Request failed for #queryAvailableTags'));
 
       function filterValidTags(response) {
         return response.resources

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -79,6 +79,7 @@
                   <!--<a href="#" title="Suspend this service" ng-click="vm.handlePowerOperation('suspend', vm.service)">{{'Suspend'|translate}}</a>-->
                 <!--</li>-->
                 <li><a href="#" title="Edit this service" ng-click="vm.editServiceModal()" ng-show="vm.showEditService">{{'Edit'|translate}}</a></li>
+                <li><a href="#" title="Edit tags" ng-click="vm.tagEditorModal()" ng-show="vm.showTagEditor">{{'Edit Tags'|translate}}</a></li>
                 <li><a href="#" title="Set Ownership" ng-click="vm.ownershipServiceModal()" ng-show="vm.showSetOwnership">{{'Set Ownership'|translate}}</a></li>
                 <li><a href="#" ng-if="vm.service.reconfigure" ng-click="vm.reconfigureService(vm.service.id)" ng-show="vm.showReconfigureService" translate>Reconfigure</a></li>
               </ul>

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -224,8 +224,8 @@
          <div class="col-lg-6 col-md-6 col-sm-6 col-xs-6">
               <div class="form-horizontal">
                 <div class="form-group">
-                  <div ng-repeat="tag in ::vm.tags.resources" class="redhat-tags">
-                    <i class="fa fa-tag pficon"></i>{{tag.category.description}}: {{tag.classification.description}}
+                  <div ng-repeat="tag in ::vm.tags" class="redhat-tags">
+                    <i class="fa fa-tag pficon"></i>{{tag.categorization.displayName}}
                   </div>
                 </div>
               </div>

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -62,21 +62,14 @@
 
     return CollectionsApi.get('services', $stateParams.serviceId, options);
   }
-  function resolveTags($stateParams, CollectionsApi) {
-    var requestAttributes = [
-      'categorization',
-      'classification',
-      'category',
-    ];
-    var options = {
-      attributes: requestAttributes,
-      decorators: [],
-      expand: 'resources',
-    };
-    var serviceUrl = $stateParams.serviceId + '/tags/';
 
-    return CollectionsApi.get('services', serviceUrl, options);
+  /** @ngInject */
+  function resolveTags($stateParams, taggingService) {
+    var serviceUrl = 'services/' + $stateParams.serviceId + '/tags/';
+
+    return taggingService.queryAvailableTags(serviceUrl);
   }
+
   /** @ngInject */
   function StateController($state, service, tags, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal,
                            TagEditorModal, EventNotifications, Consoles, Chargeback, PowerOperations) {
@@ -215,7 +208,7 @@
     }
 
     function tagEditorModal() {
-      TagEditorModal.showModal(vm.service, vm.tags.resources);
+      TagEditorModal.showModal(vm.service, vm.tags);
     }
 
     function gotoCatalogItem() {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -78,7 +78,7 @@
   }
   /** @ngInject */
   function StateController($state, service, tags, CollectionsApi, EditServiceModal, RetireServiceModal, OwnershipServiceModal,
-                           EventNotifications, Consoles, Chargeback, PowerOperations) {
+                           TagEditorModal, EventNotifications, Consoles, Chargeback, PowerOperations) {
     var vm = this;
     setInitialVars();
 
@@ -117,6 +117,7 @@
       vm.showRetireService = $state.actionFeatures.serviceRetireNow.show;
       vm.showScheduleRetirementService = $state.actionFeatures.serviceRetire.show;
       vm.showEditService = $state.actionFeatures.serviceEdit.show;
+      vm.showTagEditor = $state.actionFeatures.serviceTag.show;
       vm.showReconfigureService = $state.actionFeatures.serviceReconfigure.show;
       vm.showSetOwnership = $state.actionFeatures.serviceOwnership.show;
 
@@ -125,6 +126,7 @@
       vm.activate = activate;
       vm.removeService = removeService;
       vm.editServiceModal = editServiceModal;
+      vm.tagEditorModal = tagEditorModal;
       vm.retireServiceNow = retireServiceNow;
       vm.retireServiceLater = retireServiceLater;
       vm.ownershipServiceModal = ownershipServiceModal;
@@ -172,7 +174,7 @@
       }
     }
 
-    function setupVmMenuButtons() { 
+    function setupVmMenuButtons() {
       var vmMenuButtons = { actionButtons: [], buttonEnabledFn: {}};
       vmMenuButtons.buttonEnabledFn = vmButtonEnabled;
       var viewVirtualMachineAction = function(action, item) {
@@ -197,18 +199,22 @@
           class: 'fa pficon pficon-virtual-machine btn btn-default vm-action-button',
           title: __('View this virtual machine details'),
           actionFn: viewVirtualMachineAction,
-        }, 
+        },
       ];
 
       return vmMenuButtons;
     }
-   
+
     function openConsole(action, item) {
       Consoles.open(item.id);
     }
 
     function editServiceModal() {
       EditServiceModal.showModal(vm.service);
+    }
+
+    function tagEditorModal() {
+      TagEditorModal.showModal(vm.service, vm.tags);
     }
 
     function gotoCatalogItem() {

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -64,6 +64,7 @@
   }
   function resolveTags($stateParams, CollectionsApi) {
     var requestAttributes = [
+      'categorization',
       'classification',
       'category',
     ];
@@ -214,7 +215,7 @@
     }
 
     function tagEditorModal() {
-      TagEditorModal.showModal(vm.service, vm.tags);
+      TagEditorModal.showModal(vm.service, vm.tags.resources);
     }
 
     function gotoCatalogItem() {

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -8,6 +8,7 @@ describe('Dashboard', function() {
         serviceDelete: {show: true},
         serviceRetireNow: {show: true},
         serviceRetire: {show: true},
+        serviceTag: {show: true},
         serviceEdit: {show: true},
         serviceReconfigure: {show: true},
         serviceOwnership: {show: true},

--- a/tests/tagging.service.spec.js
+++ b/tests/tagging.service.spec.js
@@ -1,0 +1,70 @@
+describe.only('app.services.taggingService', function() {
+  var service;
+  var collectionsApiMock;
+
+  beforeEach(module('app.states', 'app.config', 'app.services', 'gettext'));
+
+  beforeEach(inject(function(taggingService, CollectionsApi) {
+    service = taggingService;
+    collectionsApiMock = sinon.mock(CollectionsApi);
+  }));
+
+  describe('#assignTags', function() {
+    it('makes 2 requests for each resource (assign, unassign)', function() {
+      collectionsApiMock
+        .expects('post')
+        .withArgs('services', sinon.match(/tags/), {})
+        .exactly(4);
+
+      service.assignTags('services', [{}, {}], [{ name: '/first/tag' }], [{ name: '/new/tag' }]);
+
+      collectionsApiMock.verify();
+    });
+  });
+
+  describe('#findSharedTags', function() {
+    it('returns an array of tags common between all selected resources', function() {
+      var availableTags = [{name: '/common/tag'}, {name: '/uncommon/tag1'}, {name: '/uncommon/tag2'}]
+      var resource1 = { tags: [{name: '/common/tag'}, {name: '/uncommon/tag1'}] };
+      var resource2 = { tags: [{name: '/common/tag'}, {name: '/uncommon/tag2'}] };
+
+      var sharedTags = service.findSharedTags([resource1, resource2], availableTags)
+
+      expect(sharedTags.length).to.eql(1);
+      expect(sharedTags[0].name).to.eql('/common/tag');
+    });
+  });
+
+  describe('#parseTag', function() {
+    it('converts a tag response into a useable tag object', function() {
+      var response = {
+        id: 1,
+        name: '/tag/name',
+        category: { id: 2 },
+        categorization: { display_name: 'fancy: name' },
+      };
+
+      var expected = {
+        id: 1,
+        name: '/tag/name',
+        category: { id: 2 },
+        categorization: { displayName: 'fancy: name' },
+      };
+
+      var actual = service.parseTag(response);
+      expect(actual).to.be.eql(expected);
+    });
+  });
+
+  describe('#queryAvailableTags', function() {
+    it('makes a request for all tags and filters for valid tags', function() {
+      collectionsApiMock
+        .expects('query')
+        .returns(Promise.resolve());
+
+      service.queryAvailableTags();
+
+      collectionsApiMock.verify();
+    });
+  });
+});

--- a/tests/tagging.service.spec.js
+++ b/tests/tagging.service.spec.js
@@ -1,4 +1,4 @@
-describe.only('app.services.taggingService', function() {
+describe('app.services.taggingService', function() {
   var service;
   var collectionsApiMock;
 


### PR DESCRIPTION
Add `TagEditorModal` component to be used for tagging services, catalogs, orchestration templates, etc. The tag editor allows assignment and un-assignment of tags for resources individually or in bulk. Assignment/un-assignment for a large number of resources is inefficient until a bulk tagging API is implemented.

UI improvements mentioned in manageiq/manageiq-design#6 will be implemented in a follow-up PR.

Bulk editing:
<img width="966" alt="screen shot 2016-12-19 at 5 16 51 pm" src="https://cloud.githubusercontent.com/assets/6842753/21331156/08da7cf6-c60f-11e6-9eb3-57d9927903a9.png">

Individual resource editing:
<img width="728" alt="screen shot 2016-12-19 at 5 16 27 pm" src="https://cloud.githubusercontent.com/assets/6842753/21331155/08cb9ff6-c60f-11e6-8cfe-e266e6d10876.png">

@miq-bot add_label euwe/no, enhancement

https://www.pivotaltracker.com/story/show/135042907