### PR TITLE
Pull power_status directly from the virtual column

### DIFF
--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -24,25 +24,25 @@
     };
 
     function powerOperationUnknownState(item) {
-      return item.power_state === "" && item.options.power_status === "";
+      return item.power_state === "" && item.power_status === "";
     }
 
     function powerOperationInProgressState(item) {
-      return (item.power_state !== "timeout" && item.options.power_status === "starting")
-        || (item.power_state !== "timeout" && item.options.power_status === "stopping")
-        || (item.power_state !== "timeout" && item.options.power_status === "suspending");
+      return (item.power_state !== "timeout" && item.power_status === "starting")
+        || (item.power_state !== "timeout" && item.power_status === "stopping")
+        || (item.power_state !== "timeout" && item.power_status === "suspending");
     }
 
     function powerOperationOnState(item) {
-      return item.power_state === "on" && item.options.power_status === "start_complete";
+      return item.power_state === "on" && item.power_status === "start_complete";
     }
 
     function powerOperationOffState(item) {
-      return item.power_state === "off" && item.options.power_status === "stop_complete";
+      return item.power_state === "off" && item.power_status === "stop_complete";
     }
 
     function powerOperationSuspendState(item) {
-      return item.power_state === "off" && item.options.power_status === "suspend_complete";
+      return item.power_state === "off" && item.power_status === "suspend_complete";
     }
 
     function powerOperationTimeoutState(item) {
@@ -50,32 +50,32 @@
     }
 
     function powerOperationStartTimeoutState(item) {
-      return item.power_state === "timeout" && item.options.power_status === "starting";
+      return item.power_state === "timeout" && item.power_status === "starting";
     }
 
     function powerOperationStopTimeoutState(item) {
-      return item.power_state === "timeout" && item.options.power_status === "stopping";
+      return item.power_state === "timeout" && item.power_status === "stopping";
     }
 
     function powerOperationSuspendTimeoutState(item) {
-      return item.power_state === "timeout" && item.options.power_status === "suspending";
+      return item.power_state === "timeout" && item.power_status === "suspending";
     }
 
     function startService(item) {
       item.power_state = '';
-      item.options.power_status = 'starting';
+      item.power_status = 'starting';
       powerOperation('start', item);
     }
 
     function stopService(item) {
       item.power_state = '';
-      item.options.power_status = 'stopping';
+      item.power_status = 'stopping';
       powerOperation('stop', item);
     }
 
     function suspendService(item) {
       item.power_state = '';
-      item.options.power_status = 'suspending';
+      item.power_status = 'suspending';
       powerOperation('suspend', item);
     }
 

--- a/client/app/states/services/details/details.html
+++ b/client/app/states/services/details/details.html
@@ -135,13 +135,13 @@
                 <div class="form-group">
                   <label class="control-label col-sm-4" translate>Power State</label>
                   <div class="col-sm-8">
-                    <i class="fa fa-circle" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state === 'on' && vm.service.options.power_status === 'start_complete'" uib-tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-circle" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state === 'off' && vm.service.options.power_status === 'stop_complete'" uib-tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-circle" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state === 'off' && vm.service.options.power_status === 'suspend_complete'" uib-tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.power_state === '' && vm.service.options.power_status === ''" uib-tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'starting'" uib-tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'stopping'" uib-tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
-                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state !== 'timeout' && vm.service.options.power_status === 'suspending'" uib-tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state === 'on' && vm.service.power_status === 'start_complete'" uib-tooltip="{{'Power State: On'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state === 'off' && vm.service.power_status === 'stop_complete'" uib-tooltip="{{'Power State: Off'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-circle" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state === 'off' && vm.service.power_status === 'suspend_complete'" uib-tooltip="{{'Power State: Suspended'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-question-circle" style="font-size:15px;color:#3397db;" ng-if="vm.service.power_state === '' && vm.service.power_status === ''" uib-tooltip="{{'Power State: Unknown'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#1dc58e;" ng-if="vm.service.power_state !== 'timeout' && vm.service.power_status === 'starting'" uib-tooltip="{{'Power State: Starting...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:#cc151d;" ng-if="vm.service.power_state !== 'timeout' && vm.service.power_status === 'stopping'" uib-tooltip="{{'Power State: Stopping...'|translate}}" tooltip-placement="bottom"></i>
+                    <i class="fa fa-spinner fa-pulse" style="font-size:15px;color:orangered;" ng-if="vm.service.power_state !== 'timeout' && vm.service.power_status === 'suspending'" uib-tooltip="{{'Power State: Suspending...'|translate}}" tooltip-placement="bottom"></i>
                   </div>
                 </div>
                 <div class="form-group">

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -49,6 +49,7 @@
       'service_template',
       'chargeback_report',
       'power_state',
+      'power_status',
       'created_at',
       'options',
       'name',

--- a/tests/services-details.state.spec.js
+++ b/tests/services-details.state.spec.js
@@ -22,21 +22,21 @@ describe('Dashboard', function() {
 
     PowerOperations = {
       powerOperationOnState: function (item) {
-        return item.power_state === "on" && item.options.power_status === "start_complete";
+        return item.power_state === "on" && item.power_status === "start_complete";
       },
       powerOperationUnknownState: function (item) {
-        return item.power_state === "" && item.options.power_status === "";
+        return item.power_state === "" && item.power_status === "";
       },
       powerOperationInProgressState: function (item) {
-        return (item.power_state !== "timeout" && item.options.power_status === "starting")
-          || (item.power_state !== "timeout" && item.options.power_status === "stopping")
-          || (item.power_state !== "timeout" && item.options.power_status === "suspending");
+        return (item.power_state !== "timeout" && item.power_status === "starting")
+          || (item.power_state !== "timeout" && item.power_status === "stopping")
+          || (item.power_state !== "timeout" && item.power_status === "suspending");
       },
       powerOperationOffState: function (item) {
-        return item.power_state === "off" && item.options.power_status === "stop_complete";
+        return item.power_state === "off" && item.power_status === "stop_complete";
       },
       powerOperationSuspendState: function (item) {
-        return item.power_state === "off" && item.options.power_status === "suspend_complete";
+        return item.power_state === "off" && item.power_status === "suspend_complete";
       },
       powerOperationTimeoutState: function (item) {
         return item.power_state === "timeout";
@@ -66,8 +66,8 @@ describe('Dashboard', function() {
       id: 123,
       name: 'foo',
       power_state: "",
+      power_status: "starting",
       options: {
-        power_status: "starting"
       },
       chargeback_report: {
         results: []
@@ -134,8 +134,8 @@ describe('Dashboard', function() {
 
     var service = {
         power_state: "off",
+        power_status: "stop_complete",
         options: {
-          power_status: "stop_complete"
         },
       chargeback_report: {
         results: []
@@ -183,8 +183,8 @@ describe('Dashboard', function() {
     var controller;
     var service = {
       power_state: "on",
+      power_status: "start_complete",
       options: {
-        power_status: "start_complete"
       },
       chargeback_report: {
         results: []

--- a/tests/services-list.state.spec.js
+++ b/tests/services-list.state.spec.js
@@ -48,8 +48,8 @@ describe('Dashboard', function() {
       resources: [
         {
           power_state: "",
+          power_status: "starting",
           options: {
-            power_status: "starting"
           }
         }
       ]
@@ -75,7 +75,7 @@ describe('Dashboard', function() {
     });
 
     it('sets the powerStatus value on the Service', function() {
-      expect(serviceItem.options.power_status).to.eq('starting');
+      expect(serviceItem.power_status).to.eq('starting');
     });
 
     it('does hide the kebab menu when "Start" operation is unknown', function() {
@@ -110,8 +110,8 @@ describe('Dashboard', function() {
       resources: [
         {
           power_state: "on",
+          power_status: "start_complete",
           options: {
-            power_status: "start_complete"
           }
         }
       ]
@@ -128,21 +128,21 @@ describe('Dashboard', function() {
 
     var PowerOperations = {
       powerOperationOnState: function(item) {
-        return item.power_state === "on" && item.options.power_status === "start_complete";
+        return item.power_state === "on" && item.power_status === "start_complete";
       },
       powerOperationUnknownState: function(item) {
-        return item.power_state === "" && item.options.power_status === "";
+        return item.power_state === "" && item.power_status === "";
       },
       powerOperationInProgressState: function(item) {
-        return (item.power_state !== "timeout" && item.options.power_status === "starting")
-          || (item.power_state !== "timeout" && item.options.power_status === "stopping")
-          || (item.power_state !== "timeout" && item.options.power_status === "suspending");
+        return (item.power_state !== "timeout" && item.power_status === "starting")
+          || (item.power_state !== "timeout" && item.power_status === "stopping")
+          || (item.power_state !== "timeout" && item.power_status === "suspending");
       },
       powerOperationOffState: function(item) {
-        return item.power_state === "off" && item.options.power_status === "stop_complete";
+        return item.power_state === "off" && item.power_status === "stop_complete";
       },
       powerOperationSuspendState: function(item) {
-        return item.power_state === "off" && item.options.power_status === "suspend_complete";
+        return item.power_state === "off" && item.power_status === "suspend_complete";
       },
       powerOperationTimeoutState: function(item) {
         return item.power_state === "timeout";


### PR DESCRIPTION
Power Status (unlike power_state) was being pulled from the cached options
hash, and forced the page to be reloaded after live calculating the power state.

After reloading the page again, the power_status would correctly show the 'green' or 'red' indicator.

This fix instantly updates the power_status indicator when the power_state is recalculated: e.g.
At every service detail page load.

https://bugzilla.redhat.com/show_bug.cgi?id=1394202