### PR TITLE
Travis CI fix for when no Saucelabs credentials are provided for a forked repo

### DIFF
--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -58,6 +58,10 @@ var config = {
 };
 
 if (process.env.TRAVIS) {
+  if (typeof process.env.SAUCE_USERNAME === 'undefined') {
+    console.log("E2E Testing was not run because Sauce credentials are not set.  Please set in order to test");
+    process.exit();
+  }
   config.sauceUser = process.env.SAUCE_USERNAME;
   config.sauceKey = process.env.SAUCE_ACCESS_KEY;
   config.capabilities = {
@@ -66,7 +70,7 @@ if (process.env.TRAVIS) {
     'build': process.env.TRAVIS_BUILD_NUMBER
   };
 }
-else{
+else {
   config.seleniumAddress = env.seleniumAddress;
 }
 


### PR DESCRIPTION
This fixes an issue where if you fork the repo and are running travis ci on it, it would fail e2e tests.  This keeps e2e tests from running in travis if you have not set SauceLabs credentials.  Pivotal Ticket - https://www.pivotaltracker.com/story/show/138245079