### PR TITLE
Output js and css in js/styles dirs respectively

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -14,8 +14,8 @@ module.exports = {
   },
 
   output: {
-    chunkFilename: '[name].bundle.js',
-    filename: '[name].bundle.js',
+    chunkFilename: 'js/[name]-[hash].chunk.js',
+    filename: 'js/[name]-[hash].js',
     path: dist,
   },
 
@@ -71,7 +71,22 @@ module.exports = {
       // font/images loaders: if smaller than limit embed as data uri
       {
         test: /\.(png|jpg|gif|svg|woff|ttf|eot)/,
-        use: ['url-loader?limit=20480&name=data/[hash].[ext]'],
+        use: [
+          {
+            loader: 'url-loader',
+            options: {
+              limit: 20480,
+              name: 'styles/[hash].[ext]',
+
+              // Determine publicPath dynamically because in production, assets
+              // must be relative to `/ui/service/`
+              publicPath: url => {
+                const path = process.env.NODE_ENV === 'production' ? '/ui/service/' : '/';
+                return path + url;
+              },
+            },
+          },
+        ],
       },
 
       // css loaders: extract styles to a separate bundle
@@ -92,7 +107,7 @@ module.exports = {
   plugins: [
 
     // Extract 'styles.css' after being processed by loaders into a single bundle
-    new ExtractTextWebpackPlugin('[name].[hash].css'),
+    new ExtractTextWebpackPlugin('styles/[name]-[hash].css'),
 
     // Copy all public assets to webpack's processing context
     new CopyWebpackPlugin([

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -5,10 +5,6 @@ const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plug
 
 const config = require('./webpack.dev.js');
 
-// Use hashes in filenames for cache busting
-config.output.chunkFilename = '[name].[hash].js';
-config.output.filename = '[name].[hash].js';
-
 // Source maps suitable for production use
 config.devtool = 'cheap-module-source-map';
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "version": "1.0.1",
   "scripts": {
-    "build": "webpack --bail --progress --profile --config config/webpack.prod.js",
+    "build": "NODE_ENV=\"production\" webpack --bail --progress --profile --config config/webpack.prod.js",
     "start": "webpack-dev-server --open --progress --config config/webpack.dev.js",
     "test": "yarn vet && karma start karma.conf.js --single-run",
     "test:watch": "karma start --auto-watch --no-single-run",


### PR DESCRIPTION
Modify webpack configuration so that build output for js will go into a
js directory while css output will go a styles directory.

In addition output filenames were modified to consistently follow the
same format:

`(js|styles)/[name]-[hash].(js|css)`