### PR TITLE
Service details page was faling to load for those services without creds

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -76,12 +76,17 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
         vm.availableTags = response;
       }
 
-      ServicesState.getServiceCredential(vm.service.options.config_info.provision.credential_id).then(assignCredential);
-      function assignCredential(response) {
-        vm.service.credential = [response];
+      if (angular.isDefined(vm.service.options.config_info)) {
+        ServicesState.getServiceCredential(vm.service.options.config_info.provision.credential_id).then(assignCredential);
+      } else {
+        vm.service.credential = [];
       }
 
       vm.loading = false;
+
+      function assignCredential(response) {
+        vm.service.credential = [response];
+      }
     }
 
     function handleFailure(response) {


### PR DESCRIPTION
No visual changes, cept now you can see service details pages for all those services that aren't ansible