### PR TITLE
Fix test:watch failures due to leaky state

### DIFF
--- a/tests/catalogs/catalog-editor.component.spec.js
+++ b/tests/catalogs/catalog-editor.component.spec.js
@@ -2,7 +2,7 @@ describe('Component: catalogEditor', function() {
 
   beforeEach(function() {
     module('app.core', 'app.states');
-    bard.inject('CatalogsState', '$state', 'Session', '$httpBackend');
+    bard.inject('CatalogsState', '$state', '$httpBackend');
   });
 
   describe('with $compile', function() {
@@ -23,9 +23,6 @@ describe('Component: catalogEditor', function() {
 
       scope = $rootScope.$new();
 
-      Session.create({
-        auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-      });
       $httpBackend.whenGET('').respond(200);
 
       scope.catalog = readJSON(mockDir + 'editCatalog.json');

--- a/tests/components/rules-list.component.spec.js
+++ b/tests/components/rules-list.component.spec.js
@@ -2,7 +2,7 @@ describe('Component: rulesList', function() {
 
   beforeEach(function() {
     module('app.components');
-    bard.inject('RulesState', 'Session', '$httpBackend');
+    bard.inject('RulesState', '$httpBackend');
   });
 
   describe('with $compile', function() {
@@ -21,9 +21,6 @@ describe('Component: rulesList', function() {
       element = angular.element('<rules-list arbitration-rules="arbitrationRules" fields="fields" profiles="profiles"/>');
       $compile(element)(scope);
 
-      Session.create({
-        auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-      });
       $httpBackend.whenGET('').respond(200);
 
       scope.arbitrationRules = [

--- a/tests/components/services-details.component.spec.js
+++ b/tests/components/services-details.component.spec.js
@@ -2,7 +2,6 @@ describe('Component: ServiceDetails', function() {
 
   beforeEach(function() {
     module('app.core', 'app.components');
-
   });
 
   describe('view', function() {
@@ -10,7 +9,7 @@ describe('Component: ServiceDetails', function() {
     let isoScope;
     let element;
 
-    beforeEach(inject(function($compile, $rootScope, $httpBackend, RBAC, Session) {
+    beforeEach(inject(function($compile, $rootScope, $httpBackend, RBAC) {
       let mockDir = 'tests/mock/services/';
 
       scope = $rootScope.$new();
@@ -21,10 +20,6 @@ describe('Component: ServiceDetails', function() {
         svc_catalog_provision: {},
         miq_request_view: {}
       }}};
-
-       Session.create({
-        auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-      });
 
       $httpBackend.whenGET('').respond(200);
 

--- a/tests/components/tagging.component.spec.js
+++ b/tests/components/tagging.component.spec.js
@@ -2,7 +2,7 @@ describe('Component: taggingWidget', function() {
 
   beforeEach(function() {
     module('app.components');
-    bard.inject('Session', '$httpBackend', 'CollectionsApi');
+    bard.inject('$httpBackend', 'CollectionsApi');
   });
 
   describe('with $compile', function() {
@@ -25,9 +25,6 @@ describe('Component: taggingWidget', function() {
 
       scope = $rootScope.$new();
 
-      Session.create({
-        auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-      });
       $httpBackend.whenGET('').respond(200);
 
       scope.tagsOfBlueprint = readJSON(mockDir + 'tags-of-blueprint.json');

--- a/tests/dashboard.state.spec.js
+++ b/tests/dashboard.state.spec.js
@@ -2,7 +2,7 @@ describe('Dashboard', function() {
   beforeEach(function() {
     module('app.core');
     module('app.states', bard.fakeToastr);
-    bard.inject('$location', '$rootScope', '$state', '$templateCache', 'Session', '$httpBackend', '$q', 'RBAC');
+    bard.inject('$location', '$rootScope', '$state', '$templateCache', '$httpBackend', '$q', 'RBAC');
   });
 
   beforeEach(function() {
@@ -11,9 +11,6 @@ describe('Dashboard', function() {
     d = d.toISOString();
     d = d.substring(0, d.indexOf('.'));
 
-    Session.create({
-      auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-    });
     $httpBackend.whenGET('').respond(200);
   });
 

--- a/tests/rules/rules-state.spec.js
+++ b/tests/rules/rules-state.spec.js
@@ -1,27 +1,14 @@
 describe('app.states.RulesState', function() {
   beforeEach(function () {
     module('app.states');
-    bard.inject('$location', '$rootScope', '$state', '$templateCache', 'Session', '$httpBackend');
-  });
-
-  beforeEach(function () {
-    Session.create({
-      auth_token: 'b10ee568ac7b5d4efbc09a6b62cb99b8',
-    });
-    $httpBackend.whenGET('').respond(200);
+    bard.inject('$state');
   });
 
   describe('route', function() {
-
-    beforeEach(function() {
-      bard.inject('$state');
-    });
-
     it('should work with $state.go', function() {
       $state.go('administration.rules');
       expect($state.is('administration.rules'));
     });
-
   });
 
   describe('controller', function() {
@@ -93,7 +80,7 @@ describe('app.states.RulesState', function() {
     };
 
     beforeEach(function() {
-      bard.inject('$controller', '$state', '$rootScope', '$document', 'RulesState', 'ProfilesState');
+      bard.inject('$controller', 'RulesState', 'ProfilesState');
     });
 
     it('should be created successfully', function() {
@@ -107,12 +94,13 @@ describe('app.states.RulesState', function() {
       expect(controller).to.be.defined;
     });
 
-    it('should get data from the APIs', function () {
+    it('should get data from the APIs', function (done) {
       getRulesSpy = sinon.stub(RulesState, 'getRules').returns(Promise.resolve(arbitrationRules));
       getFieldsSpy = sinon.stub(RulesState, 'getRuleFields').returns(Promise.resolve(fields));
       getProfilesSpy = sinon.stub(ProfilesState, 'getProfiles').returns(Promise.resolve(profiles));
 
       $state.go('administration.rules');
+      done();
 
       expect(getRulesSpy).to.have.been.called;
       expect(getFieldsSpy).to.have.been.called;


### PR DESCRIPTION
Fixes issue where state was being carried over in test runs causing 6
test cases to fail every time after the first run in watch mode.

@miq-bot add_label euwe/no, bug