### PR TITLE
Corrected parameter for state-changing function

### DIFF
--- a/client/app/states/dialogs/details/details.state.js
+++ b/client/app/states/dialogs/details/details.state.js
@@ -34,8 +34,8 @@ function StateController($state, dialog, CollectionsApi, EventNotifications, spr
   vm.dialog.deleteDialog = dialogAction('delete');
   vm.dialog.copyDialog = dialogAction('copy');
 
-  function editDialog(item) {
-    $state.go('dialogs.edit', {dialogId: item.id});
+  function editDialog() {
+    $state.go('dialogs.edit', {dialogId: vm.dialog.id});
   }
 
   function dialogAction(action) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1427278

`item` was undefined, the dialog's ID is stored in `vm.dialog.id`