### PR TITLE
Fix dialogs breadcrumb navigation

### DIFF
--- a/client/app/dialogs/dialogs-list.component.js
+++ b/client/app/dialogs/dialogs-list.component.js
@@ -116,7 +116,7 @@ function DialogListController($state, DialogsState, $filter, Language, ListView)
     vm.toolbarConfig.filterConfig.resultsCount = vm.dialogList.length;
   }
 
-  var matchesFilter = function(item, filter) {
+  function matchesFilter(item, filter) {
     if (filter.id === 'label') {
       return item.label.toLowerCase().indexOf(filter.value.toLowerCase()) !== -1;
     } else if (filter.id === 'updated_at') {
@@ -124,7 +124,7 @@ function DialogListController($state, DialogsState, $filter, Language, ListView)
     }
 
     return false;
-  };
+  }
 
   Language.fixState(DialogsState, vm.toolbarConfig);
 }


### PR DESCRIPTION
The dialogs breadcrumb error reported in the ticket was caused by the
`matchesFilter` function being defined as a function expression with
surrounding code expecting the function to be hoisted.

Convert the function to a function declaration so that it can be
hoisted.

https://www.pivotaltracker.com/story/show/141593937
https://bugzilla.redhat.com/show_bug.cgi?id=1430077

@miq-bot add_label euwe/no, bug, dialogs