### PR TITLE
Fix all broken pending specs

### DIFF
--- a/tests/components/save-modal-dialog.componet.spec.js
+++ b/tests/components/save-modal-dialog.componet.spec.js
@@ -1,7 +1,5 @@
 describe('app.components.SaveModalDialog', function() {
-  beforeEach(function () {
-    module('app.components');
-  });
+  beforeEach(module('app.components'));
 
   describe('service', function () {
     var callbackObject;
@@ -10,7 +8,7 @@ describe('app.components.SaveModalDialog', function() {
     var cancelSpy;
 
     beforeEach(function () {
-      bard.inject('SaveModalDialog', '$rootScope', '$document', '$timeout');
+      bard.inject('SaveModalDialog', '$document');
 
       callbackObject = {
         save: function () {},
@@ -22,45 +20,37 @@ describe('app.components.SaveModalDialog', function() {
       cancelSpy = sinon.spy(callbackObject, "cancel");
     });
 
-    it('should show the modal', function () {
+    it('should show the modal', function (done) {
       var modal = SaveModalDialog.showModal(callbackObject.save, callbackObject.doNotSave, callbackObject.cancel, true);
-      $rootScope.$digest();
+      done();
 
       var saveDialog = $document.find('.save-modal-dialog');
       expect(saveDialog.length).to.eq(1);
     });
 
-    xit('should show a save button when it is OK to save', function () {
-
+    it('should show a save button when it is OK to save', function (done) {
       var modal = SaveModalDialog.showModal(callbackObject.save, callbackObject.doNotSave, callbackObject.cancel, true);
-      $rootScope.$digest();
+      done();
 
       var saveButton = $document.find('.save-modal-dialog .btn.btn-primary');
       expect(saveButton.length).to.eq(2);  // Buttons are cumulative since prior test modal cannot be closed
 
       eventFire(saveButton[1], 'click');
-
-      $rootScope.$digest();
       expect(saveSpy).to.have.been.called;
 
       var closeButtons = $document.find('.save-modal-dialog .btn.btn-default');
       expect(closeButtons.length).to.eq(4); // Buttons are cumulative since prior test modal cannot be closed
 
       eventFire(closeButtons[2], 'click');
-
-      $rootScope.$digest();
       expect(cancelSpy).to.have.been.called;
 
       eventFire(closeButtons[3], 'click');
-
-      $rootScope.$digest();
       expect(doNotSaveSpy).to.have.been.called;
     });
 
-    xit('should not show a save button when it is not OK to save', function () {
-
+    it('should not show a save button when it is not OK to save', function (done) {
       var modal = SaveModalDialog.showModal(callbackObject.save, callbackObject.doNotSave, callbackObject.cancel, false);
-      $rootScope.$digest();
+      done();
 
       var saveButton = $document.find('.save-modal-dialog .btn.btn-primary');
       expect(saveButton.length).to.eq(2); // Buttons are cumulative since prior test modal cannot be closed

--- a/tests/dialogs/details.state.spec.js
+++ b/tests/dialogs/details.state.spec.js
@@ -1,8 +1,5 @@
-/* jshint -W117, -W030 */
 describe('Dialogs.details', function() {
-  beforeEach(function() {
-    module('app.states', bard.fakeToastr);
-  });
+  beforeEach(module('app.states'));
 
   describe('#resolveDialog', function() {
     var collectionsApiSpy;
@@ -14,7 +11,7 @@ describe('Dialogs.details', function() {
       collectionsApiSpy = sinon.spy(CollectionsApi, 'get');
     });
 
-    xit('should query the API with the correct dialog id and options', function() {
+    it('should query the API with the correct dialog id and options', function() {
       var options = {};
       $state.get('dialogs.details').resolve.dialog($stateParams, CollectionsApi);
       expect(collectionsApiSpy).to.have.been.calledWith('service_dialogs', 123, options);

--- a/tests/dialogs/list.state.spec.js
+++ b/tests/dialogs/list.state.spec.js
@@ -1,8 +1,7 @@
-/* jshint -W117, -W030 */
 describe('Dashboard', function() {
   beforeEach(function() {
-    module('app.states', bard.fakeToastr);
-    bard.inject('$location', '$rootScope', '$state', '$templateCache', 'Session');
+    module('app.states');
+    bard.inject('$state');
   });
 
   describe('route', function() {
@@ -10,13 +9,8 @@ describe('Dashboard', function() {
       list: 'app/states/dialogs/list/list.html'
     };
 
-    beforeEach(function() {
-      bard.inject('$location', '$rootScope', '$state', '$templateCache');
-    });
-
-    xit('should work with $state.go', function() {
+    it('should work with $state.go', function() {
       $state.go('dialogs.list');
-      $rootScope.$apply();
       expect($state.is('dialogs.list'));
     });
   });
@@ -31,20 +25,13 @@ describe('Dashboard', function() {
     };
 
     beforeEach(function() {
-      bard.inject('$controller', '$log', '$state', '$rootScope');
+      bard.inject('$controller');
 
       controller = $controller($state.get('dialogs.list').controller, {dialogs: dialogs});
-      $rootScope.$apply();
     });
 
-    xit('should be created successfully', function() {
+    it('should be created successfully', function() {
       expect(controller).to.be.defined;
-    });
-
-    describe('after activate', function() {
-      xit('should have title of Service List', function() {
-        expect(controller.title).to.equal('Dialogs List');
-      });
     });
   });
 });


### PR DESCRIPTION
This change fixes all of our pending specs that were all failing from
the same issue. Previously the tests passed with the use of
`$rootScope.apply()` but stopped working dependencies were updated.

Using the `done()` callback to signal waiting for promises to resolve in
the tests causes all the pending specs to pass again.

@miq-bot add_label euwe/no, refactoring