### PR TITLE
Update dialog dynamic checkbox values during refresh

### DIFF
--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -59,8 +59,7 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
       if (dialogField.type === 'DialogFieldDateControl' || dialogField.type === 'DialogFieldDateTimeControl') {
         dialogField.default_value = new Date(newDialogField.values);
       } else {
-        if (angular.isUndefined(newDialogField.default_value) || newDialogField.default_value === null
-          || newDialogField.default_value === '' || dialogField.type === 'DialogFieldCheckBox') {
+        if (isBlank(newDialogField.default_value) || dialogField.type === 'DialogFieldCheckBox') {
           dialogField.default_value = newDialogField.values;
         }
       }
@@ -135,5 +134,11 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
     });
 
     return fieldValues;
+  }
+
+  function isBlank(value) {
+    return angular.isUndefined(value)
+      || value === null
+      || value === '';
   }
 }

--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -60,7 +60,7 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
         dialogField.default_value = new Date(newDialogField.values);
       } else {
         if (angular.isUndefined(newDialogField.default_value) || newDialogField.default_value === null
-          || newDialogField.default_value === '') {
+          || newDialogField.default_value === '' || dialogField.type === 'DialogFieldCheckBox') {
           dialogField.default_value = newDialogField.values;
         }
       }

--- a/client/app/core/dialog-field-refresh.service.spec.js
+++ b/client/app/core/dialog-field-refresh.service.spec.js
@@ -128,6 +128,40 @@ describe('DialogFieldRefresh', function() {
         });
       });
 
+      describe('when the dialogfield type is DialogFieldCheckBox', function() {
+        beforeEach(function() {
+          successResponse = {
+            result: {
+              dialog1: {
+                type: 'DialogFieldCheckBox',
+                options: 'options',
+                read_only: false,
+                required: false,
+                values: 'f'
+              }
+            }
+          };
+
+          triggerAutoRefreshSpy = sinon.stub(DialogFieldRefresh, 'triggerAutoRefresh');
+          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse));
+        });
+
+        it('updates the attributes for the dialog field', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(dialog1.options).to.eq('options');
+          expect(dialog1.read_only).to.be.false;
+          expect(dialog1.required).to.be.false;
+          expect(dialog1.default_value).to.eq('f');
+        });
+
+        it('triggers an auto-refresh', function(done) {
+          DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialog1, 'the_url', 123);
+          done();
+          expect(triggerAutoRefreshSpy).to.have.been.called;
+        });
+      });
+
       describe('when the dialogfield type is anything else', function() {
         beforeEach(function() {
           successResponse = {


### PR DESCRIPTION
When auto refreshing dialog fields, update DialogFieldCheckBox values as
well.

https://www.pivotaltracker.com/story/show/142955157
https://bugzilla.redhat.com/show_bug.cgi?id=1438010

/cc @eclarizio 

@miq-bot add_label fine/yes, bug, catalogs