### PR TITLE
Disabled action when console button is clicked

### DIFF
--- a/client/app/components/services/service-details/service-details.component.js
+++ b/client/app/components/services/service-details/service-details.component.js
@@ -284,11 +284,15 @@ function ComponentController($state, $window, CollectionsApi, EventNotifications
   }
 
   function openConsole(item) {
-    Consoles.open(item.id);
+    if (item['supports_console?'] && item.power_state === 'on') {
+      Consoles.open(item.id);
+    }
   }
 
   function openCockpit(item) {
-    $window.open('http://' + item.ipaddresses[0] + ':9090');
+    if (item['supports_cockpit?'] && item.power_state === 'on') {
+      $window.open('http://' + item.ipaddresses[0] + ':9090');
+    }
   }
 
   function gotoComputeResource(resource) {


### PR DESCRIPTION
This is a fix for the scenario that the console and cockpit are unavailable and were still allowing the buttons to be clicked and the actions to be executed.  PV https://www.pivotaltracker.com/story/show/139248149