### PR TITLE
PT#139384081 Revert snapshots

### DIFF
--- a/client/app/catalogs/catalog-explorer.component.js
+++ b/client/app/catalogs/catalog-explorer.component.js
@@ -157,9 +157,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
       permissions: vm.permissions.delete,
     }];
 
-    const menuActions = checkPermissions(menuActionsConfig);
-    
-    return menuActions;
+    return menuActionsConfig.filter((item) => item.permissions);
   }
 
   function getListActions() {
@@ -192,7 +190,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
       actionName: 'configuration',
       icon: 'fa fa-cog',
       isDisabled: false,
-      actions: checkPermissions(configurationMenuOptions),
+      actions: configurationMenuOptions.filter((item) => item.permissions),
     }];
 
     let selectAllDisabled = true;
@@ -244,16 +242,7 @@ function ComponentController($state, Session, CatalogsState, sprintf, ListView, 
         break;
     }
   }
-  function checkPermissions(menuConfig) {
-    const approvedMenuItems = [];
-    angular.forEach(menuConfig, function(menuItem) {
-      if (menuItem.permissions) {
-        approvedMenuItems.push(menuItem);
-      }
-    });
 
-    return approvedMenuItems;
-  }
   function getToolbarConfig() {
     return {
       filterConfig: getFilterConfig(),

--- a/client/app/services/vms.service.js
+++ b/client/app/services/vms.service.js
@@ -91,7 +91,7 @@ export function VmsService(CollectionsApi, RBAC) {
 
   function revertSnapshot(vmId, snapshotId) {
     const options = {
-      "action": "revert"
+      "action": "revert",
     };
 
     return CollectionsApi.post(collection + '/' + vmId + '/snapshots/' + snapshotId, null, {}, options);

--- a/client/app/services/vms.service.js
+++ b/client/app/services/vms.service.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: "off" */
 
 /** @ngInject */
-export function VmsService(CollectionsApi) {
+export function VmsService(CollectionsApi, RBAC) {
   const collection = 'vms';
   const sort = {
     isAscending: true,
@@ -16,6 +16,8 @@ export function VmsService(CollectionsApi) {
     getFilters: getFilters,
     setFilters: setFilters,
     getSnapshots: getSnapshots,
+    getPermissions: getPermissions,
+    revertSnapshot: revertSnapshot,
     createSnapshots: createSnapshots,
     deleteSnapshots: deleteSnapshots,
   };
@@ -60,6 +62,15 @@ export function VmsService(CollectionsApi) {
     return filters;
   }
 
+  function getPermissions() {
+    return {
+      create: RBAC.hasAny(['vm_snapshot_add']),
+      delete: RBAC.hasAny(['vm_snapshot_delete']),
+      deleteAll: RBAC.hasAny(['vm_snapshot_delete_all']),
+      revert: RBAC.hasAny(['vm_snapshot_revert']),
+    };
+  }
+
   function deleteSnapshots(vmId, data) {
     const options = {
       "action": "delete",
@@ -76,6 +87,14 @@ export function VmsService(CollectionsApi) {
     };
 
     return CollectionsApi.post(collection + '/' + vmId + '/snapshots/', null, {}, options);
+  }
+
+  function revertSnapshot(vmId, snapshotId) {
+    const options = {
+      "action": "revert"
+    };
+
+    return CollectionsApi.post(collection + '/' + vmId + '/snapshots/' + snapshotId, null, {}, options);
   }
 
   // Private

--- a/client/app/services/vms/snapshots.html
+++ b/client/app/services/vms/snapshots.html
@@ -94,6 +94,16 @@
               {{item.updated_on | date:'short'}}
             </span>
         </div>
+        <div uib-dropdown="" dropdown-append-to-body class="dropdown pull-right dropdown-kebab-pf">
+          <button uib-dropdown-toggle="" class="btn btn-link dropdown-toggle" type="button">
+            <span class="fa fa-ellipsis-v"></span>
+          </button>
+          <ul uib-dropdown-menu="" class="dropdown-menu dropdown-menu-right dropdown-menu-appended-to-body">
+            <li role="menuitem" ng-class="{'disabled': item.current}">
+              <a ng-click="vm.revertSnapshot(item)" translate>Revert</a>
+            </li>
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/client/app/services/vms/snapshots.html
+++ b/client/app/services/vms/snapshots.html
@@ -22,7 +22,7 @@
     <custom-dropdown config="vm.listActions" menu-right="true"></custom-dropdown>
   </actions>
 </div>
-<div class="list-view-container section-container paged-container service-explorer-list">
+<div class="list-view-container section-container explorer-list">
   <loading status="vm.loading"></loading>
   <div ng-if="!vm.loading" class="list-view-container section-container"
        confirmation
@@ -40,7 +40,8 @@
     <div pf-list-view
          config="vm.listConfig"
          items="vm.snapshots"
-         menu-actions="vm.menuActions">
+         menu-actions="vm.menuActions"
+    update-menu-action-for-item-fn="vm.updateMenuActionForItemFn">
       <div class="row">
         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
           <span class="no-wrap">
@@ -93,16 +94,6 @@
               <strong translate>Updated:</strong>
               {{item.updated_on | date:'short'}}
             </span>
-        </div>
-        <div uib-dropdown="" dropdown-append-to-body class="dropdown pull-right dropdown-kebab-pf">
-          <button uib-dropdown-toggle="" class="btn btn-link dropdown-toggle" type="button">
-            <span class="fa fa-ellipsis-v"></span>
-          </button>
-          <ul uib-dropdown-menu="" class="dropdown-menu dropdown-menu-right dropdown-menu-appended-to-body">
-            <li role="menuitem" ng-class="{'disabled': item.current}">
-              <a ng-click="vm.revertSnapshot(item)" translate>Revert</a>
-            </li>
-          </ul>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/139384081

Snapshots now has RBAC **AND** ya can revert em!  But only if the snapshot is not a parent, and it is active (meaning the current snapshot)  Also, vm gotta be powered off, duh ;-)

Also, ported (from here) cod to the catalog explorer, refactored permissions determination (whilst building action lists/menus) to be cleaner.

## Snap its a new action! 
![image](https://cloud.githubusercontent.com/assets/6640236/24169285/8072bb52-0e53-11e7-988c-d81c79f13ca6.png)

## Oh Snap, can't act on this parent !!
![image](https://cloud.githubusercontent.com/assets/6640236/24169298/8b31194e-0e53-11e7-884d-9aea75a17f9d.png)

## Snap! can't revert, must be broken, its not, don't worry that we see server response is a good thing, once the vm is powered down snapshots can be changed around
![image](https://cloud.githubusercontent.com/assets/6640236/24169339/a9cd7c1c-0e53-11e7-829e-e263ef204073.png)
