### PR TITLE
PT#141947277 - denote retired resources

### DIFF
--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -277,7 +277,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
 
   function showToast(notification) {
     notification.show = true;
-    notification.persistent = notification.type === 'danger' || notification.type === 'error';
+    notification.persistent = notification.data.persistent || notification.type === 'danger' || notification.type === 'error';
     state.toastNotifications.push(notification);
 
     // any toast notifications with out 'danger' or 'error' status are automatically removed after a delay

--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -38,7 +38,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
 
   function miqFormatNotification(text, bindings) {
     var str = __(text);
-    lodash.each(bindings, function (value, key) {
+    lodash.each(bindings, function(value, key) {
       str = str.replace(new RegExp('%{' + key + '}', 'g'), value.text);
     });
 
@@ -47,21 +47,21 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
 
   doReset();
 
-  ServerInfo.promise.then( function() {
+  ServerInfo.promise.then(function() {
     if (ServerInfo.data.asyncNotify) {
       var cable = ActionCable.createConsumer('/ws/notifications');
 
       cable.subscriptions.create('NotificationChannel', {
-        disconnected: function () {
+        disconnected: function() {
           var vm = this;
-          Session.requestWsToken().then(null, function () {
+          Session.requestWsToken().then(null, function() {
             $log.warning('Unable to retrieve a valid ws_token!');
             // Disconnect permanently if the ws_token cannot be fetched
-            vm.consumer.connection.close({ allowReconnect: false });
+            vm.consumer.connection.close({allowReconnect: false});
           });
         },
-        received: function (data) {
-          $timeout(function () {
+        received: function(data) {
+          $timeout(function() {
             var msg = miqFormatNotification(data.text, data.bindings);
             service.add('event', data.level, msg, {message: msg}, data.id);
           });
@@ -88,7 +88,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
       attributes: 'details',
     };
 
-    CollectionsApi.query('notifications', options).then(function (result) {
+    CollectionsApi.query('notifications', options).then(function(result) {
       result.resources.forEach(function(resource) {
         var msg = miqFormatNotification(resource.details.text, resource.details.bindings);
         events.notifications.unshift({
@@ -112,10 +112,10 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
     var newNotification = {
       id: id,
       notificationType: notificationType,
-      unread: true,
+      unread: angular.isDefined(notificationData) ? notificationData.unread : true,
       type: type,
       message: message,
-      data: notificationData,
+      data: notificationData || {},
       href: id ? '/api/notifications/' + id : undefined,
       timeStamp: (new Date()).getTime(),
     };
@@ -209,11 +209,11 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
 
   function markAllRead(group) {
     if (group) {
-      var resources = group.notifications.map(function (notification) {
+      var resources = group.notifications.map(function(notification) {
         notification.unread = false;
         service.removeToast(notification);
 
-        return { href: notification.href };
+        return {href: notification.href};
       });
       if (resources.length > 0) {
         CollectionsApi.post('notifications', undefined, {}, {action: 'mark_as_seen', resources: resources});
@@ -256,7 +256,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
       var resources = group.notifications.map(function(notification) {
         service.removeToast(notification);
 
-        return { href: notification.href };
+        return {href: notification.href};
       });
 
       if (resources.length > 0) {
@@ -288,7 +288,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
         if (!notification.viewing) {
           removeToast(notification);
         }
-      }, toastDelay);
+      }, notification.data.toastDelay || toastDelay);
     }
   }
 

--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -55,7 +55,7 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
         disconnected: function() {
           var vm = this;
           Session.requestWsToken().then(null, function() {
-            $log.warning('Unable to retrieve a valid ws_token!');
+            $log.warn('Unable to retrieve a valid ws_token!');
             // Disconnect permanently if the ws_token cannot be fetched
             vm.consumer.connection.close({allowReconnect: false});
           });

--- a/client/app/core/router/router-helper.provider.js
+++ b/client/app/core/router/router-helper.provider.js
@@ -83,7 +83,7 @@ export function routerHelperProvider($locationProvider, $stateProvider, $urlRout
       msg = 'Error routing to ' + destination + '. '
         + (error.data || '') + '. <br/>' + (error.statusText || '')
         + ': ' + (error.status || '');
-      $log.warning(msg, [toState, error]);
+      $log.warn(msg, [toState, error]);
       $location.path('/');
     }
 

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -52,7 +52,10 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
       // Config setup
       permissions: ServicesState.getPermissions(),
       headerConfig: getHeaderConfig(),
-      resourceListConfig: getResourceListConfig(),
+      resourceListConfig: {
+        showSelectBox: false,
+        checkDisabled: isResourceDisabled,
+      },
     });
     fetchResources(vm.serviceId);
     Polling.start('servicesPolling', startPollingService, 50000);
@@ -280,12 +283,6 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
     }
   }
 
-  function getResourceListConfig() {
-    return {
-      showSelectBox: false,
-    };
-  }
-
   function createResourceGroups(service) {
     return {
       title: __('Compute'),
@@ -334,5 +331,9 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
 
   function gotoService(service) {
     $state.go('services.details', {serviceId: service.id});
+  }
+
+  function isResourceDisabled(item) {
+    return item.retired;
   }
 }

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -153,6 +153,13 @@
                 <div class="row">
                   <div class="col-lg-2 col-md-4 col-sm-3 col-xs-5 name-column">
                     <span class="no-wrap">
+                      <i ng-if="item.retired"
+                         class="fa fa-bed"
+                         uib-tooltip="{{'Retired resource'|translate}}"
+                         tooltip-append-to-body="true"
+                         tooltip-popup-delay="1000"
+                         tooltip-placement="bottom"></i>
+                      <span ng-if="!item.retired">
                       <i class="pficon fa fa-power-off" ng-if="item.power_state === 'off'"
                          uib-tooltip="{{'Power State: Off'|translate}}"
                          tooltip-append-to-body="true"
@@ -169,6 +176,7 @@
                          tooltip-append-to-body="true"
                          tooltip-popup-delay="1000"
                          tooltip-placement="bottom"></i>
+                      </span>
                       <a uib-tooltip="{{item.name}}"
                          tooltip-placement="bottom"
                          tooltip-append-to-body="true"
@@ -185,7 +193,7 @@
                   <div class="col-lg-2 col-md-2 col-sm-3 hidden-xs">
                     <div>
                       <span class="no-wrap">
-                        <strong translate>Snapshots</strong>&nbsp;
+                        <i class="fa fa-camera"></i>&nbsp;
                         <span ng-if="item.v_total_snapshots"
                               uib-tooltip="{{'Total Snapshots' | translate}} : {{item.v_total_snapshots}}"
                               tooltip-append-to-body="true"
@@ -252,7 +260,7 @@
                       </span>
                     </div>
                   </div>
-                  <div class="list-view-pf-actions">
+                  <div ng-if="!item.retired" class="list-view-pf-actions">
                     <div class="btn-group dropdown-kebab-pf" uib-dropdown dropdown-append-to-body>
                       <button type="button" class="btn btn-default" uib-dropdown-toggle type="button">
                         <span translate>Access</span>

--- a/client/app/states/vms/details/details.html
+++ b/client/app/states/vms/details/details.html
@@ -1,113 +1,157 @@
-<ol class="breadcrumb">
-  <li>
-    <a ui-sref="services.explorer">{{'Services'|translate}}</a>
-  </li>
-  <li>
-    <a ui-sref="services.details({serviceId: vm.vmDetails.service.id})">{{ ::vm.vmDetails.service.name }}</a>
-  </li>
-  <li>
-    {{ ::vm.vmDetails.name }}
-  </li>
-</ol>
+<div class="breadcrumb-bar">
+  <span>
+      <ol class="breadcrumb">
+        <li>
+          <a ui-sref="services">{{'Services'|translate}}</a>
+        </li>
+        <li>
+          <a ui-sref="services.details({serviceId: vm.vmDetails.service.id})">{{ ::vm.vmDetails.service.name }}</a>
+        </li>
+        <li>
+          {{ ::vm.vmDetails.name }}
+        </li>
+      </ol>
+  </span>
+</div>
+
 <div class="ss-details-wrapper vm-details-wrapper">
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Properties'|translate}}</div>
-		</div>
-		<detail-reveal title="Name" detail="{{::vm.vmDetails.name}}"></detail-reveal>
-		<detail-reveal title="Hostnames" detail="{{::vm.vmDetails.hostnames.join(',')}}"></detail-reveal>
-		<detail-reveal title="IP Addresses" detail="{{::vm.vmDetails.ipaddresses.join(',')}}"></detail-reveal>
-		<detail-reveal title="MAC Address" detail="{{::vm.vmDetails.mac_addresses.join(',')}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Container" detail="{{::vm.vmDetails.containerSpecsText}}"></detail-reveal>
-		<detail-reveal title="Parent Host/Node Platform" detail="{{::vm.vmDetails.host.vmm_product}}" ng-if="vm.vmDetails.host"></detail-reveal>
-		<detail-reveal title="Platform Tools" detail="{{::vm.vmDetails.tools_status}}"></detail-reveal>
-		<detail-reveal title="Operating System" detail="{{::vm.vmDetails.hardware.guest_os_full_name}}"></detail-reveal>
-		<detail-reveal title="Architecture" detail="{{::vm.vmDetails.hardware.bitness}} bit" ng-if="vm.vmDetails.hardware.bitness"></detail-reveal>
-		<detail-reveal title="Devices" icon="fa fa-hdd-o fa-lg" detail="{{3 + vm.vmDetails.num_disks}}" ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-		<detail-reveal title="CPU Affinity" detail="{{::vm.vmDetails.cpu_affinity}}" ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-		<detail-reveal title="Snapshots" icon="fa fa-camera fa-lg" detail="{{::vm.vmDetails.snapshotCount}}"></detail-reveal>
-		<detail-reveal title="Advanced Settings" icon="fa fa-wrench fa-lg" detail="{{::vm.vmDetails.advanced_settings.length}}"></detail-reveal>
-		<detail-reveal title="Resources" detail="{{::vm.vmDetails.resourceAvailability}}"></detail-reveal>
-		<detail-reveal title="Management Engine GUID" detail="{{::vm.vmDetails.guid}}"></detail-reveal>
-		<detail-reveal title="Virtualization" detail="{{::vm.vmDetails.hardware.virtualization_type}}" ng-if="vm.vmDetails.hardware.virtualization_type"></detail-reveal>
-		<detail-reveal title="Root Device Type" detail="{{::vm.vmDetails.hardware.root_device_type}}" ng-if="vm.vmDetails.hardware.root_device_type"></detail-reveal>
-		<detail-reveal title="ID within Provider" detail="{{::vm.vmDetails.uid_ems}}" ng-if="vm.vmDetails.uid_ems"></detail-reveal>
-	</div>
+  <h2 class="text-center" ng-if="vm.vmDetails.instance.retired">This is a retired resource.</h2>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Properties'|translate}}</div>
+    </div>
+    <detail-reveal title="Name" detail="{{::vm.vmDetails.name}}"></detail-reveal>
+    <detail-reveal title="Hostnames" detail="{{::vm.vmDetails.hostnames.join(',')}}"></detail-reveal>
+    <detail-reveal title="IP Addresses" detail="{{::vm.vmDetails.ipaddresses.join(',')}}"></detail-reveal>
+    <detail-reveal title="MAC Address" detail="{{::vm.vmDetails.mac_addresses.join(',')}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Container" detail="{{::vm.vmDetails.containerSpecsText}}"></detail-reveal>
+    <detail-reveal title="Parent Host/Node Platform" detail="{{::vm.vmDetails.host.vmm_product}}"
+                   ng-if="vm.vmDetails.host"></detail-reveal>
+    <detail-reveal title="Platform Tools" detail="{{::vm.vmDetails.tools_status}}"></detail-reveal>
+    <detail-reveal title="Operating System" detail="{{::vm.vmDetails.hardware.guest_os_full_name}}"></detail-reveal>
+    <detail-reveal title="Architecture" detail="{{::vm.vmDetails.hardware.bitness}} bit"
+                   ng-if="vm.vmDetails.hardware.bitness"></detail-reveal>
+    <detail-reveal title="Devices" icon="fa fa-hdd-o fa-lg" detail="{{3 + vm.vmDetails.num_disks}}"
+                   ng-if="vm.vmDetails.cloud===false"></detail-reveal>
+    <detail-reveal title="CPU Affinity" detail="{{::vm.vmDetails.cpu_affinity}}"
+                   ng-if="vm.vmDetails.cloud===false"></detail-reveal>
+    <detail-reveal title="Snapshots" icon="fa fa-camera fa-lg"
+                   detail="{{::vm.vmDetails.snapshotCount}}"></detail-reveal>
+    <detail-reveal title="Advanced Settings" icon="fa fa-wrench fa-lg"
+                   detail="{{::vm.vmDetails.advanced_settings.length}}"></detail-reveal>
+    <detail-reveal title="Resources" detail="{{::vm.vmDetails.resourceAvailability}}"></detail-reveal>
+    <detail-reveal title="Management Engine GUID" detail="{{::vm.vmDetails.guid}}"></detail-reveal>
+    <detail-reveal title="Virtualization" detail="{{::vm.vmDetails.hardware.virtualization_type}}"
+                   ng-if="vm.vmDetails.hardware.virtualization_type"></detail-reveal>
+    <detail-reveal title="Root Device Type" detail="{{::vm.vmDetails.hardware.root_device_type}}"
+                   ng-if="vm.vmDetails.hardware.root_device_type"></detail-reveal>
+    <detail-reveal title="ID within Provider" detail="{{::vm.vmDetails.uid_ems}}"
+                   ng-if="vm.vmDetails.uid_ems"></detail-reveal>
+  </div>
 
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Lifecycle'|translate}}</div>
-		</div>
-		<detail-reveal title="Discovered on" detail="{{ ::vm.vmDetails.created_on | date:'medium' }}"></detail-reveal>
-		<detail-reveal title="Last Analyzed" icon="fa fa-search fa-lg" detail="{{ ::vm.vmDetails.lastSyncOn | date:'medium' }}"></detail-reveal>
-		<detail-reveal title="Retirement Date" icon="fa fa-clock-o fa-lg" detail="{{ ::vm.vmDetails.retiresOn | date:'medium' }}"></detail-reveal>
-		<detail-reveal title="Provisioned On" detail="{{ ::vm.vmDetails.provisionDate | date:'medium' }}"></detail-reveal>
-		<detail-reveal title="Owner" detail="{{::vm.vmDetails.evm_owner.name}}"></detail-reveal>
-		<detail-reveal title="Group" detail="{{::vm.vmDetails.miq_group.description}}"></detail-reveal>
-	</div>
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Relationships'|translate}}</div>
-		</div>
-		<detail-reveal title="Availability Zone" detail="{{::vm.vmDetails.instance.availabilityZone}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Cloud Tenants" detail="{{::vm.vmDetails.instance.cloudTenant}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Flavor" detail="{{::vm.vmDetails.instance.flavor.name}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="VM Template" detail="{{::vm.vmDetails.instance.miq_provision_template.name}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Infrastructure provider" detail="{{::vm.vmDetails.ext_management_system.name}}" ng-if="vm.vmDetails.ext_management_system.name"></detail-reveal>
-		<detail-reveal title="{{'Cluster'|translate}} / {{'Deployment Role'|translate}}" icon="fa fa-lg pficon pficon-cluster" detail="{{::vm.vmDetails.ems_cluster.name}}"
-			ng-if="vm.vmDetails.ems_cluster.name"></detail-reveal>
-		<detail-reveal title="Host / Node" icon="fa fa-lg pficon pficon-screen" detail="{{::vm.vmDetails.host.name}}" ng-if="vm.vmDetails.host.name"></detail-reveal>
-		<detail-reveal title="Resource Pool" icon="fa fa-lg pficon pficon-resource-pool" detail="{{::vm.vmDetails.parent_resource_pool.name}}"
-			ng-if="vm.vmDetails.parent_resource_pool"></detail-reveal>
-		<detail-reveal title="Datastores" icon="fa fa-lg fa-database" detail="{{::vm.vmDetails.storages.length}}" ng-if="vm.vmDetails.storages.length > 0"></detail-reveal>
-		<detail-reveal title="Service" icon="fa fa-lg pficon pficon-service" detail="{{::vm.vmDetails.service.name}}"></detail-reveal>
-		<detail-reveal title="Virtual Private Cloud" detail="{{::vm.vmDetails.instance.cloud_networks[0].name}}" ng-if="vm.vmDetails.instance.cloud_networks.length > 0"></detail-reveal>
-		<detail-reveal title="Cloud Subnet" detail="{{::vm.vmDetails.instance.cloud_subnets[0].name}}" ng-if="vm.vmDetails.instance.cloud_subnets.length > 0"></detail-reveal>
-		<detail-reveal title="Stack" detail="{{::vm.vmDetails.instance.orchestrationStack}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Cloud Networks" detail="{{::vm.vmDetails.instance.cloud_networks.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Cloud Subnets" detail="{{::vm.vmDetails.instance.cloud_subnets.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Network Routers" detail="{{::vm.vmDetails.instance.network_routers.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Security Groups" detail="{{::vm.vmDetails.security_groups.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Floating IPs" detail="{{::vm.vmDetails.instance.floating_ip_addresses.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Network Ports" detail="{{::vm.vmDetails.instance.network_ports.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Load Balancers" detail="{{::vm.vmDetails.instance.load_balancers.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Cloud Volumes" detail="{{::vm.vmDetails.instance.cloud_volumes.length}}" ng-if="vm.vmDetails.instance"></detail-reveal>
-		<detail-reveal title="Genealogy" detail="{{'Show parent and child VMs'|translate}}" ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-		<detail-reveal title="Drift History" detail="{{::vm.vmDetails.driftHistory}}"></detail-reveal>
-		<detail-reveal title="Analysis History" detail="{{::vm.vmDetails.scanHistoryCount}}"></detail-reveal>
-	</div>
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Compliance'|translate}}</div>
-		</div>
-		<detail-reveal title="Status" detail="{{::vm.vmDetails.lastComplianceStatus}}"></detail-reveal>
-		<detail-reveal title="History" detail="{{::vm.vmDetails.complianceHistory}}"></detail-reveal>
-	</div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Lifecycle'|translate}}</div>
+    </div>
+    <detail-reveal title="Discovered on" detail="{{ ::vm.vmDetails.created_on | date:'medium' }}"></detail-reveal>
+    <detail-reveal title="Last Analyzed" icon="fa fa-search fa-lg"
+                   detail="{{ ::vm.vmDetails.lastSyncOn | date:'medium' }}"></detail-reveal>
+    <detail-reveal title="Retirement Date" icon="fa fa-clock-o fa-lg"
+                   detail="{{ ::vm.vmDetails.retiresOn | date:'medium' }}"></detail-reveal>
+    <detail-reveal title="Provisioned On" detail="{{ ::vm.vmDetails.provisionDate | date:'medium' }}"></detail-reveal>
+    <detail-reveal title="Owner" detail="{{::vm.vmDetails.evm_owner.name}}"></detail-reveal>
+    <detail-reveal title="Group" detail="{{::vm.vmDetails.miq_group.description}}"></detail-reveal>
+  </div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Relationships'|translate}}</div>
+    </div>
+    <detail-reveal title="Availability Zone" detail="{{::vm.vmDetails.instance.availabilityZone}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Cloud Tenants" detail="{{::vm.vmDetails.instance.cloudTenant}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Flavor" detail="{{::vm.vmDetails.instance.flavor.name}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="VM Template" detail="{{::vm.vmDetails.instance.miq_provision_template.name}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Infrastructure provider" detail="{{::vm.vmDetails.ext_management_system.name}}"
+                   ng-if="vm.vmDetails.ext_management_system.name"></detail-reveal>
+    <detail-reveal title="{{'Cluster'|translate}} / {{'Deployment Role'|translate}}"
+                   icon="fa fa-lg pficon pficon-cluster" detail="{{::vm.vmDetails.ems_cluster.name}}"
+                   ng-if="vm.vmDetails.ems_cluster.name"></detail-reveal>
+    <detail-reveal title="Host / Node" icon="fa fa-lg pficon pficon-screen" detail="{{::vm.vmDetails.host.name}}"
+                   ng-if="vm.vmDetails.host.name"></detail-reveal>
+    <detail-reveal title="Resource Pool" icon="fa fa-lg pficon pficon-resource-pool"
+                   detail="{{::vm.vmDetails.parent_resource_pool.name}}"
+                   ng-if="vm.vmDetails.parent_resource_pool"></detail-reveal>
+    <detail-reveal title="Datastores" icon="fa fa-lg fa-database" detail="{{::vm.vmDetails.storages.length}}"
+                   ng-if="vm.vmDetails.storages.length > 0"></detail-reveal>
+    <detail-reveal title="Service" icon="fa fa-lg pficon pficon-service"
+                   detail="{{::vm.vmDetails.service.name}}"></detail-reveal>
+    <detail-reveal title="Virtual Private Cloud" detail="{{::vm.vmDetails.instance.cloud_networks[0].name}}"
+                   ng-if="vm.vmDetails.instance.cloud_networks.length > 0"></detail-reveal>
+    <detail-reveal title="Cloud Subnet" detail="{{::vm.vmDetails.instance.cloud_subnets[0].name}}"
+                   ng-if="vm.vmDetails.instance.cloud_subnets.length > 0"></detail-reveal>
+    <detail-reveal title="Stack" detail="{{::vm.vmDetails.instance.orchestrationStack}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Cloud Networks" detail="{{::vm.vmDetails.instance.cloud_networks.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Cloud Subnets" detail="{{::vm.vmDetails.instance.cloud_subnets.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Network Routers" detail="{{::vm.vmDetails.instance.network_routers.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Security Groups" detail="{{::vm.vmDetails.security_groups.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Floating IPs" detail="{{::vm.vmDetails.instance.floating_ip_addresses.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Network Ports" detail="{{::vm.vmDetails.instance.network_ports.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Load Balancers" detail="{{::vm.vmDetails.instance.load_balancers.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Cloud Volumes" detail="{{::vm.vmDetails.instance.cloud_volumes.length}}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+    <detail-reveal title="Genealogy" detail="{{'Show parent and child VMs'|translate}}"
+                   ng-if="vm.vmDetails.cloud===false"></detail-reveal>
+    <detail-reveal title="Drift History" detail="{{::vm.vmDetails.driftHistory}}"></detail-reveal>
+    <detail-reveal title="Analysis History" detail="{{::vm.vmDetails.scanHistoryCount}}"></detail-reveal>
+  </div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Compliance'|translate}}</div>
+    </div>
+    <detail-reveal title="Status" detail="{{::vm.vmDetails.lastComplianceStatus}}"></detail-reveal>
+    <detail-reveal title="History" detail="{{::vm.vmDetails.complianceHistory}}"></detail-reveal>
+  </div>
 
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Power Management'|translate}}</div>
-		</div>
-		<detail-reveal title="Power State" detail="{{::vm.vmDetails.power_state}}"></detail-reveal>
-		<detail-reveal title="Last Boot Time" detail="{{ ::vm.vmDetails.boot_time | date:'medium' }}"></detail-reveal>
-		<detail-reveal title="State Changed On" detail="{{ ::vm.vmDetails.state_changed_on | date:'medium' }}"></detail-reveal>
-	</div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Power Management'|translate}}</div>
+    </div>
+    <detail-reveal title="Power State" detail="{{::vm.vmDetails.power_state}}"></detail-reveal>
+    <detail-reveal title="Last Boot Time" detail="{{ ::vm.vmDetails.boot_time | date:'medium' }}"></detail-reveal>
+    <detail-reveal title="State Changed On"
+                   detail="{{ ::vm.vmDetails.state_changed_on | date:'medium' }}"></detail-reveal>
+  </div>
 
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Security'|translate}}</div>
-		</div>
-		<detail-reveal title="Users" icon="fa fa-lg pficon pficon-user" detail="{{ ::vm.vmDetails.users.length }}"></detail-reveal>
-		<detail-reveal title="Groups" icon="fa fa-lg pficon pficon-users" detail="{{ ::vm.vmDetails.groups.length }}"></detail-reveal>
-		<detail-reveal title="Key Pairs" detail="{{ ::vm.vmDetails.instance.keyPairLabels.join(',') }}" ng-if="vm.vmDetails.instance"></detail-reveal>
-	</div>
-	<div class="container-fluid vm-details-container">
-		<div class="row title">
-			<div>{{'Configuration'|translate}}</div>
-		</div>
-		<detail-reveal title="Packages" detail="{{ ::vm.vmDetails.guest_applications.length }}"></detail-reveal>
-		<detail-reveal title="Init Processes" detail="{{ ::vm.vmDetails.linux_initprocesses.length }}"></detail-reveal>
-		<detail-reveal title="Files" detail="{{ ::vm.vmDetails.files.length }}"></detail-reveal>
-	</div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Security'|translate}}</div>
+    </div>
+    <detail-reveal title="Users" icon="fa fa-lg pficon pficon-user"
+                   detail="{{ ::vm.vmDetails.users.length }}"></detail-reveal>
+    <detail-reveal title="Groups" icon="fa fa-lg pficon pficon-users"
+                   detail="{{ ::vm.vmDetails.groups.length }}"></detail-reveal>
+    <detail-reveal title="Key Pairs" detail="{{ ::vm.vmDetails.instance.keyPairLabels.join(',') }}"
+                   ng-if="vm.vmDetails.instance"></detail-reveal>
+  </div>
+  <div class="container-fluid vm-details-container">
+    <div class="row title">
+      <div>{{'Configuration'|translate}}</div>
+    </div>
+    <detail-reveal title="Packages" detail="{{ ::vm.vmDetails.guest_applications.length }}"></detail-reveal>
+    <detail-reveal title="Init Processes" detail="{{ ::vm.vmDetails.linux_initprocesses.length }}"></detail-reveal>
+    <detail-reveal title="Files" detail="{{ ::vm.vmDetails.files.length }}"></detail-reveal>
+  </div>
 
 </div>

--- a/client/app/states/vms/details/details.html
+++ b/client/app/states/vms/details/details.html
@@ -15,7 +15,6 @@
 </div>
 
 <div class="ss-details-wrapper vm-details-wrapper">
-  <h2 class="text-center" ng-if="vm.vmDetails.instance.retired">This is a retired resource.</h2>
   <div class="container-fluid vm-details-container">
     <div class="row title">
       <div>{{'Properties'|translate}}</div>

--- a/client/app/states/vms/details/details.html
+++ b/client/app/states/vms/details/details.html
@@ -19,6 +19,7 @@
     <div class="row title">
       <div>{{'Properties'|translate}}</div>
     </div>
+    <detail-reveal ng-if="vm.vmDetails.instance.retired" title="Status" icon="pf pficon-warning-triangle-o" detail="{{'Retired' | translate}}"></detail-reveal>
     <detail-reveal title="Name" detail="{{::vm.vmDetails.name}}"></detail-reveal>
     <detail-reveal title="Hostnames" detail="{{::vm.vmDetails.hostnames.join(',')}}"></detail-reveal>
     <detail-reveal title="IP Addresses" detail="{{::vm.vmDetails.ipaddresses.join(',')}}"></detail-reveal>

--- a/client/app/states/vms/details/details.state.js
+++ b/client/app/states/vms/details/details.state.js
@@ -145,8 +145,11 @@ function StateController(service, vmDetails, instance, EventNotifications, sprin
     if (instance !== false) {
       processInstanceVariables(instance);
     }
-    EventNotifications.warn( sprintf(__("%s is a retired resource"), vm.vmDetails.name), {toastDelay: 100000, unread: false});
+    if (angular.isDefined(vm.vmDetails.instance) && vm.vmDetails.instance.retired) {
+      EventNotifications.warn(sprintf(__("%s is a retired resource"), vm.vmDetails.name), {persistent: true, unread: false});
+    }
   }
+
   function defaultText(inputCount, defaultText) {
     var inputArrSize = inputCount.length;
     defaultText = (defaultText === null ? 'None' : defaultText);
@@ -156,13 +159,14 @@ function StateController(service, vmDetails, instance, EventNotifications, sprin
       return inputArrSize;
     }
   }
+
   function processInstanceVariables(data) {
     var noneText = __('None');
     data.availabilityZone = (angular.isUndefined(data.availability_zone) ? noneText : data.availability_zone.name);
     data.cloudTenant = (angular.isUndefined(data.cloud_tenant) ? noneText : data.cloud_tenant);
-    data.orchestrationStack = ( angular.isUndefined(data.orchestration_stack) ? noneText :  data.orchestration_stack);
+    data.orchestrationStack = ( angular.isUndefined(data.orchestration_stack) ? noneText : data.orchestration_stack);
     data.keyPairLabels = [];
-    data.key_pairs.forEach( function(keyPair) {
+    data.key_pairs.forEach(function(keyPair) {
       data.keyPairLabels.push(keyPair.name);
     });
 

--- a/client/app/states/vms/details/details.state.js
+++ b/client/app/states/vms/details/details.state.js
@@ -118,8 +118,9 @@ function resolveInstance(CollectionsApi, vmDetails) {
   }
 }
 /** @ngInject */
-function StateController(service, vmDetails, instance) {
+function StateController(service, vmDetails, instance, EventNotifications, sprintf) {
   var vm = this;
+
 
   vm.vmDetails = vmDetails;
 
@@ -144,6 +145,7 @@ function StateController(service, vmDetails, instance) {
     if (instance !== false) {
       processInstanceVariables(instance);
     }
+    EventNotifications.warn( sprintf(__("%s is a retired resource"), vm.vmDetails.name), {toastDelay: 100000, unread: false});
   }
   function defaultText(inputCount, defaultText) {
     var inputArrSize = inputCount.length;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/141947277

@chalettu @chriskacerguis @jjlangholtz hey ya'll could use feedback on the approach here, mainly the use of eventnotification and the removal of the resource actions (we could just disable them, but my gut says that isn't going far enough... if one can't act on the resource, one shouldn't see actions on a resource)

## Action 🛒 
![image](https://cloud.githubusercontent.com/assets/6640236/24118218/60e68da2-0d83-11e7-86a5-d606e0daf8aa.png)


☝️ so a few details about this, warning banner does **not** update unread notification count, also it persists for a really long time and follows the user anywhere on the page, totally dismissable

![image](https://cloud.githubusercontent.com/assets/6640236/24104508/be64f070-0d58-11e7-8eb6-a516983767f6.png)

In this shot we see two disabled resources, in addition to the row being disabled, all actions are removed from the resource and a "retired" icon is added in place of the power icon.  Maybe add a column  stating "retired resource" in addition to the other cues in place? 


![image](https://cloud.githubusercontent.com/assets/6640236/24106037/266a2704-0d5d-11e7-95be-be763e964f1d.png)
☝️ a retired and active resource !