### PR TITLE
Fix warnings that `./skin` does not exist

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -59,9 +59,5 @@ require('./assets/sass/styles.sass');
 // Angular templates
 requireAll(require.context('./app', true, /\.html$/));
 
-// Skin overrides
-try {
-  requireAll(require.context('./skin', true, /\.(js|css)$/));
-} catch (e) {
-  // Skin dependencies are not linked
-}
+// Skin overrides, require all js and css files within `client/skin`
+requireAll(require.context('./', true, /skin\/.*\.(js|css)$/));


### PR DESCRIPTION
Adjust the skin override requires to use a regex that will work in both
skinned and non-skinned modes.

Works the same way but without the warnings.

@miq-bot add-label euwe/no, bug