### PR TITLE
Bug Fix for Service Reconfigure page not pre-populated

### DIFF
--- a/client/app/states/services/reconfigure/reconfigure.html
+++ b/client/app/states/services/reconfigure/reconfigure.html
@@ -15,8 +15,8 @@
         <div class="row">
           <div class="col-lg-8 col-md-8 col-sm-8 col-xs-8">
             <div class="ss-details-header__title">
-              <h2>{{ ::vm.serviceTemplate.name }}</h2>
-              <h4 ng-bind-html="::vm.serviceTemplate.long_description || vm.serviceTemplate.description"></h4>
+              <h2>{{ ::vm.service.name }}</h2>
+              <h4 ng-bind-html="::vm.service.long_description || vm.service.description"></h4>
             </div>
           </div>
           <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 ss-details-header__actions">
@@ -34,7 +34,7 @@
         <div class="col-md-12">
           <div class="row">
             <div ng-repeat="dialog in ::vm.dialogs">
-              <dialog-content dialog="dialog"></dialog-content>
+              <dialog-content dialog="dialog" options="vm.service.options.dialog"></dialog-content>
             </div>
           </div>
         </div>


### PR DESCRIPTION
This is the fix for a bug reported that the service reconfigure page does not populate dialog or other fields on the reconfigure page.  Pivotal Ticket https://www.pivotaltracker.com/story/show/136522459