### PR TITLE
Catalogs viewable with wrong permissions

### DIFF
--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -37,7 +37,7 @@ export function RBACFactory(lodash) {
     const navPermissions = {
       dashboard: {show: entitledForDashboard(productFeatures)},
       services: {show: entitledForServices(productFeatures)},
-      orders: {show: entitledForServices(productFeatures)},
+      orders: {show: entitledForServiceCatalogs(productFeatures)},
       requests: {show: entitledForRequests(productFeatures)},
       catalogs: {show: entitledForServiceCatalogs(productFeatures)},
       dialogs: {show: entitledForService(productFeatures)},
@@ -89,7 +89,7 @@ export function RBACFactory(lodash) {
   }
 
   function entitledForServiceCatalogs(productFeatures) {
-    return angular.isDefined(productFeatures.catalog_items_view) || angular.isDefined(productFeatures.svc_catalog_provision);
+    return  angular.isDefined(productFeatures.svc_catalog_provision);
   }
 
   function entitledForRequests(productFeatures) {

--- a/client/app/states/catalogs/explorer/explorer.state.js
+++ b/client/app/states/catalogs/explorer/explorer.state.js
@@ -14,7 +14,7 @@ function getStates(RBAC) {
       controllerAs: 'vm',
       title: __('Catalogs'),
       data: {
-        authorization: RBAC.hasAny(['catalogs', 'catalog_items_view']),
+        authorization: RBAC.hasAny(['svc_catalog_provision']),
       },
     },
   };


### PR DESCRIPTION
PV https://github.com/ManageIQ/manageiq-ui-service/pull/634
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1438922. 

Ensures that if you cannot see catalogs you also cannot see orders.  