### PR TITLE
PT#138821445 - Webpack-build passes with symlinked folders

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -142,6 +142,10 @@ module.exports = {
     }),
   ],
 
+  resolve: {
+    symlinks: false,
+  },
+
   // Disables noisy performance warnings. While the warnings are important, it
   // is not feasible to satisfy the recommendations until we start code splitting
   performance: {


### PR DESCRIPTION
https://webpack.js.org/configuration/resolve/#resolve-symlinks
So the way I understand this, we *were* resolving the symlinked folder at its location, doesn't have all da config goodness we need for things to not 💥, setting this to false, we resolve the symlinked folder where the 🐑 go to 🛌 (ie root of app).

Fixes skinning, breaks nothing, all 💃 🌮 here!

@jjlangholtz @chriskacerguis @simaishi 

@miq-bot add_label bug, euwe/no

https://www.pivotaltracker.com/story/show/138821445