### PR TITLE
Move pagination styles within pagination-footer

### DIFF
--- a/client/app/shared/pagination/_pagination.sass
+++ b/client/app/shared/pagination/_pagination.sass
@@ -1,12 +1,5 @@
 @import 'app_colors'
 
-.pagination
-  margin-top: 0
-
-  > .disabled > span
-    &:hover
-      cursor: not-allowed
-
 .pagination-footer
   background-color: $app-color-white
   border-top: 1px solid $app-color-gray
@@ -18,3 +11,10 @@
   .pagination-controls
     position: fixed
     right: 15px
+
+  .pagination
+    margin-top: 0
+
+    > .disabled > span
+      &:hover
+        cursor: not-allowed


### PR DESCRIPTION
Fix pagination bar styling regression. Move `.pagination` selector to be
more specific to avoid conflicting with Bootstrap's `.pagination` class

<img width="1178" alt="screen shot 2017-02-21 at 2 57 54 pm" src="https://cloud.githubusercontent.com/assets/6842753/23182331/2dacd074-f846-11e6-9aaa-dd45880d5a57.png">

@miq-bot add_label euwe/no, bug

/cc @AllenBW 