### PR TITLE
BZ#1429311 PT#142596807 - Duplicate order does not provision the service

### DIFF
--- a/client/app/core/shopping-cart.service.js
+++ b/client/app/core/shopping-cart.service.js
@@ -113,6 +113,7 @@ export function ShoppingCartFactory($rootScope, CollectionsApi, $q, lodash, RBAC
 
   function deleteCart() {
     persistence.getItems();
+    
     return CollectionsApi.delete('service_orders', 'cart', null);
   }
 

--- a/client/app/core/shopping-cart.service.js
+++ b/client/app/core/shopping-cart.service.js
@@ -5,6 +5,7 @@ export function ShoppingCartFactory($rootScope, CollectionsApi, $q, lodash, RBAC
   var service = {
     add: add,
     reset: reset,
+    delete: deleteCart,
     reload: reload,
     count: count,
     removeItem: removeItem,
@@ -108,6 +109,11 @@ export function ShoppingCartFactory($rootScope, CollectionsApi, $q, lodash, RBAC
 
       return newItem;
     });
+  }
+
+  function deleteCart() {
+    persistence.getItems();
+    return CollectionsApi.delete('service_orders', 'cart', null);
   }
 
   function reload() {

--- a/client/app/requests/order-explorer/order-explorer.component.js
+++ b/client/app/requests/order-explorer/order-explorer.component.js
@@ -359,7 +359,6 @@ function ComponentController($filter, lodash, ListView, Language, OrdersState, S
     function success(response) {
       ShoppingCart.reload();
       EventNotifications.success(sprintf(__('%s was duplicated, id # %d.'), item.name, response.results[0].id));
-      resolveOrders(vm.limit, 0);
     }
 
     function failure(_error) {

--- a/client/app/requests/order-explorer/order-explorer.html
+++ b/client/app/requests/order-explorer/order-explorer.html
@@ -25,7 +25,8 @@
        config="vm.listConfig"
        items="vm.ordersList"
        custom-scope="vm"
-       menu-actions="vm.menuActions">
+       menu-actions="vm.menuActions"
+       update-menu-action-for-item-fn="vm.updateMenuActionForItemFn">
     <div class="row">
       <div class="col-lg-3 col-md-3 col-sm-5 col-xs-8">
         <span class="no-wrap">


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1429311
https://www.pivotaltracker.com/story/show/142596807
Disable duplicate order for invalid  (state=cart/service_requests=0)
Duplicating an order with either of these properties will blow up the cart, so we shouldn't allow the user to do this
Duplicating order when a cart is already filled also blows up the cart, so we now clear it before duplicating an order

## 👁 look see! confirmation of duplication and item in cart! 
![image](https://cloud.githubusercontent.com/assets/6640236/24620592/41d8111c-186c-11e7-9db7-fe3023c1103e.png)

![image](https://cloud.githubusercontent.com/assets/6640236/24620617/4e88a4b2-186c-11e7-84f0-39cdcca89e78.png)

