### PR TITLE
Update webpack config to be aware of skinning

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -58,3 +58,10 @@ require('./assets/sass/styles.sass');
 
 // Angular templates
 requireAll(require.context('./app', true, /\.html$/));
+
+// Skin overrides
+try {
+  requireAll(require.context('./skin', true, /\.(js|css)$/));
+} catch (e) {
+  // Skin dependencies are not linked
+}

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextWebpackPlugin = require('extract-text-webpack-plugin');
@@ -7,6 +8,7 @@ const root = path.resolve(__dirname, '../client');
 const dist = path.resolve(__dirname, '../../manageiq/public/ui/service');
 const nodeModules = path.resolve(__dirname, '../node_modules');
 const host = process.env.PROXY_HOST || process.env.MOCK_API_HOST || '[::1]:3000'
+const hasSkinImages = fs.existsSync(`${root}/skin/images`);
 console.log("Backend proxied on "+host);
 
 module.exports = {
@@ -117,6 +119,9 @@ module.exports = {
       {from: `${root}/gettext`, to: 'gettext'},
       {from: `${nodeModules}/no-vnc`, to: 'vendor/no-vnc'},
       {from: `${nodeModules}/spice-html5-bower`, to: 'vendor/spice-html5-bower'},
+
+      // Override images with skin replacements if they exist
+      {from: hasSkinImages ? `${root}/skin/images` : '', to: 'images', force: true},
     ]),
 
     // Generate index.html from template with script/link tags for bundles


### PR DESCRIPTION
Allow images from `client/app/skin/images` to override default images. Include all *.js and *.css files from `client/app/skin/**` as the last step of the bundle.

I believe this will fix the skinning issues provided productization follows the steps outlined in the skinning README. To test locally:

1. `skin-sample/link.sh` from the root dir of the SUI.
2. `yarn start` (restart if already running)
3. Verify that images, styles, and selected text have been skinned.
4. `skin-sample/unlink.sh` to restore.

Still trying to figure out how to prevent the warning emitted when running without a skin.

@AllenBW @himdel 
@miq-bot add_label euwe/no, bug