### PR TITLE
Add several missing ngInject annotations for blueprints

### DIFF
--- a/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal-service.factory.js
+++ b/client/app/components/blueprints/blueprint-details-modal/blueprint-details-modal-service.factory.js
@@ -41,6 +41,7 @@
         return action;
       }
 
+      /** @ngInject */
       function resolveServiceCatalogs(CollectionsApi) {
         var options = {
           expand: 'resources',
@@ -50,6 +51,7 @@
         return CollectionsApi.query('service_catalogs', options);
       }
 
+      /** @ngInject */
       function resolveServiceDialogs(CollectionsApi) {
         var options = {
           expand: 'resources',
@@ -60,6 +62,7 @@
         return CollectionsApi.query('service_dialogs', options);
       }
 
+      /** @ngInject */
       function resolveTenants(CollectionsApi) {
         var options = {
           expand: 'resources',

--- a/client/app/components/service-explorer/service-explorer.component.js
+++ b/client/app/components/service-explorer/service-explorer.component.js
@@ -508,12 +508,14 @@
 
       ModalService.open(modalOptions);
 
+      /** @ngInject */
       function resolveUsers(CollectionsApi) {
         var options = {expand: 'resources', attributes: ['userid', 'name'], sort_by: 'name', sort_options: 'ignore_case'};
 
         return CollectionsApi.query('users', options);
       }
 
+      /** @ngInject */
       function resolveGroups(CollectionsApi) {
         var options = {expand: 'resources', attributes: ['description'], sort_by: 'description', sort_options: 'ignore_case'};
 

--- a/client/app/states/designer/blueprints/list/list.state.js
+++ b/client/app/states/designer/blueprints/list/list.state.js
@@ -37,6 +37,7 @@
     return CollectionsApi.query('blueprints', options);
   }
 
+  /** @ngInject */
   function resolveServiceCatalogs(CollectionsApi) {
     var options = {
       expand: 'resources',
@@ -47,6 +48,7 @@
     return CollectionsApi.query('service_catalogs', options);
   }
 
+  /** @ngInject */
   function resolveTenants(CollectionsApi) {
     var options = {
       expand: 'resources',

--- a/client/app/states/marketplace/list/list.state.js
+++ b/client/app/states/marketplace/list/list.state.js
@@ -38,6 +38,7 @@
     return CollectionsApi.query('service_templates', options);
   }
 
+  /** @ngInject */
   function resolveServiceCatalogs(CollectionsApi) {
     var options = {
       expand: 'resources',

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -241,12 +241,14 @@
 
       ModalService.open(modalOptions);
 
+      /** @ngInject */
       function resolveUsers(CollectionsApi) {
         var options = {expand: 'resources', attributes: ['userid', 'name'], sort_by: 'name', sort_options: 'ignore_case'};
 
         return CollectionsApi.query('users', options);
       }
 
+      /** @ngInject */
       function resolveGroups(CollectionsApi) {
         var options = {expand: 'resources', attributes: ['description'], sort_by: 'description', sort_options: 'ignore_case'};
 


### PR DESCRIPTION
When explicit ngInject annotations are missing, dependency injection
does not work properly when the JS is minified. These annotations were
missing leading to the behavior observed in this PT ticket.

https://www.pivotaltracker.com/story/show/137820477