### PR TITLE
[WIP] Add Last Message to requests explorer

### DIFF
--- a/client/app/components/request-explorer/request-explorer.component.js
+++ b/client/app/components/request-explorer/request-explorer.component.js
@@ -101,7 +101,15 @@ function ComponentController($state, CollectionsApi, RequestsState, ListView, $f
 
   function fetchData(limit, offset, refresh) {
     var filter = [];
-    var attributes = ['picture', 'picture.image_href', 'approval_state', 'created_on', 'description', 'requester_name'];
+    var attributes = [
+      'approval_state',
+      'created_on',
+      'description',
+      'message',
+      'picture',
+      'picture.image_href',
+      'requester_name',
+    ];
     var options = {
       expand: 'resources',
       limit: limit,

--- a/client/app/components/request-explorer/request-explorer.html
+++ b/client/app/components/request-explorer/request-explorer.html
@@ -19,46 +19,54 @@
 <div class="list-view-container section-container paged-container">
   <loading status="vm.loading"></loading>
   <div pf-list-view ng-if="!vm.loading" id="requestList" config="vm.listConfig" items="vm.listDataCopy">
-    <div class="row">
-      <div class="col-lg-4 col-md-5 col-sm-8 col-xs-8">
-        <span class="no-wrap">
-          <span class="ss-list-view__title-img">
-            <span class="ss-list-view__title-img__center"></span>
-            <img class="ss-list-view__title-img__logo" ng-src="{{ item.picture.image_href }}"
-                 ng-if="item.picture.image_href"/>
-            <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if="!item.picture.image_href"/>
-          </span>
+    <div class="list-view-pf-left">
+      <span class="ss-list-view__title-img">
+        <span class="ss-list-view__title-img__center"></span>
+        <img class="ss-list-view__title-img__logo" ng-src="{{ item.picture.image_href }}" ng-if="item.picture.image_href"/>
+        <img class="ss-list-view__title-img__logo" src="images/service.png" ng-if="!item.picture.image_href"/>
+      </span>
+    </div>
+    <div class="list-view-pf-body">
+      <div class="list-view-pf-stacked">
+        <div class="list-group-item-heading">
           {{ item.description }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
-        <span class="no-wrap">
-          <strong translate>ID </strong>&nbsp;{{ item.id }}
-        </span>
-      </div>
-      <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
-        <span class="no-wrap">
-          <strong translate>Requester </strong>&nbsp;{{ item.requester_name }}
-        </span>
-      </div>
-      <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
-        <span class="no-wrap">
-          <strong translate>Requested </strong>&nbsp;{{ item.created_on | date }}
-        </span>
-      </div>
-      <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
-        <span class="text-capitalize no-wrap">
-          <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'"
-                uib-tooltip="{{'The current approval status of the request'|translate}}"
-                tooltip-placement="bottom"></span>
-          <span class="pficon pficon-error-circle-o" ng-if="item.approval_state == 'denied'"
-                uib-tooltip="{{'The current approval status of the request'|translate}}"
-                tooltip-placement="bottom"></span>
-          <span class="pficon pficon-ok" ng-if="item.approval_state == 'approved'"
-                uib-tooltip="{{'The current approval status of the request'|translate}}"
-                tooltip-placement="bottom"></span>
-          {{ item.approval_state }}
-        </span>
+        </div>
+        <div class="list-group-item-text">
+          <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
+            <span class="no-wrap">
+              {{ item.id }}
+            </span>
+          </div>
+          <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
+            <span class="no-wrap">
+              {{ item.requester_name }}
+            </span>
+          </div>
+          <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
+            <span class="no-wrap">
+              {{ item.created_on | date }}
+            </span>
+          </div>
+          <div class="col-lg-4 col-md-5 col-sm-8 col-xs-8">
+            <span class="no-wrap">
+              {{ item.message }}
+            </span>
+          </div>
+          <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
+            <span class="text-capitalize no-wrap">
+              <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'"
+                    uib-tooltip="{{'The current approval status of the request'|translate}}"
+                    tooltip-placement="bottom"></span>
+              <span class="pficon pficon-error-circle-o" ng-if="item.approval_state == 'denied'"
+                    uib-tooltip="{{'The current approval status of the request'|translate}}"
+                    tooltip-placement="bottom"></span>
+              <span class="pficon pficon-ok" ng-if="item.approval_state == 'approved'"
+                    uib-tooltip="{{'The current approval status of the request'|translate}}"
+                    tooltip-placement="bottom"></span>
+              {{ item.approval_state }}
+            </span>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -109,6 +109,19 @@
   margin-bottom: 2px
   margin-top: 2px
 
+.list-view-pf-stacked
+  width: 100%
+
+  .list-group-item-heading
+    font-size: 14px
+
+  .list-group-item-text
+    padding-top: 8px
+    width: 100%
+
+    & > div
+      padding-left: 0
+
 +block(ss-list-view)
   +element(title-img)
     +element(logo)


### PR DESCRIPTION
Update request explorer html to show the `Last Message` field. Due to
the length of the new field, the list group items needed to be modified.
This first stab breaks each group item into two rows. Also looking into
expandable rows to see if that is a better fit.

https://bugzilla.redhat.com/show_bug.cgi?id=1365253
https://www.pivotaltracker.com/story/show/138616171

First Stab:
<img width="1179" alt="screen shot 2017-02-07 at 1 20 05 pm" src="https://cloud.githubusercontent.com/assets/6842753/22707083/950647c6-ed3f-11e6-917e-c70693792c2b.png">

@miq-bot add_label euwe/no, bug, wip