### PR TITLE
Fix issues preventing custom actions from appearing

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -91,9 +91,11 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
   }
 
   function hasCustomButtons(service) {
-    return angular.isDefined(service.custom_actions)
-      && angular.isArray(service.custom_actions.buttons)
-      && service.custom_actions.buttons.length > 0;
+    const actions = service.custom_actions || {};
+    const groups = actions.button_groups || [];
+    const buttons = [].concat(actions.buttons, ...groups.map((g) => g.buttons));
+
+    return lodash.compact(buttons).length > 0;
   }
 
   function getListActions() {

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -27,7 +27,7 @@ function getStates() {
 function resolveService($stateParams, CollectionsApi) {
   var options = {attributes: ['picture', 'picture.image_href']};
 
-  return CollectionsApi.get('services/', $stateParams.serviceId, options);
+  return CollectionsApi.get('services', $stateParams.serviceId, options);
 }
 
 /** @ngInject */


### PR DESCRIPTION
Resolves a pair of issues discovered during QE verification. Update the
function that determines whether a service has custom actions to check
for the presence of buttons within button groups. Previously this was
only checking for the presence of unassigned buttons.

Also remove erroneous trailing `/` from the CollectionsApi#get request
when resolving the custom button details state.

https://www.pivotaltracker.com/story/show/143079265

@miq-bot add_label fine/yes, bug, services