### PR TITLE
Minify css bundle output from `yarn build`

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -38,7 +38,7 @@ module.exports = {
   },
 
   // Output source maps suitable for development
-  devtool: 'inline-source-map',
+  devtool: 'cheap-module-inline-source-map',
 
   module: {
 
@@ -80,8 +80,8 @@ module.exports = {
         loader: ExtractTextWebpackPlugin.extract({
           fallbackLoader: 'style-loader',
           loader: [
-            'css-loader?importLoaders=2&sourceMap',
-            'postcss-loader?sourceMap=inline',
+            'css-loader?importLoaders=2&sourceMap=true',
+            'postcss-loader',
             'sass-loader?sourceMap'
           ],
         }),

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -1,6 +1,7 @@
 const webpack = require('webpack');
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plugin');
 
 const config = require('./webpack.dev.js');
 
@@ -9,7 +10,7 @@ config.output.chunkFilename = '[name].[hash].js';
 config.output.filename = '[name].[hash].js';
 
 // Source maps suitable for production use
-config.devtool = 'source-map';
+config.devtool = 'cheap-module-source-map';
 
 config.plugins.push(
   new webpack.NoErrorsPlugin(),
@@ -25,7 +26,9 @@ config.plugins.push(
   new HtmlWebpackPlugin({
     base: '/ui/service/',
     template: '../client/index.ejs',
-  })
+  }),
+
+  new OptimizeCssAssetsWebpackPlugin()
 );
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "ngtemplate-loader": "1.3.1",
     "no-vnc": "kanaka/noVNC#0.6.1",
     "node-sass": "4.1.1",
+    "optimize-css-assets-webpack-plugin": "1.3.0",
     "phantomjs-prebuilt": "2.1.14",
     "postcss-loader": "1.2.1",
     "q": "1.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1624,7 +1624,7 @@ cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
-"cssnano@>=2.6.1 <4":
+"cssnano@>=2.6.1 <4", cssnano@^3.4.0:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/cssnano/-/cssnano-3.10.0.tgz#4f38f6cea2b9b17fa01490f23f1dc68ea65c1c38"
   dependencies:
@@ -4606,6 +4606,14 @@ optimist@^0.6.1, optimist@~0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
+optimize-css-assets-webpack-plugin@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/optimize-css-assets-webpack-plugin/-/optimize-css-assets-webpack-plugin-1.3.0.tgz#331b3dc7ac0b2b3597f68d18fd555f5a0c81b15c"
+  dependencies:
+    cssnano "^3.4.0"
+    underscore "^1.8.3"
+    webpack-sources "^0.1.0"
+
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
@@ -6301,6 +6309,10 @@ ultron@1.0.x:
 unc-path-regex@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
+
+underscore@^1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Add an additional webpack plugin to minify the output css bundle when
building for production.

In addition adjust source map settings for versions that are faster and
smaller. Tested with latest version of Chrome and the source maps worked
pretty well, with other browsers/versions your mileage may vary.

https://www.pivotaltracker.com/story/show/137196541