### PR TITLE
Speed up e2e test execution time

### DIFF
--- a/client/app/catalogs/catalog-explorer.e2e.js
+++ b/client/app/catalogs/catalog-explorer.e2e.js
@@ -1,6 +1,5 @@
 describe('Component: catalogExplorer', function() {
   beforeEach(function() {
-    browser.sleep(10000);
     browser.get('/catalogs');
   });
   it('should have correct breadcrumb', function() {

--- a/client/app/requests/order-explorer/order-explorer.e2e.js
+++ b/client/app/requests/order-explorer/order-explorer.e2e.js
@@ -1,6 +1,5 @@
 describe('Component: orderExplorer', function() {
   beforeEach(function() {
-    browser.sleep(10000);
     browser.get('/orders');
   });
   it('should have correct breadcrumb', function() {

--- a/client/app/services/vms/snapshots.e2e.js
+++ b/client/app/services/vms/snapshots.e2e.js
@@ -1,7 +1,6 @@
 describe('Component: snapshots', function() {
   it('should list two snapshots', function() {
     browser.get('vms/10000000001447/snapshots');
-    browser.sleep(10000);
 
     const list = element.all(by.css('.list-view-container .list-group .list-group-item'));
     expect(list.count()).toBe(2);

--- a/client/app/shared/pagination/pagination.e2e.js
+++ b/client/app/shared/pagination/pagination.e2e.js
@@ -1,7 +1,6 @@
 describe('Component: pagination', function() {
   it('should correctly respond to a change in limit', function() {
     browser.get('/services');
-    browser.sleep(10000);
     element.all(by.css('.pagination-footer button')).click();
     element.all(by.css('.pagination-footer ul.dropdown-menu li:nth-child(1) a')).click();
 
@@ -11,7 +10,6 @@ describe('Component: pagination', function() {
 
   it('should successfully page forward', function() {
     browser.get('/catalogs');
-    browser.sleep(10000);
     changeLimit();
 
     const limit = element.all(by.css('.pagination-footer .pagination-controls'));
@@ -24,7 +22,6 @@ describe('Component: pagination', function() {
 
   it('should successfully page backward', function() {
     browser.get('/catalogs');
-    browser.sleep(10000);
     changeLimit();
 
     const limit = element.all(by.css('.pagination-footer .pagination-controls'));
@@ -44,10 +41,8 @@ describe('Component: pagination', function() {
 function changeLimit() {
   element.all(by.css('.pagination-footer button')).click();
   element.all(by.css('.pagination-footer ul.dropdown-menu li:nth-child(1) a')).click();
-  browser.sleep(10000);
 }
 
 function pageNext() {
   element.all(by.css('.pagination-footer .pagination-controls ul.pagination span[alt="Next"]')).click();
-  browser.sleep(10000);
 }

--- a/client/app/states/dashboard/dashboard.e2e.js
+++ b/client/app/states/dashboard/dashboard.e2e.js
@@ -1,7 +1,6 @@
 describe('dashboard', function() {
   beforeEach(function () {
-    browser.sleep(10000);
-    browser.get(protractorConfig.baseUrl);
+    browser.get(browser.baseUrl);
   });
   it('should have two counters up top', function() {
     var list = element.all(by.css('.ss-dashboard__card-primary__count'));

--- a/client/app/states/login/login.e2e.js
+++ b/client/app/states/login/login.e2e.js
@@ -1,6 +1,5 @@
 describe('pages with login', function() {
   it('should log in with a non-Angular page', function() {
-    browser.sleep(10000);
     console.log("Executing login Test");
     browser.driver.executeScript('return window.sessionStorage.getItem("ngStorage-token");').then(function(retValue) {
       console.log("Token value =>" + retValue);

--- a/client/app/templates/template-editor.e2e.js
+++ b/client/app/templates/template-editor.e2e.js
@@ -1,6 +1,5 @@
 describe('Component: templateEditor', function () {
   beforeEach(function () {
-    browser.sleep(10000);
     browser.get('/templates/edit/10000000000124');
   });
   it('should have correct breadcrumb', function () {

--- a/client/app/templates/template-explorer.e2e.js
+++ b/client/app/templates/template-explorer.e2e.js
@@ -1,6 +1,5 @@
 describe('Component: templateExplorer', function () {
   beforeEach(function () {
-    browser.sleep(10000);
     browser.get('/templates');
   });
   it('should have correct breadcrumb', function () {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -28,7 +28,6 @@ var env = {
 // This is the configuration file showing how a suite of tests might
 // handle log-in using the onPrepare field.
 var config = {
- // seleniumAddress: env.seleniumAddress,
   specs: [
     '**/*.e2e.js'
   ],
@@ -38,28 +37,21 @@ var config = {
   baseUrl: env.baseUrl + '/',
 
   onPrepare: function() {
-    global.protractorConfig = env;
-
     // Required for protractor to work with a hybrid AngularJs/Angular app
     browser.ignoreSynchronization = true;
     browser.waitForAngularEnabled(false);
 
     browser.driver.manage().window().maximize();
     browser.driver.get(env.baseUrl );
-    browser.sleep(5000);
     browser.driver.findElement(by.id('inputUsername')).sendKeys('admin');
     browser.driver.findElement(by.id('inputPassword')).sendKeys('smartvm');
     browser.driver.findElement(by.css('button[type=submit]')).click();
 
-    // Login takes some time, so wait until it's done.
-    // For the test app's login, we know it's done when it redirects to
-    // index.html.
-    return browser.driver.wait(function() {
-      return browser.driver.getCurrentUrl().then(function(url) {
-
-        return env.baseUrl +'/';
-      });
-    }, 10000);
+    return browser.driver.wait(
+      protractor.until.urlIs(browser.baseUrl),
+      10 * 1000,
+      'Browser did not redirect to dashboard after logging in...'
+    );
   }
 };
 


### PR DESCRIPTION
Remove `browser.sleep` calls since they no longer appear necessary.
Remove global `protractorConfig` variable and use built-in
`browser.baseUrl` instead.

Also refactor login procedure to use promises and built in web driver
functions.

Reduces e2e test time from ~250 seconds to ~20 seconds.

@miq-bot add_label euwe/no, enhancement