### PR TITLE
BZ#143319861 fix rbac lnav refactor rbac service

### DIFF
--- a/client/app/core/layouts.config.js
+++ b/client/app/core/layouts.config.js
@@ -24,17 +24,12 @@ function getLayouts() {
 /** @ngInject */
 function enterApplication(Polling, lodash, NavCounts, Navigation, RBAC) {
   // Application layout displays the navigation which might have items that require polling to update the counts
-  var navFeatures = RBAC.getNavFeatures();
-  var actionFeatures = RBAC.getActionFeatures();
+  const navFeatures = RBAC.getNavFeatures();
   angular.forEach(NavCounts.counts, updateCount);
-  angular.forEach(Navigation.items, function(value, key) {
+  angular.forEach(Navigation.items, (value, key) => {
     navFeatures[key] = lodash.merge(value, navFeatures[key]);
-    angular.forEach(value.secondary, function(secondaryValue, secondaryKey) {
-      actionFeatures[secondaryKey] = lodash.merge(secondaryValue, actionFeatures[secondaryKey]);
-    });
   });
   RBAC.setNavFeatures(navFeatures);
-  RBAC.setActionFeatures(actionFeatures);
 
   function updateCount(count, key) {
     if (navFeatures[key].show) {
@@ -42,8 +37,6 @@ function enterApplication(Polling, lodash, NavCounts, Navigation, RBAC) {
       if (count.interval) {
         Polling.start(key, count.func, count.interval);
       }
-    } else {
-      return false;
     }
   }
 }

--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -1,50 +1,31 @@
-/* eslint-disable arrow-parens */
-
 /** @ngInject */
 export function RBACFactory(lodash) {
-  var features = {};
   var navFeatures = {};
-  var actionFeatures = {};
+  let features = {};
   let currentRole;
 
-  var service = {
+  return {
+    all: all,
     set: set,
     has: has,
     hasAny: hasAny,
     hasRole: hasRole,
-    all: all,
-    navigationEnabled: navigationEnabled,
-    getNavFeatures: getNavFeatures,
-    getActionFeatures: getActionFeatures,
-    setNavFeatures: setNavFeatures,
-    setActionFeatures: setActionFeatures,
     setRole: setRole,
+    getNavFeatures: getNavFeatures,
+    setNavFeatures: setNavFeatures,
+    navigationEnabled: navigationEnabled,
   };
-
-  return service;
 
   function set(productFeatures) {
     features = productFeatures || {};
 
-    const actionsPermissions = {
-      serviceView: {show: angular.isDefined(productFeatures.service_view)},
-      serviceEdit: {show: angular.isDefined(productFeatures.service_edit)},
-      serviceTag: {show: angular.isDefined(productFeatures.service_tag)},
-      serviceDelete: {show: angular.isDefined(productFeatures.service_delete)},
-      serviceReconfigure: {show: angular.isDefined(productFeatures.service_reconfigure)},
-      serviceRetireNow: {show: angular.isDefined(productFeatures.service_retire_now)},
-      serviceRetire: {show: angular.isDefined(productFeatures.service_retire)},
-      serviceOwnership: {show: angular.isDefined(productFeatures.service_ownership)},
-    };
-    setActionFeatures(actionsPermissions);
     const navPermissions = {
-      dashboard: {show: entitledForDashboard(productFeatures)},
-      services: {show: entitledForServices(productFeatures)},
-      orders: {show: entitledForServiceCatalogs(productFeatures)},
-      requests: {show: entitledForRequests(productFeatures)},
-      catalogs: {show: entitledForServiceCatalogs(productFeatures)},
-      dialogs: {show: entitledForService(productFeatures)},
-      templates: {show: entitledForTemplates(productFeatures)},
+      dashboard: {show: angular.isDefined(productFeatures.dashboard_view)},
+      services: {show: angular.isDefined(productFeatures.service_view)},
+      orders: {show: angular.isDefined(productFeatures.miq_request_view)},
+      requests: {show: angular.isDefined(productFeatures.miq_request_view)},
+      catalogs: {show: angular.isDefined(productFeatures.catalog_items_view)},
+      reports: {show: angular.isDefined(productFeatures.miq_report_saved_reports_view || productFeatures.miq_report_view)},
     };
     setNavFeatures(navPermissions);
   }
@@ -54,13 +35,7 @@ export function RBACFactory(lodash) {
   }
 
   function hasAny(permissions) {
-    const hasPermission = permissions.some(function(feature) {
-      if (angular.isDefined(features[feature])) {
-        return true;
-      }
-    });
-
-    return hasPermission;
+    return permissions.some((feature) => angular.isDefined(features[feature]));
   }
 
   function hasRole(...roles) {
@@ -75,48 +50,12 @@ export function RBACFactory(lodash) {
     navFeatures = features;
   }
 
-  function setActionFeatures(features) {
-    actionFeatures = features;
-  }
-
   function setRole(newRole) {
     currentRole = newRole;
   }
 
-  function getActionFeatures() {
-    return actionFeatures;
-  }
-
   function getNavFeatures() {
     return navFeatures;
-  }
-
-  function entitledForServices(_productFeatures) {
-    var serviceFeature = lodash.find(actionFeatures, function(o) {
-      return o.show === true;
-    });
-
-    return angular.isDefined(serviceFeature);
-  }
-
-  function entitledForServiceCatalogs(productFeatures) {
-    return  angular.isDefined(productFeatures.svc_catalog_provision);
-  }
-
-  function entitledForRequests(productFeatures) {
-    return angular.isDefined(productFeatures.miq_request_view);
-  }
-
-  function entitledForDashboard(productFeatures) {
-    return angular.isDefined(productFeatures.dashboard_view);
-  }
-
-  function entitledForTemplates(productFeatures) {
-    return angular.isDefined(productFeatures.orchestration_templates_view);
-  }
-
-  function entitledForService(productFeatures) {
-    return angular.isDefined(productFeatures.service_view);
   }
 
   function navigationEnabled() {

--- a/client/app/core/session.service.spec.js
+++ b/client/app/core/session.service.spec.js
@@ -67,23 +67,19 @@ describe('Session', function() {
       Session.loadUser();
       $httpBackend.flush();
       var navFeatures = RBAC.getNavFeatures();
-      var actionFeatures = RBAC.getActionFeatures();
 
       expect(navFeatures.dashboard.show).to.eq(true);
       expect(navFeatures.services.show).to.eq(true);
       expect(navFeatures.requests.show).to.eq(false);
       expect(navFeatures.catalogs.show).to.eq(false);
-
-      expect(actionFeatures.serviceEdit.show).to.eq(true);
-      expect(actionFeatures.serviceDelete.show).to.eq(false);
-      expect(actionFeatures.serviceReconfigure.show).to.eq(false);
     });
 
     it('sets visibility for "Service Catalogs" and "Requests" only on navbar and enables "Service Request" button', function() {
       var response = {authorization: {product_features: {
         dashboard_view: {},
-        svc_catalog_provision: {},
-        miq_request_view: {}
+        catalog_items_view: {},
+        miq_request_view: {},
+        miq_report_view: {}
       }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
@@ -94,7 +90,9 @@ describe('Session', function() {
       expect(navFeatures.dashboard.show).to.eq(true);
       expect(navFeatures.services.show).to.eq(false);
       expect(navFeatures.requests.show).to.eq(true);
+      expect(navFeatures.orders.show).to.eq(true);
       expect(navFeatures.catalogs.show).to.eq(true);
+      expect(navFeatures.reports.show).to.eq(true);
     });
 
     it('returns false if user is not entitled to use ssui', function() {

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -2,7 +2,6 @@
 
 /** @ngInject */
 export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
-  const actionFeatures = RBAC.getActionFeatures();
   const permissions = getPermissions();
   const services = {};
 
@@ -120,7 +119,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
     let lifeCycleActions;
     const clockIcon = 'fa fa-clock-o';
 
-    if (actionFeatures.serviceRetireNow.show || actionFeatures.serviceRetire.show) {
+    if (permissions.retire || permissions.setRetireDate) {
       lifeCycleActions = {
         title: __('Lifecycle'),
         actionName: 'lifecycle',
@@ -200,9 +199,7 @@ export function ServicesStateFactory(ListConfiguration, CollectionsApi, RBAC) {
   function getConfigurationCustomDropdown(editServiceFn, removeServicesFn, setOwnershipFn) {
     let configActions;
 
-    if (actionFeatures.serviceDelete.show
-      || actionFeatures.serviceEdit.show
-      || actionFeatures.serviceOwnership.show) {
+    if (permissions.edit || permissions.delete || permissions.setOwnership) {
       configActions = {
         title: __('Configuration'),
         actionName: 'configuration',

--- a/client/app/states/services/details/details.state.spec.js
+++ b/client/app/states/services/details/details.state.spec.js
@@ -15,18 +15,9 @@ describe('Dashboard', function() {
     var controller;
 
     beforeEach(function() {
-      bard.inject('$componentController', 'RBAC');
+      bard.inject('$componentController');
 
-      RBAC.setActionFeatures( {
-        serviceDelete: {show: true},
-        serviceRetireNow: {show: true},
-        serviceRetire: {show: true},
-        serviceTag: {show: true},
-        serviceEdit: {show: true},
-        serviceReconfigure: {show: true},
-        serviceOwnership: {show: true},
-      });
-      controller = $componentController('serviceExplorer'), {};
+      controller = $componentController('serviceExplorer', {});
     });
 
     it('should be created successfully', function() {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439844
https://www.pivotaltracker.com/story/show/143319861

Refactor servicesstate to use permissions rather than actionfeatures
Fix lnav rbac rbac views, remove depreciated action features

No visual changes, but ss for verification of working solution, you'll notice a user with only two roles, catalog and reports, able to navigate to both tabs
![image](https://cloud.githubusercontent.com/assets/6640236/24810832/ba8b0a56-1b91-11e7-9936-9aa6e27dcf64.png)
![image](https://cloud.githubusercontent.com/assets/6640236/24810846/bea84838-1b91-11e7-93af-265885644ae3.png)
