### PR TITLE
Rbac for custom actions

### DIFF
--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -58,7 +58,7 @@ export function authInit($rootScope, $state, $log, Session, $sessionStorage, Lan
       if (angular.isDefined(toState.data.authorization) && !toState.data.authorization) {
         event.preventDefault();
         $state.transitionTo('dashboard');
-        
+
         return;
       }
       if (!toState.data.requireUser) {
@@ -91,6 +91,7 @@ export function authInit($rootScope, $state, $log, Session, $sessionStorage, Lan
         .then(function (response) {
           if (angular.isDefined(response)) {
             ApplianceInfo.set(response);
+            RBAC.setRole(response.identity.role);
           }
           resolve();
         })

--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -5,17 +5,20 @@ export function RBACFactory(lodash) {
   var features = {};
   var navFeatures = {};
   var actionFeatures = {};
+  let currentRole;
 
   var service = {
     set: set,
     has: has,
     hasAny: hasAny,
+    hasRole: hasRole,
     all: all,
     navigationEnabled: navigationEnabled,
     getNavFeatures: getNavFeatures,
     getActionFeatures: getActionFeatures,
     setNavFeatures: setNavFeatures,
     setActionFeatures: setActionFeatures,
+    setRole: setRole,
   };
 
   return service;
@@ -60,6 +63,10 @@ export function RBACFactory(lodash) {
     return hasPermission;
   }
 
+  function hasRole(...roles) {
+    return roles.some((role) => currentRole === role);
+  }
+
   function all() {
     return features;
   }
@@ -70,6 +77,10 @@ export function RBACFactory(lodash) {
 
   function setActionFeatures(features) {
     actionFeatures = features;
+  }
+
+  function setRole(newRole) {
+    currentRole = newRole;
   }
 
   function getActionFeatures() {

--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -64,7 +64,7 @@ export function RBACFactory(lodash) {
   }
 
   function hasRole(...roles) {
-    return roles.some((role) => currentRole === role);
+    return roles.some((role) => role === currentRole || role === '_ALL_');
   }
 
   function all() {

--- a/client/app/core/rbac.service.spec.js
+++ b/client/app/core/rbac.service.spec.js
@@ -1,0 +1,33 @@
+describe('RBAC service', () => {
+  let service;
+
+  beforeEach(module('app.core'));
+
+  beforeEach(inject((RBAC) => {
+    service = RBAC;
+  }));
+
+  describe('#hasRole', () => {
+    it('returns true if current role matches the given role', () => {
+      service.setRole('admin');
+
+      const result = service.hasRole('admin');
+
+      expect(result).to.be.true;
+    });
+
+    it('returns true if current role matches any given role', () => {
+      service.setRole('super_admin');
+
+      const result = service.hasRole('admin', 'super_admin');
+
+      expect(result).to.be.true;
+    })
+
+    it('returns false if current role does not match any given roles', () => {
+      const result = service.hasRole('admin');
+
+      expect(result).to.be.false;
+    });
+  });
+});

--- a/client/app/core/rbac.service.spec.js
+++ b/client/app/core/rbac.service.spec.js
@@ -8,6 +8,12 @@ describe('RBAC service', () => {
   }));
 
   describe('#hasRole', () => {
+    it('returns true if given role is _ALL_', () => {
+      const result = service.hasRole('_ALL_');
+
+      expect(result).to.be.true;
+    });
+
     it('returns true if current role matches the given role', () => {
       service.setRole('admin');
 

--- a/client/app/services/custom-button/custom-button.component.js
+++ b/client/app/services/custom-button/custom-button.component.js
@@ -12,10 +12,17 @@ export const CustomButtonComponent = {
 };
 
 /** @ngInject */
-function CustomButtonController($state, EventNotifications, CollectionsApi) {
+function CustomButtonController($state, EventNotifications, CollectionsApi, RBAC) {
   const vm = this;
 
+  vm.hasRequiredRole = hasRequiredRole;
   vm.invokeCustomAction = invokeCustomAction;
+
+  function hasRequiredRole(button) {
+    const acceptableRoles = button.visibility.roles;
+
+    return RBAC.hasRole(...acceptableRoles);
+  }
 
   function invokeCustomAction(button) {
     if (button.resource_action && button.resource_action.dialog_id) {

--- a/client/app/services/custom-button/custom-button.component.spec.js
+++ b/client/app/services/custom-button/custom-button.component.spec.js
@@ -9,11 +9,19 @@ describe('CustomButton component', () => {
       buttons: [
         {
           name: 'Foo',
+          visibility: {
+            roles: ['_ALL_'],
+          },
           resource_action: {
             dialog_id: '_a dialog id_'
           },
         },
-        { name: 'Bar' },
+        {
+          name: 'Bar',
+          visibility: {
+            roles: ['_ALL_'],
+          },
+        },
       ],
     };
     parentScope.serviceId = '_a service id_';
@@ -41,6 +49,42 @@ describe('CustomButton component', () => {
     const actions = element[0].querySelectorAll('.custom-button-action');
 
     expect(actions.length).to.eq(numActions);
+  });
+
+  describe('for actions visible to specified roles', () => {
+    let RBAC;
+
+    beforeEach(inject((_RBAC_) => {
+      RBAC = _RBAC_;
+      parentScope.customActions = {
+        buttons: [
+          {
+            name: 'Secret Button',
+            visibility: {
+              roles: ['Secret-Agent'],
+            },
+          },
+        ],
+      };
+    }));
+
+    it('displays a button if the role allows', () => {
+      RBAC.setRole('Secret-Agent');
+      parentScope.$digest();
+
+      const actions = element[0].querySelectorAll('.custom-button-action');
+
+      expect(actions.length).to.eq(1);
+    });
+
+    it('does not display a button if the role disallows', () => {
+      RBAC.setRole('Innocent-Bystander');
+      parentScope.$digest();
+
+      const actions = element[0].querySelectorAll('.custom-button-action');
+
+      expect(actions.length).to.eq(0);
+    });
   });
 
   describe('#invokeCustomAction', () => {

--- a/client/app/services/custom-button/custom-button.html
+++ b/client/app/services/custom-button/custom-button.html
@@ -8,6 +8,7 @@
     <ul uib-dropdown-menu role="menu" aria-labelledby="button_custom_actions">
       <li ng-repeat="button in vm.customActions.buttons" role="presentation">
         <a role="menuitem" tabindex="-1" class="custom-button-action"
+          ng-if="vm.hasRequiredRole(button)"
           ng-click="vm.invokeCustomAction(button)">
           {{ button.name }}
         </a>
@@ -16,6 +17,7 @@
         <li class="dropdown-header">{{ buttonGroup.name.split('|')[0] }}</li>
         <li ng-repeat="button in buttonGroup.buttons" role="presentation">
           <a role="menuitem" tabindex="-1" class="custom-button-action"
+            ng-if="vm.hasRequiredRole(button)"
             ng-click="vm.invokeCustomAction(button)">
             {{ button.name }}
           </a>

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -54,6 +54,7 @@ function StateController(exception, $state, Text, RBAC, API_LOGIN, API_PASSWORD,
       .then(function(response) {
         if (angular.isDefined(response)) {
           ApplianceInfo.set(response);
+          RBAC.setRole(response.identity.role);
         }
 
 


### PR DESCRIPTION
Add RBAC support for custom actions. During login and page refreshes the currently authenticated user's role will be set on the RBAC service. When visiting pages that support custom actions, render only the custom actions allowed for the role.

The existing RBAC service had access control mechanisms based on product features. This change extends the RBAC service to also check for roles.

No UX changes.

https://www.pivotaltracker.com/story/show/143079265

@miq-bot add_label fine/yes, enhancement