### PR TITLE
Updated our yarn command and turned on caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,13 @@ node_js:
 - 6.9.1
 sudo: false
 cache:
+  yarn: true
   directories:
   - node_modules
 before_install:
 - npm install -g yarn@0.19.1
 install:
-- yarn install --force
+- yarn install
 after_script:
 - codeclimate-test-reporter < reports/coverage/report-lcov/lcov.info
 notifications:


### PR DESCRIPTION
This is a proposed enhancement that would just have us use the regular yarn install command so we can leverage caching.  This also turns on travis’s support for yarn caching 