### PR TITLE
Do not pre-populate retirement date with today's date

### DIFF
--- a/client/app/services/retire-service-modal/retire-service-modal.component.js
+++ b/client/app/services/retire-service-modal/retire-service-modal.component.js
@@ -17,10 +17,7 @@ function ComponentController($scope, $state, CollectionsApi, EventNotifications,
 
   angular.extend(vm, {
     visibleOptions: [],
-    modalData: {
-      date: new Date(),
-      warn: 0,
-    },
+    modalData: {},
     isService: vm.resolve.services.length === 1,
     resetModal: false,
     services: vm.resolve.services,
@@ -54,7 +51,7 @@ function ComponentController($scope, $state, CollectionsApi, EventNotifications,
       vm.resetModal = true;
       var existingDate = new Date(vm.services[0].retires_on);
       var existingUTCDate = new Date(existingDate.getTime() + existingDate.getTimezoneOffset() * 60000);
-      vm.modalData.date = vm.services[0].retires_on ? existingUTCDate : new Date();
+      vm.modalData.date = vm.services[0].retires_on ? existingUTCDate : null;
       vm.modalData.warn = vm.services[0].retirement_warn || 0;
     }
 


### PR DESCRIPTION
Change the retire service modal to not display today's date in the
retirement field by default. For all action button groups that have a
reset button, it is important to copy the initial state of the form to
determine whether buttons should be enabled/disabled.

https://www.pivotaltracker.com/story/show/141145109
https://bugzilla.redhat.com/show_bug.cgi?id=1426758

@miq-bot add_label euwe/no, bug, services