### PR TITLE
[Euwe] Add clear button to retire service modals

### DIFF
--- a/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
+++ b/client/app/components/retire-service-modal/retire-service-modal-service.factory.js
@@ -50,6 +50,7 @@
 
     vm.dateOptions = {
       autoclose: true,
+      clearBtn: true,
       todayBtn: 'linked',
       todayHighlight: true,
       startDate: new Date(),
@@ -69,7 +70,10 @@
     }
 
     function retireService() {
-      CollectionsApi.post('services', vm.service.id, {}, vm.modalData).then(retireSuccess, retireFailure);
+      var data = angular.copy(vm.modalData);
+      data.resource.date = data.resource.date ? data.resource.date : '';
+
+      CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure);
 
       function retireSuccess() {
         $modalInstance.close();

--- a/client/index.html
+++ b/client/index.html
@@ -23,7 +23,6 @@
   </style>
   <!-- build:css styles/lib.css -->
   <!-- bower:css -->
-  <link rel="stylesheet" href="/bower_components/bootstrap-combobox/css/bootstrap-combobox.css" />
   <link rel="stylesheet" href="/bower_components/bootstrap-datepicker/dist/css/bootstrap-datepicker3.css" />
   <link rel="stylesheet" href="/bower_components/bootstrap-select/dist/css/bootstrap-select.css" />
   <link rel="stylesheet" href="/bower_components/bootstrap-switch/dist/css/bootstrap3/bootstrap-switch.css" />
@@ -33,6 +32,7 @@
   <link rel="stylesheet" href="/bower_components/datatables-colvis/css/dataTables.colVis.css" />
   <link rel="stylesheet" href="/bower_components/google-code-prettify/bin/prettify.min.css" />
   <link rel="stylesheet" href="/bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />
+  <link rel="stylesheet" href="/bower_components/patternfly-bootstrap-combobox/css/bootstrap-combobox.css" />
   <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly.css" />
   <link rel="stylesheet" href="/bower_components/patternfly/dist/css/patternfly-additions.css" />
   <link rel="stylesheet" href="/bower_components/angular-patternfly/dist/styles/angular-patternfly.css" />
@@ -75,7 +75,6 @@
   <script src="/bower_components/angular-gettext/dist/angular-gettext.js"></script>
   <script src="/bower_components/lodash/lodash.js"></script>
   <script src="/bower_components/bootstrap/dist/js/bootstrap.js"></script>
-  <script src="/bower_components/bootstrap-combobox/js/bootstrap-combobox.js"></script>
   <script src="/bower_components/bootstrap-datepicker/dist/js/bootstrap-datepicker.min.js"></script>
   <script src="/bower_components/bootstrap-select/dist/js/bootstrap-select.js"></script>
   <script src="/bower_components/bootstrap-switch/dist/js/bootstrap-switch.js"></script>
@@ -90,6 +89,7 @@
   <script src="/bower_components/moment/moment.js"></script>
   <script src="/bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"></script>
   <script src="/bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+  <script src="/bower_components/patternfly-bootstrap-combobox/js/bootstrap-combobox.js"></script>
   <script src="/bower_components/patternfly-bootstrap-treeview/dist/bootstrap-treeview.min.js"></script>
   <script src="/bower_components/patternfly/dist/js/patternfly.js"></script>
   <script src="/bower_components/angular-patternfly/dist/angular-patternfly.js"></script>
@@ -185,6 +185,7 @@
   <script src="/client/app/services/navigation.provider.js"></script>
   <script src="/client/app/services/orders-state.service.js"></script>
   <script src="/client/app/services/polling.service.js"></script>
+  <script src="/client/app/services/poweroperations.service.js"></script>
   <script src="/client/app/services/product-info.service.js"></script>
   <script src="/client/app/services/profiles-state.service.js"></script>
   <script src="/client/app/services/rbac.service.js"></script>


### PR DESCRIPTION
Adds a clear button to the bootstrap datepicker for the retire service
modals. This allows a user to remove a previously set retirement date.

Note that this will only work if you actually click the clear button, if
you simply delete the previous input and then click save, the previous
selected value from the datepicker will be submitted.

The modifications to `client/index.html` come from running
`npm install`. It appears that somewhere along the line those changes
weren't committed. It shouldn't have any side effects seeing as they are
automatically injected when running `npm install` anyways.