### PR TITLE
Ensure radio buttons that should be visible are actually visible

### DIFF
--- a/client/app/components/dialog-content/dialog-content.html
+++ b/client/app/components/dialog-content/dialog-content.html
@@ -87,12 +87,12 @@
                     </select>
 
                     <span
-                      ng-if="vm.inputDisabled"
+                      ng-if="dialogField.read_only || vm.inputDisabled"
                       ng-switch-when="DialogFieldRadioButton"
                       class="btn-group">
                       <label>{{ vm.parsedOptions[dialogField.name] }}</label>
                     </span>
-                    <span ng-if="vm.inputDisabled === false"
+                    <span ng-if="dialogField.read_only === false || vm.inputDisabled === false"
                       ng-switch-when="DialogFieldRadioButton"
                       class="btn-group">
                       <label


### PR DESCRIPTION
While I was testing https://github.com/ManageIQ/manageiq-ui-service/pull/503 I found that radio buttons just weren't appearing even though they were supposed to be. I've changed the logic to look at when they should be visible to be consistent with the other field types.

Before:
![screen shot 2017-02-09 at 10 52 23 am](https://cloud.githubusercontent.com/assets/164557/22798322/53f14ab0-eeb6-11e6-8d4f-17cbaee73c94.png)

After:
![screen shot 2017-02-09 at 10 51 46 am](https://cloud.githubusercontent.com/assets/164557/22798327/5959b38e-eeb6-11e6-90d9-adaa0ccbbf66.png)

