### PR TITLE
[EUWE] Update bower.json to source sinon via registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
   ],
   "devDependencies": {
     "bardjs": "~0.1.8",
-    "sinon": "http://sinonjs.org/releases/sinon-1.15.4.js"
+    "sinon": "1.15.4"
   },
   "dependencies": {
     "jquery": "^2.1.4",


### PR DESCRIPTION
Looks like sinonjs.org stopped hosting the version we were sourcing.
Instead source the desired version through the registry.

@miq-bot add_label darga/yes, bug

/cc @simaishi 