### PR TITLE
Sort tagging widget tag categories

### DIFF
--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -89,6 +89,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
         'all_vms',
         'custom_actions',
         'service_resources',
+        'tags',
       ],
       filter: getQueryFilters(filters),
     };

--- a/client/app/shared/tagging/_tagging.sass
+++ b/client/app/shared/tagging/_tagging.sass
@@ -7,7 +7,7 @@
 
 .tag-category-select
   float: left
-  width: 126px
+  width: 180px
 
 .no-tag-header
   font-style: italic
@@ -17,7 +17,7 @@
 .tag-value-select
   float: left
   margin-left: 14px
-  width: 150px
+  width: 180px
 
 .tag-add
   color: $color-lochmara-approx

--- a/client/app/shared/tagging/tagging.component.js
+++ b/client/app/shared/tagging/tagging.component.js
@@ -12,7 +12,7 @@ export const TaggingComponent = {
 };
 
 /** @ngInject */
-function TaggingController($scope, $filter, $q, $log, CollectionsApi, TaggingService) {
+function TaggingController($scope, $filter, $q, $log, CollectionsApi, TaggingService, lodash) {
   var vm = this;
 
   vm.tags = {};
@@ -71,7 +71,7 @@ function TaggingController($scope, $filter, $q, $log, CollectionsApi, TaggingSer
     CollectionsApi.query('categories', options).then(loadSuccess, loadFailure);
 
     function loadSuccess(response) {
-      vm.tags.categories = response.resources;
+      vm.tags.categories = lodash.sortBy(response.resources, 'description');
       vm.tags.selectedCategory = vm.tags.categories[0];
       deferred.resolve();
     }

--- a/client/app/shared/tagging/tagging.component.spec.js
+++ b/client/app/shared/tagging/tagging.component.spec.js
@@ -53,7 +53,6 @@ describe('Component: taggingWidget', function() {
       setTimeout(function() {
         isoScope.$digest();
         expect(isoScope.vm.tags.all).to.eq(scope.allTags.resources);
-        expect(isoScope.vm.tags.categories).to.eq(scope.tagCategories.resources);
         expect(isoScope.vm.showTagDropdowns).to.eq(true);
 
         expect(collectionsApiSpy).to.have.been.calledWith('categories', options);
@@ -72,12 +71,12 @@ describe('Component: taggingWidget', function() {
         isoScope.$digest();
         let tagCategorySelect = element.find(".tag-category-select");
         let tagCategories = angular.element(tagCategorySelect).find("option");
-        expect(tagCategories[0].text).to.be.eq("Location");
+        expect(tagCategories[0].text).to.be.eq("Auto Approve - Max CPU");
         expect(tagCategories[0].selected).to.be.eq(true);
 
         let tagsOfCategorySelect = element.find(".tag-value-select");
         let tagsOfCategory = angular.element(tagsOfCategorySelect).find("option");
-        expect(tagsOfCategory.length).to.be.eq(5);    // 5 Location options
+        expect(tagsOfCategory.length).to.be.eq(6);    // 6 Auto Approve options
         expect(tagsOfCategory[0].selected).to.be.eq(true);
 
         done();
@@ -129,7 +128,7 @@ describe('Component: taggingWidget', function() {
         expect(angular.element(tagsOfItem[1]).parent().parent().text().trim()).to.be.eq("Service Level: Gold");
 
         // Select tag category 'Service Level' and tag 'Platinum'
-        isoScope.vm.tags.selectedCategory = isoScope.vm.tags.categories[5];
+        isoScope.vm.tags.selectedCategory = isoScope.vm.tags.categories[24];
         isoScope.$digest();
         isoScope.vm.tags.selectedTag = isoScope.vm.tags.filtered[3];
         isoScope.$digest();
@@ -138,8 +137,8 @@ describe('Component: taggingWidget', function() {
 
         let tagCategorySelect = element.find(".tag-category-select");
         let tagCategories = angular.element(tagCategorySelect).find("option");
-        expect(tagCategories[5].text).to.be.eq("Service Level");
-        expect(tagCategories[5].selected).to.be.eq(true);
+        expect(tagCategories[24].text).to.be.eq("Service Level");
+        expect(tagCategories[24].selected).to.be.eq(true);
 
         let tagsOfCategorySelect = element.find(".tag-value-select");
         let tagsOfCategory = angular.element(tagsOfCategorySelect).find("option");


### PR DESCRIPTION
* Add tags back to `getServices` request attributes for bulk taggging
* Increase width enough to fully display initial category and value
* Update specs to account for sorted categories

https://www.pivotaltracker.com/story/show/142251411
https://bugzilla.redhat.com/show_bug.cgi?id=1434174

@miq-bot add_label euwe/no, bug

<img width="932" alt="screen shot 2017-03-22 at 3 24 18 pm" src="https://cloud.githubusercontent.com/assets/6842753/24216887/4351ecd6-0f14-11e7-9f88-a0dc2956dd59.png">