### PR TITLE
[EUWE] BZ: 1409959

### DIFF
--- a/client/app/config/navigation.config.js
+++ b/client/app/config/navigation.config.js
@@ -147,7 +147,7 @@
     function fetchServices() {
       var options = {
         expand: false,
-        filter: ['service_id=nil'],
+        filter: ['ancestry=null'],
         auto_refresh: true,
       };
 

--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -102,7 +102,7 @@
 
     var days30 = currentDate.setDate(currentDate.getDate() + 30);
     var date2 = 'retires_on<' + $filter('date')(days30, 'yyyy-MM-dd');
-    var options = {expand: false, filter: ['service_id=nil', date1, date2]};
+    var options = {expand: false, filter: ['ancestry=null', date1, date2]};
 
     return CollectionsApi.query('services', options);
   }
@@ -112,7 +112,7 @@
     if (!$state.navFeatures.services.show) {
       return undefined;
     }
-    var options = {expand: false, filter: ['service_id=nil', 'retired=true'] };
+    var options = {expand: false, filter: ['ancestry=null', 'retired=true'] };
 
     return CollectionsApi.query('services', options);
   }
@@ -125,7 +125,7 @@
 
     var options = {
       expand: 'resources',
-      filter: ['service_id=nil'],
+      filter: ['ancestry=null'],
       attributes: ['chargeback_report'],
     };
 

--- a/client/app/states/services/list/list.state.js
+++ b/client/app/states/services/list/list.state.js
@@ -29,7 +29,7 @@
     var options = {
       expand: 'resources',
       attributes: ['picture', 'picture.image_href', 'evm_owner.name', 'v_total_vms', 'chargeback_report'],
-      filter: ['service_id=nil'],
+      filter: ['ancestry=null'],
     };
 
     return CollectionsApi.query('services', options);


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1409959

For some reason, some other pr that merged into euwe invalidated the filter `service_id=nil` (which was being used to grab parent services).  This pr replace all instances of the invalid filter that was preventing state resolves.  The filter `ancestry=null`  is presently being used on master, though there was no single pr that resulted in this change so we are making a new pr here.

`ancestry=null` achieves the same result intended by `service_id=nil`

@simaishi @chessbyte @chriskacerguis 

@miq-bot add_label euwe/yes, bug