### PR TITLE
Set X-Miq-Group header for every request

### DIFF
--- a/client/app/core/authentication-api.factory.js
+++ b/client/app/core/authentication-api.factory.js
@@ -16,7 +16,7 @@ export function AuthenticationApiFactory($http, $base64, API_BASE, Session, Noti
     }).then(loginSuccess, loginFailure);
 
     function loginSuccess(response) {
-      Session.create(response.data);
+      Session.setAuthToken(response.data.auth_token);
     }
 
     function loginFailure(response) {

--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -77,10 +77,8 @@ export function authInit($rootScope, $state, Session, $sessionStorage, logger, L
   function syncSession() {
     return new Promise(function (resolve, reject) {
       // trying saved token..
-      Session.create({
-        auth_token: $sessionStorage.token,
-        miqGroup: $sessionStorage.miqGroup,
-      });
+      Session.setAuthToken($sessionStorage.token);
+      Session.setMiqGroup($sessionStorage.miqGroup);
 
       Session.loadUser()
         .then(Language.onReload)

--- a/client/app/core/session.service.spec.js
+++ b/client/app/core/session.service.spec.js
@@ -57,7 +57,7 @@ describe('Session', function() {
       var response = {authorization: {product_features: {
         service_view: {},
         service_edit: {}
-      }}};
+      }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
       Session.loadUser();
@@ -79,7 +79,7 @@ describe('Session', function() {
       var response = {authorization: {product_features: {
         svc_catalog_provision: {},
         miq_request_view: {}
-      }}};
+      }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
       Session.loadUser();
@@ -94,7 +94,7 @@ describe('Session', function() {
 
     it('returns false if user is not entitled to use ssui', function() {
       var response = {authorization: {product_features: {
-      }}};
+      }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
       Session.loadUser();


### PR DESCRIPTION
Break down `Session.create` into two distinct setters because the auth
token and miq group values come from two separate HTTP requests.

The group value is returned as part of the user object when the
authorizations request is made.

https://www.pivotaltracker.com/story/show/140246987
https://bugzilla.redhat.com/show_bug.cgi?id=1422551

@miq-bot add_label euwe/yes, bug
/cc @chalettu 

Separate follow-up PR in progress for backport.