### PR TITLE
Add 'Last Message' to the requests explorer

### DIFF
--- a/client/app/requests/request-explorer/request-explorer.component.js
+++ b/client/app/requests/request-explorer/request-explorer.component.js
@@ -113,7 +113,15 @@ function ComponentController($state, CollectionsApi, RequestsState, ListView, $f
 
   function fetchData(limit, offset, _refresh) {
     var filter = [];
-    var attributes = ['picture', 'picture.image_href', 'approval_state', 'created_on', 'description', 'requester_name'];
+    var attributes = [
+      'approval_state',
+      'created_on',
+      'description',
+      'message',
+      'picture',
+      'picture.image_href',
+      'requester_name',
+    ];
     var options = {
       expand: 'resources',
       limit: limit,

--- a/client/app/requests/request-explorer/request-explorer.html
+++ b/client/app/requests/request-explorer/request-explorer.html
@@ -32,18 +32,33 @@
           {{ item.description }}
         </span>
       </div>
-      <div class="col-lg-2 col-md-3 col-sm-4 col-xs-4">
-        <span class="no-wrap">
-          <strong translate>ID </strong>&nbsp;{{ item.id }}
-        </span>
+      <div class="col-lg-3 col-md-5 col-sm-4 col-xs-4">
+        <div class="list-view-stacked-item no-wrap"
+             uib-tooltip="The last message emitted by the request processing state machine"
+             tooltip-append-to-body="true"
+             tooltip-popup-delay="1000"
+             tooltip-placement="bottom-left">
+          <strong translate>Last Message</strong>&nbsp;
+          <div>
+            {{ item.message }}
+          </div>
+        </div>
       </div>
       <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
-        <span class="no-wrap">
-          <strong translate>Requester </strong>&nbsp;{{ item.requester_name }}
-        </span>
+        <div class="list-view-stacked-item"
+             uib-tooltip="Requester: {{item.requester_name}}"
+             tooltip-append-to-body="true"
+             tooltip-popup-delay="1000"
+             tooltip-placement="bottom-left">
+          <strong translate>Requester</strong>&nbsp;
+          <div>
+            {{ item.requester_name }}
+          </div>
+        </div>
       </div>
       <div class="col-lg-2 hidden-md hidden-sm hidden-xs">
-        <div class="list-view-stacked-item" uib-tooltip="Requested: {{item.created_on | date : 'short'}}"
+        <div class="list-view-stacked-item"
+             uib-tooltip="Requested: {{item.created_on | date : 'short'}}"
              tooltip-append-to-body="true"
              tooltip-popup-delay="1000"
              tooltip-placement="bottom-left">
@@ -53,7 +68,7 @@
           </div>
         </div>
       </div>
-      <div class="col-lg-2 col-md-4 hidden-sm hidden-xs">
+      <div class="col-lg-1 col-md-2 hidden-sm hidden-xs">
         <span class="text-capitalize no-wrap">
           <span class="fa fa-clock-o" ng-if="item.approval_state == 'pending_approval'"
                 uib-tooltip="{{'The current approval status of the request'|translate}}"
@@ -64,7 +79,6 @@
           <span class="pficon pficon-ok" ng-if="item.approval_state == 'approved'"
                 uib-tooltip="{{'The current approval status of the request'|translate}}"
                 tooltip-placement="bottom"></span>
-          {{ item.approval_state }}
         </span>
       </div>
     </div>


### PR DESCRIPTION
Replace the 'ID' field with the 'Last Message' field in the requests
explorer. The id field is not used in any other collection view while
the message field generally provides more 'at a glance' information.

Because the message field is generally larger than the id column was,
shorten the approval status field to show only the icon and not the
text.

This change also modifies the other fields to have the stacked column
look, for consistency.

https://www.pivotaltracker.com/story/show/138616171
https://bugzilla.redhat.com/show_bug.cgi?id=1365253

@miq-bot add_label euwe/no, bug, requests

**Before:**
<img width="1170" alt="screen shot 2017-03-09 at 11 39 43 am" src="https://cloud.githubusercontent.com/assets/6842753/23760251/205db2ca-04bd-11e7-9e82-5a6fa73fa2d6.png">

**After:**
<img width="1188" alt="screen shot 2017-03-09 at 11 38 25 am" src="https://cloud.githubusercontent.com/assets/6842753/23760183/f51dd07c-04bc-11e7-8770-aed90632ecc8.png">
