### PR TITLE
For angular patternfly downgrading lodash

### DIFF
--- a/client/app/services/chargeback.service.js
+++ b/client/app/services/chargeback.service.js
@@ -68,7 +68,7 @@
 
       return {
         start_date: latestDate,
-        used_cost_sum: lodash.sumBy(latestReports, 'used_cost_sum'),
+        used_cost_sum: lodash.sum(latestReports, 'used_cost_sum'),
         vms: latestReports,
       };
     }

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -196,7 +196,7 @@
 
     function resolveRequestPromises(promiseArray, type, lodash, $q) {
       $q.all(promiseArray).then(function(data) {
-        var count = lodash.sumBy(data, 'subcount');
+        var count = lodash.sum(data, 'subcount');
         vm.requestsCount[type] = count;
         vm.requestsCount.total += count;
       });

--- a/gulp/config.js
+++ b/gulp/config.js
@@ -72,7 +72,7 @@ module.exports = (function() {
         './node_modules/jquery/dist/jquery.js',
         './node_modules/components-jqueryui/jquery-ui.min.js',
         './node_modules/jquery-match-height/dist/jquery.matchHeight.js',
-        './node_modules/lodash/lodash.js',
+        './node_modules/lodash/index.js',
         './node_modules/sprintf-js/src/sprintf.js',
         './node_modules/actioncable/lib/assets/compiled/action_cable.js',
         './node_modules/google-code-prettify/bin/prettify.min.js',

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "karma-phantomjs-launcher": "1.0.2",
     "karma-read-json": "1.1.0",
     "karma-sinon": "1.0.5",
-    "lodash": "4.17.4",
+    "lodash": "3.10.1",
     "merge": "1.2.0",
     "merge-stream": "1.0.1",
     "minimist": "1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5819,15 +5819,15 @@ lodash.templatesettings@^3.0.0:
     lodash._reinterpolate "^3.0.0"
     lodash.escape "^3.0.0"
 
+lodash@3.10.1, lodash@3.x, lodash@^3.10.1, lodash@^3.2.0, lodash@^3.5.0, lodash@^3.7.0, lodash@^3.8.0, lodash@~3.10.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@3.7.x:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.7.0.tgz#3678bd8ab995057c07ade836ed2ef087da811d45"
 
-lodash@3.x, lodash@^3.10.1, lodash@^3.2.0, lodash@^3.5.0, lodash@^3.7.0, lodash@^3.8.0, lodash@~3.10.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-
-lodash@4.17.4, lodash@^4.0.0, lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 


### PR DESCRIPTION
For whenever we can go back to 4.x, `sum` will have to be changed back to `sumBy`