### PR TITLE
Update TaggingService to use bulk tag APIs

### DIFF
--- a/client/app/core/core.module.js
+++ b/client/app/core/core.module.js
@@ -49,7 +49,7 @@ import { TemplatesServiceFactory } from './templates.service.js';
 import { TagEditorFactory } from './tag-editor-modal/tag-editor-modal.service.js';
 import { gettextInit } from './gettext.config.js';
 import { layoutInit } from  './layouts.config.js';
-import { taggingService } from './tagging.service.js';
+import { TaggingService } from './tagging.service.js';
 
 export const CoreModule = angular
   .module('app.core', [
@@ -100,7 +100,7 @@ export const CoreModule = angular
   .factory('TemplatesService', TemplatesServiceFactory)
   .factory('TagEditorModal', TagEditorFactory)
   .factory('logger', LoggerService)
-  .factory('taggingService', taggingService)
+  .factory('TaggingService', TaggingService)
   .provider('Navigation', NavigationProvider)
   .config(configure)
   .config(authConfig)

--- a/client/app/core/tag-editor-modal/tag-editor-modal.service.js
+++ b/client/app/core/tag-editor-modal/tag-editor-modal.service.js
@@ -35,7 +35,7 @@ export function TagEditorFactory($uibModal) {
 
 /** @ngInject */
 function TagEditorModalController(services, tags, $controller, $uibModalInstance,
-                                  $state, taggingService, EventNotifications) {
+                                  $state, TaggingService, EventNotifications) {
   var vm = this;
   var base = $controller('BaseModalController', {
     $uibModalInstance: $uibModalInstance,
@@ -48,7 +48,7 @@ function TagEditorModalController(services, tags, $controller, $uibModalInstance
 
   // Override
   function save() {
-    return taggingService.assignTags('services', vm.services, tags, vm.modalData.tags)
+    return TaggingService.assignTags('services', vm.services, tags, vm.modalData.tags)
       .then(saveSuccess)
       .catch(saveFailure);
 

--- a/client/app/core/tagging.service.spec.js
+++ b/client/app/core/tagging.service.spec.js
@@ -1,20 +1,20 @@
-describe('taggingService', function() {
+describe('TaggingService', function() {
   var service;
   var collectionsApiMock;
 
   beforeEach(module('app.states'));
 
-  beforeEach(inject(function(taggingService, CollectionsApi) {
-    service = taggingService;
+  beforeEach(inject(function(TaggingService, CollectionsApi) {
+    service = TaggingService;
     collectionsApiMock = sinon.mock(CollectionsApi);
   }));
 
   describe('#assignTags', function() {
-    it('makes 2 requests for each resource (assign, unassign)', function() {
+    it('makes 2 bulk requests (assign, unassign)', function() {
       collectionsApiMock
         .expects('post')
-        .withArgs('services', sinon.match(/tags/), {})
-        .exactly(4);
+        .withArgs('services', null, {})
+        .exactly(2);
 
       service.assignTags('services', [{}, {}], [{ name: '/first/tag' }], [{ name: '/new/tag' }]);
 

--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -9,7 +9,7 @@ export const ServiceExplorerComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, ServicesState, Language, ListView, Chargeback, taggingService, TagEditorModal,
+function ComponentController($state, ServicesState, Language, ListView, Chargeback, TaggingService, TagEditorModal,
                              EventNotifications, ModalService, PowerOperations, lodash, Polling) {
   var vm = this;
   vm.$onInit = activate();
@@ -435,12 +435,12 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
 
   function doEditTags(services) {
     var extractSharedTagsFromSelectedServices
-      = lodash.partial(taggingService.findSharedTags, services);
+      = lodash.partial(TaggingService.findSharedTags, services);
 
     var launchTagEditorForSelectedServices
       = lodash.partial(TagEditorModal.showModal, services);
 
-    return taggingService.queryAvailableTags()
+    return TaggingService.queryAvailableTags()
       .then(extractSharedTagsFromSelectedServices)
       .then(launchTagEditorForSelectedServices);
   }

--- a/client/app/shared/tagging/tagging.component.js
+++ b/client/app/shared/tagging/tagging.component.js
@@ -12,7 +12,7 @@ export const TaggingComponent = {
 };
 
 /** @ngInject */
-function TaggingController($scope, $filter, $q, $log, CollectionsApi, taggingService) {
+function TaggingController($scope, $filter, $q, $log, CollectionsApi, TaggingService) {
   var vm = this;
 
   vm.tags = {};
@@ -131,7 +131,7 @@ function TaggingController($scope, $filter, $q, $log, CollectionsApi, taggingSer
 
     // Add Selected Tag
     if (!matchingTag.length) {
-      var parsedTag = taggingService.parseTag(vm.tags.selectedTag);
+      var parsedTag = TaggingService.parseTag(vm.tags.selectedTag);
       vm.tagsOfItem.push(parsedTag);
     }
   };

--- a/client/app/states/services/details/details.state.js
+++ b/client/app/states/services/details/details.state.js
@@ -59,7 +59,7 @@ function resolveService($stateParams, CollectionsApi) {
   ];
   var options = {
     attributes: requestAttributes,
-    decorators: ['vms.snapshots',     
+    decorators: ['vms.snapshots',
       'vms.v_total_snapshots',
       'vms.v_snapshot_newest_name',
       'vms.v_snapshot_newest_timestamp',
@@ -73,14 +73,14 @@ function resolveService($stateParams, CollectionsApi) {
 }
 
 /** @ngInject */
-function resolveTags($stateParams, taggingService) {
+function resolveTags($stateParams, TaggingService) {
   var serviceUrl = 'services/' + $stateParams.serviceId + '/tags/';
 
-  return taggingService.queryAvailableTags(serviceUrl);
+  return TaggingService.queryAvailableTags(serviceUrl);
 }
 
 /** @ngInject */
-function StateController($scope, $stateParams, service, tags, CollectionsApi, Polling, taggingService) {
+function StateController($scope, $stateParams, service, tags, CollectionsApi, Polling, TaggingService) {
   var vm = this;
   vm.service = service;
   vm.tags = tags;
@@ -90,12 +90,12 @@ function StateController($scope, $stateParams, service, tags, CollectionsApi, Po
   $scope.$on('$destroy', function () {
     Polling.stop('servicesPolling');
   });
-  
+
   function startPollingService() {
     resolveService($stateParams, CollectionsApi).then(function (data) {
       vm.service = data;
     });
-    resolveTags($stateParams, taggingService).then(function (data) {
+    resolveTags($stateParams, TaggingService).then(function (data) {
       vm.tags = data;
     });
   }


### PR DESCRIPTION
Rename taggingService to TaggingService to maintain consistency with
other services.

Refactor `TaggingService#assignTags` to use the new bulk tag assign and
unassign endpoints. With this change the number of HTTP requests for
bulk assignments will be bounded at up to 2 (assign and/or unassign).

https://www.pivotaltracker.com/story/show/134447009

@miq-bot add_label euwe/no, refactoring