### PR TITLE
Ensured that sorting gets applied every time we query for requests.

### DIFF
--- a/client/app/requests/request-explorer/request-explorer.component.js
+++ b/client/app/requests/request-explorer/request-explorer.component.js
@@ -139,6 +139,7 @@ function ComponentController($state, CollectionsApi, RequestsState, ListView, $f
         vm.requestCount = response.subcount;
         vm.toolbarConfig.filterConfig.resultsCount = vm.requestCount;
       }
+      sortChange(RequestsState.getSort().currentField, RequestsState.getSort().isAscending);
     }
 
     function handleError() {


### PR DESCRIPTION
Fix for PV https://www.pivotaltracker.com/story/show/140565343.  Ensured sort choices continue to work after polling occurs