### PR TITLE
Add asterisk to required catalog edit field

### DIFF
--- a/client/app/components/catalogs/catalog-editor.html
+++ b/client/app/components/catalogs/catalog-editor.html
@@ -32,7 +32,7 @@
                   </div>
                 </div>
                 <div class="form-group">
-                  <label class="control-label col-sm-4" translate>Description</label>
+                  <label class="control-label col-sm-4">{{'Description' | translate}} *</label>
                   <div class="col-sm-8">
                     <input id="catalog-editor-description"
                            class="form-control"

--- a/client/app/components/process-requests-modal/process-requests-modal.html
+++ b/client/app/components/process-requests-modal/process-requests-modal.html
@@ -8,7 +8,7 @@
 </div>
 <div class="modal-body">
   <form ng-if="vm.modalType !== 'invalid'" class="form-horizontal">
-    <div pf-form-group pf-input-class="col-sm-10" pf-label="* {{'Note'|translate}}">
+    <div pf-form-group pf-input-class="col-sm-10" pf-label="{{'Note'|translate}} *">
         <textarea id="description" name="reason" ng-model="vm.modalData.reason" required>
           {{ vm.modalData.reason }}
         </textarea>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/139408261
Adds a asterisk to required field: https://github.com/patternfly/patternfly-design/blob/master/pattern-library/forms-and-controls/forms/design/design.md

This also updates an asterisk that was place preceding required field (as directed [here](https://github.com/ManageIQ/manageiq-ui-service/pull/397#issuecomment-268635687))
## After
![image](https://cloud.githubusercontent.com/assets/6640236/22830702/7fb4310c-ef75-11e6-8f57-003467826f64.png)
![image](https://cloud.githubusercontent.com/assets/6640236/22830736/994dafda-ef75-11e6-915a-a0004a45f7a8.png)


