### PR TITLE
Remove uib-tooltip directive from custom-dropdown

### DIFF
--- a/client/app/shared/custom-dropdown/custom-dropdown.html
+++ b/client/app/shared/custom-dropdown/custom-dropdown.html
@@ -1,6 +1,5 @@
 <span class="primary-action pull-left" uib-dropdown>
-  <button type="button" class="btn btn-default" uib-dropdown-toggle type="button"
-          ng-disabled="vm.config.isDisabled" uib-tooltip=" {{vm.config.title}} " tooltip-placement="left">
+  <button type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="vm.config.isDisabled">
     <i class="{{vm.config.icon}}"></i>
     <sapn ng-if="vm.config.name">{{vm.config.name}}</sapn>
     <span class="caret"></span>


### PR DESCRIPTION
In certain situations custom-dropdowns obscure the view of other
controls, this change removes the uib-tooltip for custom-dropdowns since
it typically adds clutter.

https://www.pivotaltracker.com/story/show/141594039
https://bugzilla.redhat.com/show_bug.cgi?id=1430331

@miq-bot add_label euwe/no, bug