### PR TITLE
Disable $q unhandled rejection exceptions

### DIFF
--- a/client/app/core/config.js
+++ b/client/app/core/config.js
@@ -9,11 +9,13 @@ var DEVEL_DOMAINS = [
 var isDevel = window._.includes(DEVEL_DOMAINS, window.location.hostname);
 
 /** @ngInject */
-export function configure($logProvider, $compileProvider) {
+export function configure($logProvider, $compileProvider, $qProvider) {
   $logProvider.debugEnabled(isDevel);
   $compileProvider.debugInfoEnabled(isDevel);
 
   // TODO: Remove following line as per: https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$compile
   $compileProvider.preAssignBindingsEnabled(true);
+
+  $qProvider.errorOnUnhandledRejections(false);
 }
 


### PR DESCRIPTION
Ever since our Angular 1.5.9 upgrade we have seen exceptions when
closing modals. This stems from some of our dependencies not handling
rejections when using the `$q` service which effectively puts it out of
our control.

Since we are using native `Promise`s instead of `$q` going forward, we
don't need the potential benefit of these exceptions being raised and
can instead disable them.

@miq-bot add_label euwe/no, ehancement