### PR TITLE
PT#140713141-BZ#1425597-Orders now only shows service_orders of state:ordered

### DIFF
--- a/client/app/requests/orders-state.service.js
+++ b/client/app/requests/orders-state.service.js
@@ -42,7 +42,7 @@ export function OrdersStateFactory(ListConfiguration, CollectionsApi) {
   // Private
 
   function getQueryFilters(filters) {
-    const queryFilters = [];
+    const queryFilters = ['state=ordered'];
 
     angular.forEach(filters, function(nextFilter) {
       if (nextFilter.id === 'name') {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/140713141
https://bugzilla.redhat.com/show_bug.cgi?id=1425597

Orders now only shows service_orders of `state:ordered``
Cart and wishlist were two other states, the extra "ghost" order was the newly emptied cart

## you'll notice nav count is same as total result count no
![image](https://cloud.githubusercontent.com/assets/6640236/23411986/1fe7e472-fda2-11e6-94e2-b5ffffb653f8.png)
