### PR TITLE
Fix services filter count and pagination controls

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -320,7 +320,8 @@ function ComponentController($state, ServicesState, Language, ListView, Chargeba
   }
 
   function getFilterCount() {
-    ServicesState.getServicesMinimal(ServicesState.getFilters()).then(querySuccess, queryFailure);
+    ServicesState.getServicesMinimal(ServicesState.services.getFilters())
+      .then(querySuccess, queryFailure);
 
     function querySuccess(result) {
       vm.filterCount = result.subcount;


### PR DESCRIPTION
Pagination controls for services were not usable because the
`filterCount` was not being updated. The failure to update was due to an
attempt to call a previously moved function.

Update to call `getFilters` from the new location.

@miq-bot add_label euwe/no, bug, services