### PR TITLE
Make cascading auto-refresh behavior more consistent with how it was previously

### DIFF
--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -22,6 +22,7 @@ export function DialogFieldRefreshFactory(lodash, CollectionsApi, EventNotificat
 
       if (dialogFieldToRefresh.length > 0) {
         dialogFieldToRefresh[0].beingRefreshed = true;
+        dialogFieldToRefresh[0].triggerOverride = true;
         refreshSingleDialogField(allDialogFields, dialogFieldToRefresh[0], url, resourceId);
       }
     };
@@ -89,7 +90,7 @@ export function DialogFieldRefreshFactory(lodash, CollectionsApi, EventNotificat
   }
 
   function triggerAutoRefresh(dialogField) {
-    if (dialogField.trigger_auto_refresh === true) {
+    if (dialogField.trigger_auto_refresh === true || dialogField.triggerOverride === true) {
       parent.postMessage({refreshableFieldIndex: dialogField.refreshableFieldIndex}, '*');
     }
   }

--- a/client/app/core/dialog-field-refresh.service.spec.js
+++ b/client/app/core/dialog-field-refresh.service.spec.js
@@ -42,6 +42,10 @@ describe('DialogFieldRefresh', function() {
       it('sets the being refreshed flag to true', function() {
         expect(dialogField2.beingRefreshed).to.equal(true);
       });
+
+      it('sets the trigger override flag to true', function() {
+        expect(dialogField2.triggerOverride).to.equal(true);
+      });
     });
   });
 
@@ -427,9 +431,26 @@ describe('DialogFieldRefresh', function() {
         dialogField.trigger_auto_refresh = false;
       });
 
-      it('does not post a message', function() {
-        DialogFieldRefresh.triggerAutoRefresh(dialogField);
-        expect(postMessageSpy).not.to.have.been.called;
+      describe('when the override is true', function() {
+        beforeEach(function() {
+          dialogField.triggerOverride = true;
+        });
+
+        it('posts a message with the field name', function() {
+          DialogFieldRefresh.triggerAutoRefresh(dialogField);
+          expect(postMessageSpy).to.have.been.calledWith({refreshableFieldIndex: 123}, '*');
+        });
+      });
+
+      describe('when the override is undefined', function() {
+        beforeEach(function() {
+          dialogField.triggerOverride = undefined;
+        });
+
+        it('does not post a message', function() {
+          DialogFieldRefresh.triggerAutoRefresh(dialogField);
+          expect(postMessageSpy).not.to.have.been.called;
+        });
       });
     });
   });


### PR DESCRIPTION
This is the service-ui counterpart to https://github.com/ManageIQ/manageiq-ui-classic/pull/433, please see that PR for more details on the reasoning behind this change.

@miq-bot add_label darga/yes euwe/yes
@miq-bot assign @chriskacerguis 

/cc @gmcculloug 