### PR TITLE
Ensure reasonabe size of explorer list view childeren

### DIFF
--- a/client/assets/sass/_explorer.sass
+++ b/client/assets/sass/_explorer.sass
@@ -4,11 +4,16 @@
       padding-bottom: 0
 
     .power-icon
-      cursor: default;
+      cursor: default
 
   .list-view-pf
     height: calc(100vh - 237px)
     overflow-y: auto
+
+  .explorer-children-list
+    .list-view-pf
+      height: auto
+      overflow-y: auto
 
   [class*='col-']
     padding-left: 10px


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/142134113

## before this pr, huge space for expanded list items
![screenshot from 2017-03-21 09-10-14](https://cloud.githubusercontent.com/assets/6640236/24153736/a924eeb8-0e25-11e7-9b77-8bdb35958f90.png)

## after, reasonable space for expanded list items
![image](https://cloud.githubusercontent.com/assets/6640236/24153801/cee297ae-0e25-11e7-8b5f-64e7aa7d1e24.png)

## after, still space for kebab menus!
![image](https://cloud.githubusercontent.com/assets/6640236/24155952/93902c56-0e2b-11e7-86ce-a40a87de9a56.png)

