### PR TITLE
Updated polling on Service Details page to support tags and also resources

### DIFF
--- a/client/app/components/services/service-details/service-details.component.js
+++ b/client/app/components/services/service-details/service-details.component.js
@@ -15,7 +15,10 @@ function ComponentController($state, CollectionsApi, EventNotifications, Chargeb
   var vm = this;
 
   vm.$onInit = activate();
-
+  vm.$onChanges = function(changesObj) {
+    createResourceGroups();
+  };
+  
   function activate() {
     Chargeback.processReports(vm.service);
 

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -73,9 +73,8 @@ function resolveTags($stateParams, taggingService) {
 }
 
 /** @ngInject */
-function StateController($scope, $stateParams, service, tags, CollectionsApi, Polling) {
+function StateController($scope, $stateParams, service, tags, CollectionsApi, Polling, taggingService) {
   var vm = this;
-
   vm.service = service;
   vm.tags = tags;
   vm.pollingInterval = 10000;
@@ -88,6 +87,9 @@ function StateController($scope, $stateParams, service, tags, CollectionsApi, Po
   function startPollingService() {
     resolveService($stateParams, CollectionsApi).then(function (data) {
       vm.service = data;
+    });
+    resolveTags($stateParams, taggingService).then(function (data) {
+      vm.tags = data;
     });
   }
 }


### PR DESCRIPTION
This is a enhancement to enable polling refresh of resources and tags on the service details page.  Part of PV https://www.pivotaltracker.com/story/show/134430901