### PR TITLE
Add clear button to retire service modals

### DIFF
--- a/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -30,6 +30,7 @@ function ComponentController($scope, $state, CollectionsApi, EventNotifications,
 
   vm.dateOptions = {
     autoclose: true,
+    clearBtn: true,
     todayBtn: 'linked',
     todayHighlight: true,
     startDate: new Date(),
@@ -67,17 +68,8 @@ function ComponentController($scope, $state, CollectionsApi, EventNotifications,
   function save() {
     var data = {
       action: 'retire',
-      resources: null,
+      resources: vm.services.map(setRetire),
     };
-
-    if (vm.isService) {
-      data.resources = [vm.modalData];
-    } else {
-      var resources = [];
-      angular.copy(vm.services, resources);
-      lodash.forEach(resources, setRetire);
-      data.resources = resources;
-    }
 
     CollectionsApi.post('services', '', {}, data).then(saveSuccess, saveFailure);
 
@@ -92,8 +84,11 @@ function ComponentController($scope, $state, CollectionsApi, EventNotifications,
     }
 
     function setRetire(service) {
-      service.date = vm.modalData.date;
-      service.warn = vm.modalData.warn;
+      const copy = angular.copy(service);
+      copy.date = vm.modalData.date || '';
+      copy.warn = vm.modalData.warn;
+
+      return copy;
     }
   }
 


### PR DESCRIPTION
Adds a clear button to the bootstrap datepicker for the retire service
modals. This allows a user to remove a previously set retirement date.

Note that this will only work if you actually click the clear button, if
you simply delete the previous input and then click save, the previous
selected value from the datepicker will be submitted.

https://bugzilla.redhat.com/show_bug.cgi?id=1406944

A separate PR will be made for Euwe since there will likely be
conflicts.

@miq-bot add_label euwe/yes, bug