### PR TITLE
Add yarn test:watch task for more enjoyable testing

### DIFF
--- a/client/app/components/blueprints/blueprint-details-modal/order-list.directive.html
+++ b/client/app/components/blueprints/blueprint-details-modal/order-list.directive.html
@@ -12,7 +12,7 @@
                         dnd-moved="moved(list, $index)",
                         ng-class="{notdraggable: item.disabled}">
                         <div class="item">
-                            <img ng-if="item.image" class="item-image" src="{{item.image}}">
+                            <img ng-if="item.image" class="item-image" ng-src="{{item.image}}">
                             <i ng-if="item.bundle && !item.image" class="fa fa-gift fa-2x item-icon"></i>
                             {{item.name}}
                         </div>

--- a/client/app/components/blueprints/blueprint-editor/draggable-items.html
+++ b/client/app/components/blueprints/blueprint-editor/draggable-items.html
@@ -5,7 +5,7 @@
         data-jqyoui-options="{revert: 'invalid', helper: 'clone'}"
         ng-click="vm.clickCallbackfmDir(item)"
         uib-tooltip="{{(item.disableInToolbox ? 'Items cannot be added to the canvas more than once.' : '') | translate}}">
-        <img ng-if="item.image" src="{{item.image}}">
+        <img ng-if="item.image" ng-src="{{item.image}}">
         <i ng-if="item.icon && !item.image" class="draggable-item-icon {{item.icon}}"></i>
         <span>{{ item.name }}</span>
     </li>

--- a/client/app/components/catalogs/catalog-list.html
+++ b/client/app/components/catalogs/catalog-list.html
@@ -66,7 +66,7 @@
              items="$parent.item.serviceTemplates">
           <span class="list-view-expand-content-left ss-list-view__title-img">
             <span class="ss-list-view__title-img__center"></span>
-            <img class="ss-list-view__title-img__logo" src="{{item.picture.image_href}}" ng-if="item.picture"/>
+            <img class="ss-list-view__title-img__logo" ng-src="{{item.picture.image_href}}" ng-if="item.picture"/>
             <span class="list-item-img service-template-img" ng-if="!item.picture"></span>
           </span>
           <div class="row designer-catalog-templates-content">

--- a/client/app/components/profiles/profile-details.html
+++ b/client/app/components/profiles/profile-details.html
@@ -7,7 +7,7 @@
             <div class="col-lg-7 col-md-6 col-sm-6 col-xs-6">
               <div class="ss-details-header__title-img">
                 <span class="ss-details-header__title-img__center"></span>
-                <img class="ss-details-header__title-img__logo" src="{{vm.profile.providerImage}}" ng-if="vm.profile.providerImage"/>
+                <img class="ss-details-header__title-img__logo" ng-src="{{vm.profile.providerImage}}" ng-if="vm.profile.providerImage"/>
               </div>
               <div class="ss-details-header__title">
                 <h2>{{vm.profile.name }}</h2>

--- a/client/app/components/profiles/profiles-list.html
+++ b/client/app/components/profiles/profiles-list.html
@@ -24,7 +24,7 @@
           <span class="no-wrap">
             <span class="ss-list-view__title-img">
               <span class="ss-list-view__title-img__center"></span>
-              <img class="ss-list-view__title-img__logo" src="{{item.providerImage}}" ng-if="item.providerImage"/>
+              <img class="ss-list-view__title-img__logo" ng-src="{{item.providerImage}}" ng-if="item.providerImage"/>
             </span>
             <span uib-tooltip="{{item.ext_management_system.name}}" tooltip-placement="bottom">
               {{item.ext_management_system.name}}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,8 @@
-var webpackConfig = require('./config/webpack.test.js');
+'use strict';
+
+const webpackConfig = require('./config/webpack.test.js');
 
 module.exports = function(config) {
-  'use strict';
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: './',
@@ -29,20 +30,21 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      {pattern: './client/app.js', watched: false},
-      {pattern: './node_modules/phantomjs-polyfill/bind-polyfill.js', watched: false},
-      {pattern: './node_modules/angular-mocks/angular-mocks.js', watched: false},
-      {pattern: './node_modules/bardjs/bard.js', watched: false},
-      {pattern: './node_modules/sinon/pkg/sinon.js', watched: false},
-      {pattern: './node_modules/karma-read-json/karma-read-json.js', watched: false},
-      {pattern: './node_modules/bardjs/bard.js', watched: false},
-      {pattern: './tests/test-helpers/*.js', watched: false},
-      {pattern: './tests/**/*.js', watched: false},
-      {pattern: './tests/**/*.json', watched: false, included: false, served: true, nocache: false}
+      {pattern: './client/app.js'},
+      {pattern: './node_modules/phantomjs-polyfill/bind-polyfill.js'},
+      {pattern: './node_modules/angular-mocks/angular-mocks.js'},
+      {pattern: './node_modules/bardjs/bard.js'},
+      {pattern: './node_modules/sinon/pkg/sinon.js'},
+      {pattern: './node_modules/karma-read-json/karma-read-json.js'},
+      {pattern: './node_modules/bardjs/bard.js'},
+      {pattern: './tests/test-helpers/*.js'},
+      {pattern: './tests/**/*.js'},
+      {pattern: './tests/**/*.json', included: false, served: true, nocache: false},
+      {pattern: './client/assets/images/providers/*.svg', included: false, served: true, nocache: false},
     ],
 
     proxies: {
-      '/images/': 'http://localhost:9876/client/assets/images/',
+      '/images/': '/images/',
     },
 
     // preprocess matching files before serving them to the browser

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "webpack --bail --progress --profile --config config/webpack.prod.js",
     "start": "webpack-dev-server --open --progress --config config/webpack.dev.js",
-    "test": "karma start karma.conf.js --single-run"
+    "test": "karma start karma.conf.js --single-run",
+    "test:watch": "karma start --auto-watch --no-single-run"
   },
   "devDependencies": {
     "actioncable": "5.0.1",

--- a/tests/components/rules-list.component.spec.js
+++ b/tests/components/rules-list.component.spec.js
@@ -20,7 +20,7 @@ describe('Component: rulesList', function() {
 
       element = angular.element('<rules-list arbitration-rules="arbitrationRules" fields="fields" profiles="profiles"/>');
       $compile(element)(scope);
-      
+
       Session.create({
         auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
       });
@@ -83,9 +83,9 @@ describe('Component: rulesList', function() {
           id: '4'
         }
       ];
-      
+
       editRulesSpy = sinon.stub(RulesState, 'editRules').returns(Promise.resolve(successResponse));
-      
+
       scope.$apply();
     }));
 


### PR DESCRIPTION
Add `yarn test:watch` which gives you a testing mode much faster than
simply running `yarn test`. With test watch webpack only needs to do the
expensive bundle once and then will watch file changes with incremental
builds, making subsequent test runs very quick.

For a really enjoyable testing experience use `describe.only` for the
test block that you are focused on!

This change also contains a few karma configuration tweaks to facilitate
file watching and to remove all the noisy warnings from the test output.

<img width="795" alt="screen shot 2017-01-13 at 11 57 21 am" src="https://cloud.githubusercontent.com/assets/6842753/21941381/83973eb2-d996-11e6-85a8-d736b66caa29.png">


Also fixed some low-hanging bugs that were using `src` instead of
`ng-src` for attrs that contained angular expressions.