### PR TITLE
PT#140438905 - Reconfigure delete action to send resource array of actionalble items

### DIFF
--- a/client/app/services/vms.service.js
+++ b/client/app/services/vms.service.js
@@ -60,13 +60,13 @@ export function VmsService(CollectionsApi) {
     return filters;
   }
 
-  function deleteSnapshots(vmId, snapshotId) {
-    const options = {"action": "delete"};
-    if (angular.isDefined(snapshotId)) {
-      return CollectionsApi.post(collection + '/' + vmId + '/snapshots/' + snapshotId, null, {}, options);
-    }
+  function deleteSnapshots(vmId, data) {
+    const options = {
+      "action": "delete",
+      "resources": data,
+    };
 
-    return CollectionsApi.post(collection + '/' + vmId, null, {}, options);
+    return CollectionsApi.post(collection + '/' + vmId + '/snapshots/', null, {}, options);
   }
 
   function createSnapshots(vmId, data) {

--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -27,7 +27,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
       // Functions
       resolveSnapshots: resolveSnapshots,
       deleteSnapshots: deleteSnapshots,
-      canceldelete: canceldelete,
+      cancelDelete: cancelDelete,
 
       // Config
       listConfig: getListConfig(),
@@ -114,21 +114,28 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
   }
 
   function deleteSnapshots() {
-    canceldelete();
-    VmsService.deleteSnapshots(vm.vm.id, vm.deleteSnapshotId).then(success, failure);
+    cancelDelete();
+    VmsService.deleteSnapshots(vm.vm.id, vm.snapshotsToRemove).then(success, failure);
 
     function success(response) {
-      vm.deleteSnapshotId = undefined;
-      EventNotifications.success(sprintf(__('All snapshots of vm %s have been deleted'), vm.vm.name));
+      response.results.forEach((response) => {
+        console.log(response);
+        if (response.success) {
+          EventNotifications.success(__('Success deleting snapshot. ')+ response.message);
+        } else {
+          EventNotifications.error(__('Error deleting snapshot. ') + response.message);
+        }
+      });
+      vm.snapshotsToRemove = undefined;
       resolveSnapshots();
     }
 
     function failure(response) {
-      EventNotifications.error(__('There was an error deleting snapshots.'));
+      EventNotifications.error(response.data.error.message);
     }
   }
 
-  function canceldelete() {
+  function cancelDelete() {
     vm.deleteModal = false;
   }
 
@@ -174,10 +181,11 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
 
   function deleteSnapshot(action, item) {
     if (angular.isDefined(item)) {
-      vm.deleteSnapshotId = item.id;
+      vm.snapshotsToRemove = [{"href": item.href}];
       vm.deleteTitle = __('Delete Snapshot');
       vm.deleteMessage = sprintf(__('Please confirm, this action will delete snapshot %s'), item.name);
     } else {
+      vm.snapshotsToRemove = vm.snapshots;
       vm.deleteTitle = sprintf(__('Delete All Snapshots on VM %s'), vm.vm.name);
       vm.deleteMessage = sprintf(__('Please confirm, this action will delete all snapshots of vm %s'), vm.vm.name);
     }
@@ -185,7 +193,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
   }
 
   function processSnapshot(action, item) {
-    var modalOptions = {
+    const modalOptions = {
       component: 'processSnapshotsModal',
       resolve: {
         vm: function() {

--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -119,9 +119,8 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
 
     function success(response) {
       response.results.forEach((response) => {
-        console.log(response);
         if (response.success) {
-          EventNotifications.success(__('Success deleting snapshot. ')+ response.message);
+          EventNotifications.success(__('Success deleting snapshot. ') + response.message);
         } else {
           EventNotifications.error(__('Error deleting snapshot. ') + response.message);
         }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140438905
Woops guys, was accidentally deleting vms instead of all snapshots on a vm, but we're good now.

Nothing to see here, except when doing batch actions, there will be an event notification for each item acted on, (this is normal and as it should be, some operations will pass others fail for a myriad of reasons) . So if you delete 100000 snapshots at once, the :earth_asia: might :boom: 