### PR TITLE
BZ#1439555 - snapshot counts inaccurate

### DIFF
--- a/client/app/core/collections-api.factory.js
+++ b/client/app/core/collections-api.factory.js
@@ -82,13 +82,6 @@ export function CollectionsApiFactory($http, API_BASE) {
       params.push('attributes=' + encodeURIComponent(options.attributes));
     }
 
-    if (options.decorators) {
-      if (angular.isArray(options.decorators)) {
-        options.decorators = options.decorators.join(',');
-      }
-      params.push('decorators=' + encodeURIComponent(options.decorators));
-    }
-
     if (options.filter) {
       angular.forEach(options.filter, function(filter) {
         params.push('filter[]=' + encodeURIComponent(filter));

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -192,19 +192,12 @@
                     <div>
                       <span class="no-wrap">
                         <i class="fa fa-camera"></i>&nbsp;
-                        <span ng-if="item.v_total_snapshots"
-                              uib-tooltip="{{'Total Snapshots' | translate}} : {{item.v_total_snapshots}}"
+                        <span uib-tooltip="{{'Total Snapshots' | translate}} : {{item.v_total_snapshots}}"
                               tooltip-append-to-body="true"
                               tooltip-popup-delay="1000"
                               tooltip-placement="bottom">
                           {{item.v_total_snapshots}}
                         </span>
-                          <i ng-if="!item.v_total_snapshots"
-                             class="pficon fa fa-question-circle"
-                             uib-tooltip="{{'Totals Snapshots: Unknown'|translate}}"
-                             tooltip-append-to-body="true"
-                             tooltip-popup-delay="1000"
-                             tooltip-placement="bottom"></i>
                       </span>
                     </div>
                   </div>
@@ -259,8 +252,8 @@
                     </div>
                   </div>
                   <div ng-if="!item.retired " class="list-view-pf-actions">
-                    <div class="btn-group dropdown-kebab-pf" uib-dropdown dropdown-append-to-body 
-                    ng-if="customScope.permissions.cockpit || customScope.permissions.console">
+                    <div class="btn-group dropdown-kebab-pf" uib-dropdown dropdown-append-to-body
+                         ng-if="customScope.permissions.cockpit || customScope.permissions.console">
                       <button type="button" class="btn btn-default" uib-dropdown-toggle type="button">
                         <span translate>Access</span>
                         <span class="caret"></span>
@@ -273,7 +266,7 @@
                           <a href="#" translate>Open HTML5 Console</a>
                         </li>
                         <li role="menuitem"
-                            ng-class="{'disabled': !item['supports_cockpit?'] || item.power_state !== 'on' || !customScope.permissions.cockpit}"
+                            ng-class="{'disabled': !item['supports_launch_cockpit?'] || item.power_state !== 'on' || !customScope.permissions.cockpit}"
                             ng-click="customScope.openCockpit(item)">
                           <a href="#" translate>Open Cockpit Console</a>
                         </li>
@@ -284,16 +277,20 @@
                         <span class="fa fa-ellipsis-v"></span>
                       </button>
                       <ul uib-dropdown-menu="" class="dropdown-menu dropdown-menu-right dropdown-menu-appended-to-body">
-                        <li role="menuitem" ng-if="customScope.permissions.powerOn" ng-class="{'disabled': customScope.disableStartButton(item)}">
-                          <a ng-click="customScope.startVM(item, customScope.disableStartButton(item))" translate>Start</a>
+                        <li role="menuitem" ng-if="customScope.permissions.powerOn"
+                            ng-class="{'disabled': customScope.disableStartButton(item)}">
+                          <a ng-click="customScope.startVM(item, customScope.disableStartButton(item))"
+                             translate>Start</a>
                         </li>
-                        <li role="menuitem" ng-if="customScope.permissions.powerOff" ng-class="{'disabled': customScope.disableStopButton(item)}">
+                        <li role="menuitem" ng-if="customScope.permissions.powerOff"
+                            ng-class="{'disabled': customScope.disableStopButton(item)}">
                           <a ng-click="customScope.stopVM(item, customScope.disableStopButton(item))" translate>Stop</a>
                         </li>
-                        <li role="menuitem" ng-if="customScope.permissions.suspend" ng-class="{'disabled': customScope.disableSuspendButton(item)}">
+                        <li role="menuitem" ng-if="customScope.permissions.suspend"
+                            ng-class="{'disabled': customScope.disableSuspendButton(item)}">
                           <a ng-click="customScope.suspendVM(item, customScope.disableSuspendButton(item))" translate>Suspend</a>
                         </li>
-                          <li role="menuitem" 
+                        <li role="menuitem"
                             confirmation
                             confirmation-if="vm.retireVMFlag"
                             confirmation-title="{{'Retire Resource'|translate}}"
@@ -304,7 +301,7 @@
                             confirmation-on-ok="customScope.retireVM(item)"
                             confirmation-on-cancel="vm.retireVMFlag=false"
                             ng-if="customScope.permissions.retire"
-                          >
+                        >
                           <a ng-click="vm.retireVMFlag=true" translate>Retire</a>
                         </li>
                         <li role="separator" class="divider"></li>

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -29,17 +29,10 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
         'miq_group.description', 'all_service_children', 'aggregate_all_vm_cpus', 'aggregate_all_vm_memory', 'aggregate_all_vm_disk_count',
         'aggregate_all_vm_disk_space_allocated', 'aggregate_all_vm_disk_space_used', 'aggregate_all_vm_memory_on_disk', 'retired',
         'retirement_state', 'retirement_warn', 'retires_on', 'actions', 'custom_actions', 'provision_dialog', 'service_resources',
-        'chargeback_report', 'service_template', 'parent_service', 'power_state', 'power_status', 'options',
+        'chargeback_report', 'service_template', 'parent_service', 'power_state', 'power_status', 'options', 'vms.ipaddresses',
+        'vms.snapshots', 'vms.v_total_snapshots', 'vms.v_snapshot_newest_name', 'vms.v_snapshot_newest_timestamp', 'vms.v_snapshot_newest_total_size',
+        'vms.supports_console?', 'vms.supports_launch_cockpit?',
       ],
-      decorators: [
-        'vms.ipaddresses',
-        'vms.snapshots',
-        'vms.v_total_snapshots',
-        'vms.v_snapshot_newest_name',
-        'vms.v_snapshot_newest_timestamp',
-        'vms.v_snapshot_newest_total_size',
-        'vms.supports_console?',
-        'vms.supports_cockpit?'],
       expand: ['vms', 'orchestration_stacks'],
     };
 
@@ -167,6 +160,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
 
     return lifeCycleActions;
   }
+
   function checkMenuPermissions(menuOptions) {
     const menu = [];
     angular.forEach(menuOptions, (menuOption) => {
@@ -177,6 +171,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
 
     return menu;
   }
+
   function getPolicyCustomDropdown(editTagsFn) {
     let policyActions;
 
@@ -254,7 +249,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
       ];
       configActions.actions = checkMenuPermissions(configMenuOptions);
     }
-    
+
     return configActions;
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439555
https://www.pivotaltracker.com/story/show/143251619

Complete resolution of this bz is blocked by outstanding pr: https://github.com/ManageIQ/manageiq-ui-service/pull/635

Remove use of decorators, updates servicedetails view for snapshot count
- removes depreciated decorator parameter from collectionsapi service
- updates supports_cockpit to suppose_launch_cockpit

TODO: update vmdetail view to update snapshots

## no visual changes, but look its working!  (zero count for snapshots, both access options available)
![image](https://cloud.githubusercontent.com/assets/6640236/24760440/b036c954-1ab6-11e7-9314-89790c8fc424.png)
