### PR TITLE
Fix for service dialog being submitted before entry point code on dynamic fields has completed execution

### DIFF
--- a/client/app/states/catalogs/details/details.html
+++ b/client/app/states/catalogs/details/details.html
@@ -31,7 +31,7 @@
             <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 ss-details-header__actions">
               <button type="button"
                       class="btn btn-primary"
-                      ng-disabled="! vm.cartAllowed() || vm.addingToCart"
+                      ng-disabled="vm.addToCartDisabled()"
                       confirmation
                       confirmation-if="vm.alreadyInCart()"
                       confirmation-title="{{'Duplicate Shopping Cart Item'|translate}}"

--- a/client/app/states/catalogs/details/details.state.js
+++ b/client/app/states/catalogs/details/details.state.js
@@ -48,6 +48,7 @@ function Controller(dialogs, serviceTemplate, EventNotifications, DialogFieldRef
   vm.addToCart = addToCart;
   vm.cartAllowed = ShoppingCart.allowed;
   vm.alreadyInCart = alreadyInCart;
+  vm.addToCartDisabled = addToCartDisabled;
 
   var autoRefreshableDialogFields = [];
   var allDialogFields = [];
@@ -68,6 +69,18 @@ function Controller(dialogs, serviceTemplate, EventNotifications, DialogFieldRef
     dialogUrl,
     vm.serviceTemplate.id
   );
+
+  function addToCartDisabled() {
+    return (!vm.cartAllowed() || vm.addingToCart) || anyDialogsBeingRefreshed();
+  }
+
+  function anyDialogsBeingRefreshed() {
+    function checkRefreshing(dialogField) {
+      return dialogField.beingRefreshed;
+    }
+
+    return allDialogFields.some(checkRefreshing);
+  }
 
   function dataForSubmit(href) {
     var dialogFieldData = {};


### PR DESCRIPTION
This fix will simply disable the add to cart button when dynamic fields are processing so that it's not possible to submit the dialog while the automate methods are still running.

https://bugzilla.redhat.com/show_bug.cgi?id=1431688

@jjlangholtz Can you review, please?

/cc @gmcculloug 

@miq-bot add_label bug 