### PR TITLE
Configure eslint to detect unused vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,6 +23,7 @@
   },
   "rules": {
     "accessor-pairs": "error",
+    "angular/on-watch": "off",
     "array-bracket-spacing": "off",
     "array-callback-return": "off",
     "arrow-body-style": "error",
@@ -234,7 +235,13 @@
     "no-unneeded-ternary": "error",
     "no-unsafe-negation": "error",
     "no-unused-expressions": "off",
-    "no-unused-vars": "off",
+    "no-unused-vars": [
+      "error",
+      {
+        "args": "all",
+        "argsIgnorePattern": "^_"
+      }
+    ],
     "no-use-before-define": "off",
     "no-useless-call": "error",
     "no-useless-computed-key": "error",

--- a/client/app/app.controller.js
+++ b/client/app/app.controller.js
@@ -10,13 +10,13 @@ export class AppController {
   }
 
   $onInit() {
-    this.$scope.$on('$stateChangeStart', (event, toState, toParams, fromState, fromParams) => {
+    this.$scope.$on('$stateChangeStart', (_event, toState) => {
       if (toState.resolve) {
         this.progressbar.start();
       }
     });
 
-    this.$scope.$on('$stateChangeSuccess', (event, toState, toParams, fromState, fromParams) => {
+    this.$scope.$on('$stateChangeSuccess', (_event, toState) => {
       if (toState.resolve) {
         this.progressbar.complete();
       }

--- a/client/app/catalogs/catalog-explorer.component.js
+++ b/client/app/catalogs/catalog-explorer.component.js
@@ -58,7 +58,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
     $state.go('catalogs.editor', {catalogId: catalog.id});
   }
 
-  function handleEdit(action, catalog) {
+  function handleEdit(_action, catalog) {
     editCatalog(catalog);
   }
 
@@ -103,7 +103,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
     vm.confirmDelete = false;
   }
 
-  function handleDelete(action, catalog) {
+  function handleDelete(_action, catalog) {
     vm.catalogToDelete = catalog;
     vm.confirmDelete = true;
     vm.deleteConfirmationMessage = sprintf(__('Are you sure you want to delete catalog %s?'),
@@ -316,7 +316,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
       }
     }
 
-    function failure(error) {
+    function failure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading catalogs.'));
     }

--- a/client/app/catalogs/catalogs-state.service.js
+++ b/client/app/catalogs/catalogs-state.service.js
@@ -104,7 +104,7 @@ export function CatalogsStateFactory(CollectionsApi, EventNotifications, sprintf
       }
     }
 
-    return CollectionsApi.post('service_catalogs', null, {}, catalogObj).then(createSuccess, createFailure);
+    return CollectionsApi.post('service_catalogs', null, {}, addObj).then(createSuccess, createFailure);
   }
 
   function editCatalog(catalog, skipResults) {

--- a/client/app/components/template-explorer/template-explorer.component.js
+++ b/client/app/components/template-explorer/template-explorer.component.js
@@ -4,11 +4,11 @@ import templateUrl from './template-explorer.html';
 export const TemplateExplorerComponent = {
   controller: ComponentController,
   controllerAs: 'vm',
-  templateUrl: 'app/components/template-explorer/template-explorer.html',
+  templateUrl,
 };
 
 /** @ngInject */
-function ComponentController(ListView, Language, TemplatesService, EventNotifications, Session, Polling) {
+function ComponentController(ListView, TemplatesService, EventNotifications, Session, Polling) {
   const vm = this;
   vm.$onInit = activate();
   vm.$onDestroy = function() {
@@ -122,11 +122,12 @@ function ComponentController(ListView, Language, TemplatesService, EventNotifica
     if (!refresh) {
       vm.loading = true;
     }
-    const existingTemplates = (angular.isDefined(vm.templatesList) && refresh ? angular.copy(vm.templatesList) : []);
     vm.offset = String(offset);
 
     TemplatesService.getMinimal(vm.filters).then(setResultTotals);
-    TemplatesService.getTemplates(limit, vm.offset, vm.filters, vm.sortConfig).then(querySuccess);
+    TemplatesService.getTemplates(limit, vm.offset, vm.filters, vm.sortConfig)
+      .then(querySuccess)
+      .catch(queryFailure);
 
     function querySuccess(response) {
       vm.loading = false;
@@ -134,7 +135,7 @@ function ComponentController(ListView, Language, TemplatesService, EventNotifica
       vm.templates = response.resources;
       vm.templatesList = [];
       angular.forEach(vm.templates, processTemplates);
-      
+
       function processTemplates(template) {
         switch (template.type) {
           case 'OrchestrationTemplateAzure':
@@ -170,13 +171,13 @@ function ComponentController(ListView, Language, TemplatesService, EventNotifica
       }
     }
 
-    function queryFailure(error) {
+    function queryFailure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading templates.'));
     }
   }
 
-  function selectionChange(item) {
+  function selectionChange(_item) {
     vm.selectedItemsList = vm.templatesList.filter(function (service) {
       return service.selected;
     });

--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -33,7 +33,6 @@ export function authConfig($httpProvider) {
 
     function endSession() {
       var $state = $injector.get('$state');
-      var Notifications = $injector.get('Notifications');
       var Session = $injector.get('Session');
 
       if ('login' !== $state.current.name) {
@@ -46,15 +45,15 @@ export function authConfig($httpProvider) {
 
 /** @ngInject */
 export function authInit($rootScope, $state, Session, $sessionStorage, logger, Language, ServerInfo, ProductInfo, $window, RBAC) {
-  var unregisterStart = $rootScope.$on('$stateChangeStart', changeStart);
-  var unregisterError = $rootScope.$on('$stateChangeError', changeError);
-  var unregisterSuccess = $rootScope.$on('$stateChangeSuccess', changeSuccess);
+  $rootScope.$on('$stateChangeStart', changeStart);
+  $rootScope.$on('$stateChangeError', changeError);
+  $rootScope.$on('$stateChangeSuccess', changeSuccess);
 
   $sessionStorage.$sync();  // needed when called right on reload
   if ($sessionStorage.token) {
     syncSession();
   }
-  function changeStart(event, toState, toParams, fromState, fromParams) {
+  function changeStart(event, toState, toParams, _fromState, _fromParams) {
     if (toState.data && !toState.data.requireUser) {
       return;
     }
@@ -75,7 +74,7 @@ export function authInit($rootScope, $state, Session, $sessionStorage, logger, L
     syncSession().then(rbacReloadOrLogin(toState, toParams)).catch(badUser);
   }
   function syncSession() {
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve, _reject) {
       // trying saved token..
       Session.setAuthToken($sessionStorage.token);
       Session.setMiqGroup($sessionStorage.miqGroup);
@@ -106,7 +105,7 @@ export function authInit($rootScope, $state, Session, $sessionStorage, logger, L
     $window.location.href = $state.href('login');
   }
 
-  function changeError(event, toState, toParams, fromState, fromParams, error) {
+  function changeError(event, toState, _toParams, _fromState, _fromParams, error) {
     // If a 401 is encountered during a state change, then kick the user back to the login
     if (401 === error.status) {
       event.preventDefault();

--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -2,7 +2,7 @@
 /* eslint angular/angularelement: "off" */
 
 /** @ngInject */
-export function DialogFieldRefreshFactory(lodash, CollectionsApi, EventNotifications) {
+export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
   var service = {
     listenForAutoRefreshMessages: listenForAutoRefreshMessages,
     refreshSingleDialogField: refreshSingleDialogField,
@@ -69,9 +69,9 @@ export function DialogFieldRefreshFactory(lodash, CollectionsApi, EventNotificat
 
   function setupDialogData(dialogs, allDialogFields, autoRefreshableDialogFields) {
     angular.forEach(dialogs, function(dialog) {
-      angular.forEach(dialog.dialog_tabs, function(dialogTab, dialogTabIndex) {
-        angular.forEach(dialogTab.dialog_groups, function(dialogGroup, dialogGroupIndex) {
-          angular.forEach(dialogGroup.dialog_fields, function(dialogField, dialogFieldIndex) {
+      angular.forEach(dialog.dialog_tabs, function(dialogTab) {
+        angular.forEach(dialogTab.dialog_groups, function(dialogGroup) {
+          angular.forEach(dialogGroup.dialog_fields, function(dialogField) {
             allDialogFields.push(dialogField);
 
             selectDefaultValue(dialogField, dialogField);
@@ -96,23 +96,6 @@ export function DialogFieldRefreshFactory(lodash, CollectionsApi, EventNotificat
   }
 
   // Private
-
-  function refreshMultipleDialogFields(allDialogFields, fieldNamesToRefresh, url, resourceId) {
-    function refreshSuccess(result) {
-      angular.forEach(allDialogFields, function(dialogField) {
-        if (fieldNamesToRefresh.indexOf(dialogField.name) > -1) {
-          var resultObj = result.result[dialogField.name];
-          updateAttributesForDialogField(dialogField, resultObj);
-        }
-      });
-    }
-
-    function refreshFailure(result) {
-      EventNotifications.error('There was an error automatically refreshing dialogs' + result);
-    }
-
-    fetchDialogFieldInfo(allDialogFields, fieldNamesToRefresh, url, resourceId, refreshSuccess, refreshFailure);
-  }
 
   function updateAttributesForDialogField(dialogField, newDialogField) {
     copyDynamicAttributes(dialogField, newDialogField);

--- a/client/app/core/language-switcher/language-switcher.directive.js
+++ b/client/app/core/language-switcher/language-switcher.directive.js
@@ -16,7 +16,7 @@ export function LanguageSwitcherDirective() {
   return directive;
 
   /** @ngInject */
-  function LanguageSwitcherController($scope, gettextCatalog, Language, lodash, $state, $window) {
+  function LanguageSwitcherController($scope, Language, lodash, $state) {
     var vm = this;
     vm.mode = vm.mode || 'menu';
 

--- a/client/app/core/list-view.service.js
+++ b/client/app/core/list-view.service.js
@@ -2,7 +2,7 @@
 /* eslint no-cond-assign: "off" */
 
 /** @ngInject */
-export function ListViewFactory($log) {
+export function ListViewFactory() {
   var listView = {};
 
   listView.applyFilters = function(filters, retList, origList, stateFactory, matchesFilter) {

--- a/client/app/core/navigation.provider.js
+++ b/client/app/core/navigation.provider.js
@@ -18,7 +18,7 @@ export function NavigationProvider() {
   }
 
   /** @ngInject */
-  function Navigation($rootScope, $window, lodash) {
+  function Navigation() {
     var service = {
       items: model.items,
     };

--- a/client/app/core/navigation/navigation-controller.js
+++ b/client/app/core/navigation/navigation-controller.js
@@ -228,6 +228,7 @@ export function NavigationController(Text,
     destroyCart();
     destroyNotifications();
     destroyToast();
+    destroy();
   });
 
   function handleItemClick(item) {

--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -64,26 +64,12 @@ export function RBACFactory(lodash) {
   function getNavFeatures() {
     return navFeatures;
   }
-  function entitledForServices(productFeatures) {
+  function entitledForServices(_productFeatures) {
     var serviceFeature = lodash.find(actionFeatures, function(o) {
       return o.show === true;
     });
 
     return angular.isDefined(serviceFeature);
-  }
-
-  function isAnyActionAllowed(actions, productFeatures) {
-    return actions.some(action => angular.isDefined(productFeatures[action]));
-  }
-
-  function entitledForCatalogItems(productFeatures) {
-    var actions = ["atomic_catalogitem_edit",
-      "atomic_catalogitem_new",
-      "catalog_items_view",
-      "catalogitem_edit",
-      "catalogitem_new"];
-
-    return isAnyActionAllowed(actions, productFeatures);
   }
 
   function entitledForServiceCatalogs(productFeatures) {

--- a/client/app/core/router/router-helper.provider.js
+++ b/client/app/core/router/router-helper.provider.js
@@ -57,12 +57,12 @@ export function routerHelperProvider($locationProvider, $stateProvider, $urlRout
       // Route cancellation:
       // On routing error, go to the dashboard.
       // Provide an exit clause if it tries to do it twice.
-      var unregisterError = $rootScope.$on('$stateChangeError', handleRoutingErrors);
-      var unregisterSuccess = $rootScope.$on('$stateChangeSuccess', updateTitle);
+      $rootScope.$on('$stateChangeError', handleRoutingErrors);
+      $rootScope.$on('$stateChangeSuccess', updateTitle);
       // Hack in redirect to default children
       // Discussions: https://github.com/angular-ui/ui-router/issues/1235
       // https://github.com/angular-ui/ui-router/issues/27
-      var unregisterStart = $rootScope.$on('$stateChangeStart', redirectTo);
+      $rootScope.$on('$stateChangeStart', redirectTo);
     }
 
     function getStates() {
@@ -71,7 +71,7 @@ export function routerHelperProvider($locationProvider, $stateProvider, $urlRout
 
     // Private
 
-    function handleRoutingErrors(event, toState, toParams, fromState, fromParams, error) {
+    function handleRoutingErrors(_event, toState, _toParams, _fromState, _fromParams, error) {
       var destination, msg;
 
       if (handlingStateChangeError) {
@@ -87,7 +87,7 @@ export function routerHelperProvider($locationProvider, $stateProvider, $urlRout
       $location.path('/');
     }
 
-    function updateTitle(event, toState) {
+    function updateTitle(_event, toState) {
       stateCounts.changes++;
       handlingStateChangeError = false;
       $rootScope.title = config.docTitle + ' ' + (toState.title ? __(toState.title) : ''); // data bind to <title>

--- a/client/app/core/session.service.js
+++ b/client/app/core/session.service.js
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function SessionFactory($http, $q, $sessionStorage, gettextCatalog, $window, $state, $cookies, lodash, RBAC, Polling) {
+export function SessionFactory($http, $q, $sessionStorage, $window, $state, $cookies, RBAC, Polling) {
   var model = {
     token: null,
     user: {},

--- a/client/app/core/shopping-cart.service.js
+++ b/client/app/core/shopping-cart.service.js
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function ShoppingCartFactory($rootScope, CollectionsApi, $q, $http, lodash, RBAC) {
+export function ShoppingCartFactory($rootScope, CollectionsApi, $q, lodash, RBAC) {
   var state = null;
 
   var service = {

--- a/client/app/core/tagging.service.js
+++ b/client/app/core/tagging.service.js
@@ -18,8 +18,8 @@ export function TaggingService(CollectionsApi, lodash, exception) {
     const tagObjectsToUnassign = tagsToUnassign.map(toTagObject);
 
     return Promise.all([
-      postTagPayload('assign_tags', tagsToAssign),
-      postTagPayload('unassign_tags', tagsToUnassign),
+      postTagPayload('assign_tags', tagObjectsToAssign),
+      postTagPayload('unassign_tags', tagObjectsToUnassign),
     ]);
 
     function tagName(tag) {

--- a/client/app/dialogs/dialogs-list.component.js
+++ b/client/app/dialogs/dialogs-list.component.js
@@ -63,7 +63,7 @@ function DialogListController($state, DialogsState, $filter, Language, ListView)
     $state.go('dialogs.edit', {dialogId: 'new'});
   }
 
-  function handleClick(item, e) {
+  function handleClick(item, _event) {
     $state.go('dialogs.details', {dialogId: item.id});
   }
 
@@ -85,7 +85,7 @@ function DialogListController($state, DialogsState, $filter, Language, ListView)
   /* Apply the filtering to the data list */
   filterChange(DialogsState.getFilters());
 
-  function sortChange(sortId, isAscending) {
+  function sortChange(sortId, _isAscending) {
     vm.dialogList.sort(compareFn);
 
     /* Keep track of the current sorting state */

--- a/client/app/requests/order-explorer/order-explorer.component.js
+++ b/client/app/requests/order-explorer/order-explorer.component.js
@@ -279,7 +279,7 @@ function ComponentController($filter, lodash, ListView, Language, OrdersState, E
       getFilterCount();
     }
 
-    function queryFailure(error) {
+    function queryFailure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading orders.'));
     }
@@ -292,7 +292,7 @@ function ComponentController($filter, lodash, ListView, Language, OrdersState, E
       vm.filterCount = result.subcount;
     }
 
-    function queryFailure(error) {
+    function queryFailure(_error) {
       EventNotifications.error(__('There was an error loading orders.'));
     }
   }
@@ -327,7 +327,7 @@ function ComponentController($filter, lodash, ListView, Language, OrdersState, E
     ModalService.open(modalOptions);
   }
 
-  function duplicateOrder(action, item) {
+  function duplicateOrder(_action, item) {
     CollectionsApi.post('service_orders', null, null, {action: "copy", resources: [{id: item.id}]}).then(success, failure);
 
     function success(response) {
@@ -335,12 +335,12 @@ function ComponentController($filter, lodash, ListView, Language, OrdersState, E
       resolveOrders(vm.limit, 0);
     }
 
-    function failure(error) {
+    function failure(_error) {
       EventNotifications.error(sprintf(__('There was an error duplicating %s.'), item.name));
     }
   }
 
-  function removeOrder(action, item) {
+  function removeOrder(_action, item) {
     const modalOptions = {
       component: 'processOrderModal',
       resolve: {

--- a/client/app/requests/request-explorer/request-explorer.component.js
+++ b/client/app/requests/request-explorer/request-explorer.component.js
@@ -101,7 +101,7 @@ function ComponentController($state, CollectionsApi, RequestsState, ListView, $f
 
   // Private
 
-  function fetchData(limit, offset, refresh) {
+  function fetchData(limit, offset, _refresh) {
     var filter = [];
     var attributes = ['picture', 'picture.image_href', 'approval_state', 'created_on', 'description', 'requester_name'];
     var options = {
@@ -181,7 +181,7 @@ function ComponentController($state, CollectionsApi, RequestsState, ListView, $f
     $state.go('requests.details', {requestId: item.id});
   }
 
-  function sortChange(sortId, direction) {
+  function sortChange(sortId, _direction) {
     vm.listDataCopy.sort(compareFn);
 
     /* Keep track of the current sorting state */

--- a/client/app/services/custom-button/custom-button.directive.js
+++ b/client/app/services/custom-button/custom-button.directive.js
@@ -14,7 +14,7 @@ export function CustomButtonDirective($window, $timeout) {
       serviceTemplateCatalogId: '=',
     },
     link: link,
-    templateUrl: 'app/components/custom-button/custom-button.html',
+    templateUrl,
     controller: CustomButtonController,
     controllerAs: 'vm',
     bindToController: true,
@@ -22,7 +22,7 @@ export function CustomButtonDirective($window, $timeout) {
 
   return directive;
 
-  function link(scope, element, attrs, controller, transclude) {
+  function link(scope, _element, _attrs, controller, _transclude) {
     controller.activate();
 
     var win = angular.element($window);

--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -150,7 +150,7 @@ export function PowerOperationsFactory(CollectionsApi, EventNotifications, sprin
   function powerOperation(apiType, powerAction, item, itemType) {
     CollectionsApi.post(apiType, item.id, {}, {action: powerAction}).then(actionSuccess, actionFailure);
 
-    function actionSuccess(response) {
+    function actionSuccess(_response) {
       if (powerAction === 'start') {
         EventNotifications.success(sprintf(__("%s was started"), item.name));
       } else if (powerAction === 'stop') {

--- a/client/app/services/retire-service-modal/retire-service-modal.component.js
+++ b/client/app/services/retire-service-modal/retire-service-modal.component.js
@@ -12,7 +12,7 @@ export const RetireServiceModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($scope, $state, CollectionsApi, EventNotifications, moment, lodash) {
+function ComponentController($scope, $state, CollectionsApi, EventNotifications, moment) {
   var vm = this;
 
   angular.extend(vm, {

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -203,7 +203,7 @@ function ComponentController($state, $window, CollectionsApi, EventNotifications
       $state.go('services');
     }
 
-    function removeFailure(data) {
+    function removeFailure(_data) {
       EventNotifications.error(__('There was an error removing this service.'));
     }
   }

--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -144,15 +144,15 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
     action.isDisabled = !actionEnabled(action.actionName, item);
   }
 
-  function startService(action, item) {
+  function startService(_action, item) {
     PowerOperations.startService(item);
   }
 
-  function stopService(action, item) {
+  function stopService(_action, item) {
     PowerOperations.stopService(item);
   }
 
-  function suspendService(action, item) {
+  function suspendService(_action, item) {
     PowerOperations.suspendService(item);
   }
 
@@ -311,20 +311,6 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
     ];
   }
 
-  function getCurrentFilters() {
-    var filters = ['ancestry=null'];
-
-    angular.forEach(vm.headerConfig.filterConfig.appliedFilters, function(nextFilter) {
-      if (nextFilter.id === 'name') {
-        filters.push("name='%" + nextFilter.value + "%'");
-      } else {
-        filters.push(nextFilter.id + '=' + nextFilter.value);
-      }
-    });
-
-    return filters;
-  }
-
   function getFilterCount() {
     ServicesState.getServicesMinimal(ServicesState.getFilters()).then(querySuccess, queryFailure);
 
@@ -332,7 +318,7 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
       vm.filterCount = result.subcount;
     }
 
-    function queryFailure(error) {
+    function queryFailure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading the services.'));
     }
@@ -392,7 +378,7 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
       getFilterCount();
     }
 
-    function queryFailure(error) {
+    function queryFailure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading the services.'));
     }
@@ -546,27 +532,27 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
     doRetireService(vm.selectedItemsList);
   }
 
-  function editServiceItem(action, item) {
+  function editServiceItem(_action, item) {
     doEditService(item);
   }
 
-  function editTagsItem(action, item) {
+  function editTagsItem(_action, item) {
     doEditTags([item]);
   }
 
-  function removeServicesItem(action, item) {
+  function removeServicesItem(_action, item) {
     doRemoveServices([item]);
   }
 
-  function setOwnershipItem(action, item) {
+  function setOwnershipItem(_action, item) {
     doSetOwnership([item]);
   }
 
-  function setServiceRetirementItem(action, item) {
+  function setServiceRetirementItem(_action, item) {
     doSetServiceRetirement([item]);
   }
 
-  function retireServiceItem(action, item) {
+  function retireServiceItem(_action, item) {
     doRetireService([item]);
   }
 }

--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -150,7 +150,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
       vm.snapshots = response.resources;
     }
 
-    function failure(error) {
+    function failure(_error) {
       vm.loading = false;
       EventNotifications.error(__('There was an error loading snapshots.'));
     }
@@ -163,7 +163,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
       vm.vm = response;
     }
 
-    function failure(error) {
+    function failure(_error) {
       EventNotifications.error(__('There was an error loading the vm.'));
     }
   }
@@ -178,7 +178,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
     resolveSnapshots();
   }
 
-  function deleteSnapshot(action, item) {
+  function deleteSnapshot(_action, item) {
     if (angular.isDefined(item)) {
       vm.snapshotsToRemove = [{"href": item.href}];
       vm.deleteTitle = __('Delete Snapshot');
@@ -191,7 +191,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
     vm.deleteModal = true;
   }
 
-  function processSnapshot(action, item) {
+  function processSnapshot(_action, _item) {
     const modalOptions = {
       component: 'processSnapshotsModal',
       resolve: {

--- a/client/app/shared/autofocus.directive.js
+++ b/client/app/shared/autofocus.directive.js
@@ -13,7 +13,7 @@ export function AutofocusDirective($timeout) {
 
   return directive;
 
-  function link(scope, element) {
+  function link(_scope, element) {
     $timeout(setFocus, 1);
 
     function setFocus() {

--- a/client/app/shared/confirmation/confirmation.directive.js
+++ b/client/app/shared/confirmation/confirmation.directive.js
@@ -31,7 +31,7 @@ export function ConfirmationDirective($uibPosition, $window) {
 
   return directive;
 
-  function link(scope, element, attrs, controller, transclude) {
+  function link(scope, element, attrs, controller) {
     controller.activate({
       getOffset: getOffset,
       getPosition: getPosition,

--- a/client/app/shared/icon-list/icon-list.component.js
+++ b/client/app/shared/icon-list/icon-list.component.js
@@ -2,15 +2,9 @@ import './_icon-list.sass';
 import templateUrl from './icon-list.html';
 
 export const IconListComponent = {
-  controller: ComponentController,
   controllerAs: 'vm',
   bindings: {
     items: '<',
   },
   templateUrl,
 };
-
-/** @ngInject */
-function ComponentController() {
-  var vm = this;
-}

--- a/client/app/shared/tagging/tagging.component.js
+++ b/client/app/shared/tagging/tagging.component.js
@@ -89,7 +89,7 @@ function TaggingController($scope, $filter, $q, $log, CollectionsApi, TaggingSer
   }
 
   vm.showTagDropdowns = false;
-  $scope.$watch('vm.tags.selectedCategory', function(value) {
+  $scope.$watch('vm.tags.selectedCategory', function() {
     vm.tags.filtered = $filter('filter')(vm.tags.all, matchCategory);
     if (vm.tags.filtered) {
       vm.tags.selectedTag = vm.tags.filtered[0];

--- a/client/app/states/dialogs/details/details.state.js
+++ b/client/app/states/dialogs/details/details.state.js
@@ -35,7 +35,7 @@ function StateController($state, dialog, CollectionsApi, EventNotifications, spr
   vm.dialog.copyDialog = dialogAction('copy');
 
   function editDialog(item) {
-    $state.go('dialogs.edit', {dialogId: dialog.id});
+    $state.go('dialogs.edit', {dialogId: item.id});
   }
 
   function dialogAction(action) {
@@ -56,11 +56,10 @@ function StateController($state, dialog, CollectionsApi, EventNotifications, spr
       }
 
       function actionFailure() {
-        var actionString;
         if (action === 'copy') {
-          actionString = EventNotifications.error(__('There was an error copying this dialog.'));
+          EventNotifications.error(__('There was an error copying this dialog.'));
         } else {
-          actionString = EventNotifications.error(__('There was an error deleting this dialog.'));
+          EventNotifications.error(__('There was an error deleting this dialog.'));
         }
       }
     };

--- a/client/app/states/requests/explorer/explorer.state.js
+++ b/client/app/states/requests/explorer/explorer.state.js
@@ -8,14 +8,8 @@ function getStates() {
     'requests.explorer': {
       url: '',
       templateUrl: 'app/states/requests/explorer/explorer.html',
-      controller: StateController,
       controllerAs: 'vm',
       title: N_('Requests'),
     },
   };
-}
-
-/** @ngInject */
-function StateController(RequestsState) {
-  var vm = this;
 }

--- a/client/app/states/requests/explorer/explorer.state.spec.js
+++ b/client/app/states/requests/explorer/explorer.state.spec.js
@@ -1,4 +1,4 @@
-describe('Dashboard', function() {
+describe('app.states.requestsExplorer', function() {
   beforeEach(function() {
     module('app.states', 'app.requests');
     bard.inject('$location', '$rootScope', '$state', '$templateCache', 'Session');
@@ -12,27 +12,6 @@ describe('Dashboard', function() {
     it('should work with $state.go', function() {
       $state.go('requests');
       expect($state.is('requests.explorer'));
-    });
-  });
-
-  describe('controller', function() {
-    var controller;
-
-    var requests = {
-      name: 'requests',
-      count: 1,
-      subcount: 1,
-      resources: []
-    };
-
-    beforeEach(function() {
-      bard.inject('$controller', '$log', '$state', '$rootScope', 'Notifications');
-
-      controller = $controller($state.get('requests.explorer').controller, {requests: requests});
-    });
-
-    it('should be created successfully', function() {
-      expect(controller).to.be.defined;
     });
   });
 });

--- a/client/app/states/services/explorer/explorer.state.js
+++ b/client/app/states/services/explorer/explorer.state.js
@@ -8,14 +8,8 @@ function getStates() {
     'services.explorer': {
       url: '',
       templateUrl: 'app/states/services/explorer/explorer.html',
-      controller: StateController,
       controllerAs: 'vm',
       title: N_('Services Explorer'),
     },
   };
-}
-
-/** @ngInject */
-function StateController() {
-  var vm = this;
 }


### PR DESCRIPTION
Modify eslint configuration to error when a variable is unused. In some
situations it actually makes sense not to use select positional variable
arguments. In those scenarios you can prefix the variable with `_` to
hint eslint (and human readers) that the variable is intentionally not
being used.

The `angular/on-watch` rule was turned off because it conflicts with the
unused var rule by encouraging the use of variables in situations that
don't make sense.

Surprisingly, enabling this rule revealed several minor bugs related to
the use the wrong variables.

@miq-bot add_label euwe/no, enhancement, housekeeping

/cc @AllenBW 😄 