### PR TITLE
Removed Cursor Pointer css

### DIFF
--- a/client/assets/sass/_details-view.sass
+++ b/client/assets/sass/_details-view.sass
@@ -30,7 +30,6 @@
       max-width: 100px
       position: relative
 
-    cursor: pointer
     float: left
     margin-left: -10px
     padding: 10px 10px 10px 0


### PR DESCRIPTION
This fix is for BZ ticket https://bugzilla.redhat.com/show_bug.cgi?id=1406938 .   The cursor pointer is showing on logos that have no URL to lead them to.  I looked up all elements that referenced this class and couldn’t conclude we have used links for any of the places logos are shown. 