### PR TITLE
Bootstrap both AngularJS and Angular frameworks

### DIFF
--- a/client/app/app.module.ts
+++ b/client/app/app.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { UpgradeModule } from '@angular/upgrade/static';
+
+@NgModule({
+  imports: [
+    BrowserModule,
+    UpgradeModule,
+  ],
+})
+export class AppModule {
+  ngDoBootstrap() {}
+}

--- a/client/app/main.ts
+++ b/client/app/main.ts
@@ -1,0 +1,12 @@
+import './polyfills.ts';
+import '../app.js';
+
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { UpgradeModule } from '@angular/upgrade/static';
+
+import { AppModule } from './app.module';
+
+platformBrowserDynamic().bootstrapModule(AppModule).then(platformRef => {
+  const upgrade = platformRef.injector.get(UpgradeModule) as UpgradeModule;
+  upgrade.bootstrap(document.documentElement, ['app'], { strictDi: true });
+});

--- a/client/app/polyfills.ts
+++ b/client/app/polyfills.ts
@@ -1,0 +1,20 @@
+// This file includes polyfills needed by Angular and is loaded before
+// the app. You can add your own extra polyfills to this file.
+import 'core-js/es6/symbol';
+import 'core-js/es6/object';
+import 'core-js/es6/function';
+import 'core-js/es6/parse-int';
+import 'core-js/es6/parse-float';
+import 'core-js/es6/number';
+import 'core-js/es6/math';
+import 'core-js/es6/string';
+import 'core-js/es6/date';
+import 'core-js/es6/array';
+import 'core-js/es6/regexp';
+import 'core-js/es6/map';
+import 'core-js/es6/set';
+import 'core-js/es6/reflect';
+import 'core-js/es6/promise';
+
+import 'core-js/es7/reflect';
+import 'zone.js/dist/zone';

--- a/client/index.ejs
+++ b/client/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html ng-app="app" ng-strict-di class="layout-pf layout-pf-fixed layout-pf-fixed-inner-scroll transitions">
+<html class="layout-pf layout-pf-fixed layout-pf-fixed-inner-scroll transitions">
   <head lang="en">
     <title ng-bind="title" translate>Service UI</title>
     <meta charset="utf-8"/>

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const ExtractTextWebpackPlugin = require('extract-text-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -14,7 +15,7 @@ console.log("Backend proxied on "+host);
 module.exports = {
   context: root,
   entry: {
-    app: './app.js',
+    app: './app/main.ts',
   },
 
   output: {
@@ -64,7 +65,10 @@ module.exports = {
       // ts loaders: standard typescript loader
       {
         test: /\.ts$/,
-        use: ['ts-loader'],
+        use: [
+          'babel-loader?presets[]=env',
+          'ts-loader',
+        ],
       },
 
       // js loaders: transpile based on browserslist from package.json
@@ -147,6 +151,13 @@ module.exports = {
       base: '/',
       template: '../client/index.ejs',
     }),
+
+    // Fix circular dependency error:
+    // https://github.com/angular/angular/issues/11580#issuecomment-282705332
+    new webpack.ContextReplacementPlugin(
+      /angular(\\|\/)core(\\|\/)@angular/,
+      root
+    )
   ],
 
   resolve: {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
     "vet": "eslint \"client/**/*.js\" && sass-lint --verbose --no-exit"
   },
   "devDependencies": {
+    "@angular/common": "4.0.0-rc.2",
+    "@angular/compiler": "4.0.0-rc.2",
+    "@angular/core": "4.0.0-rc.2",
+    "@angular/platform-browser": "4.0.0-rc.2",
+    "@angular/platform-browser-dynamic": "4.0.0-rc.2",
+    "@angular/upgrade": "4.0.0-rc.2",
     "actioncable": "5.0.1",
     "angular": "1.6.1",
     "angular-animate": "1.6.1",
@@ -55,6 +61,7 @@
     "clean-webpack-plugin": "0.1.15",
     "codeclimate-test-reporter": "0.4.0",
     "copy-webpack-plugin": "4.0.1",
+    "core-js": "2.4.1",
     "css-loader": "0.26.1",
     "debug": "2.6.0",
     "ejs": "2.5.5",
@@ -110,6 +117,7 @@
     "protractor": "5.1.0",
     "q": "1.4.1",
     "request": "2.79.0",
+    "rxjs": "5.2.0",
     "sass-lint": "1.10.2",
     "sass-loader": "4.1.1",
     "sinon": "1.17.7",
@@ -122,22 +130,14 @@
     "url-loader": "0.5.7",
     "webpack": "2.2.1",
     "webpack-dev-server": "2.3.0",
-    "yargs": "6.6.0"
+    "yargs": "6.6.0",
+    "zone.js": "0.7.2"
   },
   "dependencies": {
-    "@angular/common": "4.0.0-rc.2",
-    "@angular/compiler": "4.0.0-rc.2",
-    "@angular/core": "4.0.0-rc.2",
-    "@angular/platform-browser": "4.0.0-rc.2",
-    "@angular/platform-browser-dynamic": "4.0.0-rc.2",
-    "@angular/upgrade": "4.0.0-rc.2",
-    "core-js": "2.4.1",
     "express": "4.14.1",
     "http-proxy": "1.16.2",
     "morgan": "1.7.0",
-    "rxjs": "5.2.0",
-    "serve-favicon": "2.3.2",
-    "zone.js": "0.7.2"
+    "serve-favicon": "2.3.2"
   },
   "browserslist": [
     "last 2 versions",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "start:mock-webserver": "cd server && node app.js",
     "start:all": "yarn start:mock-api & yarn start:mock-webserver",
     "test": "yarn vet && karma start karma.conf.js --single-run",
-    "test:e2e": "./node_modules/.bin/protractor protractor.conf.js",
+    "test:e2e": "protractor protractor.conf.js",
     "test:watch": "karma start --auto-watch --no-single-run",
     "vet": "eslint \"client/**/*.js\" && sass-lint --verbose --no-exit"
   },

--- a/package.json
+++ b/package.json
@@ -125,10 +125,19 @@
     "yargs": "6.6.0"
   },
   "dependencies": {
+    "@angular/common": "4.0.0-rc.2",
+    "@angular/compiler": "4.0.0-rc.2",
+    "@angular/core": "4.0.0-rc.2",
+    "@angular/platform-browser": "4.0.0-rc.2",
+    "@angular/platform-browser-dynamic": "4.0.0-rc.2",
+    "@angular/upgrade": "4.0.0-rc.2",
+    "core-js": "2.4.1",
     "express": "4.14.1",
     "http-proxy": "1.16.2",
     "morgan": "1.7.0",
-    "serve-favicon": "2.3.2"
+    "rxjs": "5.2.0",
+    "serve-favicon": "2.3.2",
+    "zone.js": "0.7.2"
   },
   "browserslist": [
     "last 2 versions",

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -39,6 +39,11 @@ var config = {
 
   onPrepare: function() {
     global.protractorConfig = env;
+
+    // Required for protractor to work with a hybrid AngularJs/Angular app
+    browser.ignoreSynchronization = true;
+    browser.waitForAngularEnabled(false);
+
     browser.driver.manage().window().maximize();
     browser.driver.get(env.baseUrl );
     browser.sleep(5000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@angular/common@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-4.0.0-rc.2.tgz#69f68639270d71b2e8c552e4fa939975fcb88304"
+
+"@angular/compiler@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-4.0.0-rc.2.tgz#643e199e6792413f42cf149a9cf1672284787c11"
+
+"@angular/core@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-4.0.0-rc.2.tgz#59535050e5d0e6141417186eee571296f8e9c3d0"
+
+"@angular/platform-browser-dynamic@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.0.0-rc.2.tgz#f2bbab322706dc6361d46647e1e2b7c26f036a1c"
+
+"@angular/platform-browser@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/platform-browser/-/platform-browser-4.0.0-rc.2.tgz#bcca05ce85d320ee0b257640f15479b59fed20f0"
+
+"@angular/upgrade@4.0.0-rc.2":
+  version "4.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@angular/upgrade/-/upgrade-4.0.0-rc.2.tgz#e569801330bf7640725bd86bb94cedc15e0aead1"
+
 "@types/node@^6.0.46":
   version "6.0.62"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.62.tgz#85222c077b54f25b57417bb708b9f877bda37f89"
@@ -1568,7 +1592,7 @@ copy-webpack-plugin@4.0.1:
     minimatch "^3.0.0"
     node-dir "^0.1.10"
 
-core-js@^2.2.0, core-js@^2.4.0:
+core-js@2.4.1, core-js@^2.2.0, core-js@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
@@ -5957,6 +5981,12 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rxjs@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 safe-buffer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
@@ -6506,6 +6536,10 @@ svgo@^0.7.0:
     mkdirp "~0.5.1"
     sax "~1.2.1"
     whet.extend "~0.9.9"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 table@^3.7.8:
   version "3.8.3"
@@ -7220,3 +7254,7 @@ yauzl@2.4.1:
 yeast@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/yeast/-/yeast-0.1.2.tgz#008e06d8094320c372dbc2f8ed76a0ca6c8ac419"
+
+zone.js@0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/zone.js/-/zone.js-0.7.2.tgz#1a62b6be4b24d1b935e4566b0b4386b66966d1a7"


### PR DESCRIPTION
Going forward AngularJS refers to the 1.x framework while Angular refers
to the 2+ framework.

Automatic bootstrapping using `ng-app` in `index.ejs` is not supported
for Angular and hybrid applications. Instead, manually bootstrap both
frameworks from `app/main.ts` and make it the new webpack entry point.

The new entry point imports polyfills required for Angular to operate
correctly and then imports the existing AngularJS bootstrapping process
from `app.js`.

This change also adds a number of new dependencies and peer dependencies
required to run Angular.

Aside from a slightly larger output bundle, the application should
function exactly the same as it did before. The only difference is that
we can now add new dependencies and units in Angular.

https://www.pivotaltracker.com/story/show/140847211

@miq-bot add_label euwe/no, enhancement