### PR TITLE
BZ#1440966 correctly handle action errors

### DIFF
--- a/client/app/core/action-notifications.service.js
+++ b/client/app/core/action-notifications.service.js
@@ -1,0 +1,12 @@
+/** @ngInject */
+export function ActionNotificationsFactory(EventNotifications) {
+  return {
+    add: add,
+  };
+
+  function add(response, successMsg = "", failMsg = "") {
+    response.results.forEach((response) => {
+      response.success ? EventNotifications.success(successMsg + ' ' + response.message) : EventNotifications.error(failMsg + ' ' + response.message);
+    });
+  }
+}

--- a/client/app/core/core.module.js
+++ b/client/app/core/core.module.js
@@ -17,6 +17,7 @@ import {
 } from './navigation.config.js';
 
 // Core
+import { ActionNotificationsFactory } from './action-notifications.service';
 import { ApplianceInfo } from './appliance-info.service.js';
 import { AuthenticationApiFactory } from './authentication-api.factory.js';
 import { BaseModalController } from './modal/base-modal-controller.js';
@@ -76,6 +77,7 @@ export const CoreModule = angular
   .controller('NavigationController', NavigationController)
   .component('shoppingCart', ShoppingCartComponent)
   .directive('languageSwitcher', LanguageSwitcherDirective)
+  .factory('ActionNotifications', ActionNotificationsFactory)
   .factory('ApplianceInfo', ApplianceInfo)
   .factory('AuthenticationApi', AuthenticationApiFactory)
   .factory('Chargeback', ChargebackFactory)

--- a/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
+++ b/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
@@ -13,7 +13,7 @@ export const ProcessSnapshotsModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($controller, $state, EventNotifications, VmsService, sprintf) {
+function ComponentController($controller, $state, EventNotifications, VmsService, ActionNotifications) {
   const vm = this;
 
   vm.$onInit = function() {
@@ -33,10 +33,10 @@ function ComponentController($controller, $state, EventNotifications, VmsService
     VmsService.createSnapshots(vm.vm.id, vm.modalData).then(success, failure);
   }
 
-  function success() {
+  function success(response) {
     vm.close();
     $state.go($state.current, {}, {reload: true});
-    EventNotifications.success(sprintf(__("Creating snapshot %s of VM %s."), vm.modalData.name, vm.vm.name));
+    ActionNotifications.add(response, __('Creating snapshot.'), __('Error creating snapshot.'));
   }
 
   function failure(response) {

--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -12,7 +12,7 @@ export const VmSnapshotsComponent = {
 };
 
 /** @ngInject */
-function ComponentController(VmsService, sprintf, EventNotifications, ListView, ModalService) {
+function ComponentController(VmsService, sprintf, EventNotifications, ListView, ModalService, ActionNotifications) {
   const vm = this;
 
   vm.$onInit = function() {
@@ -142,13 +142,7 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
     VmsService.deleteSnapshots(vm.vm.id, vm.snapshotsToRemove).then(success, failure);
 
     function success(response) {
-      response.results.forEach((response) => {
-        if (response.success) {
-          EventNotifications.success(__('Success deleting snapshot. ') + response.message);
-        } else {
-          EventNotifications.error(__('Error deleting snapshot. ') + response.message);
-        }
-      });
+      ActionNotifications.add(response, __('Deleting snapshot.'), __('Error deleting snapshot.'));
       vm.snapshotsToRemove = undefined;
       resolveSnapshots();
     }
@@ -216,15 +210,15 @@ function ComponentController(VmsService, sprintf, EventNotifications, ListView, 
   }
 
   function revertSnapshot(_action, item) {
-    VmsService.revertSnapshot(vm.vm.id, item.id).then(handleResponse);
+    VmsService.revertSnapshot(vm.vm.id, item.id).then(success, failure);
 
-    function handleResponse(response) {
-      if (response.success) {
-        EventNotifications.success(__('Success reverting snapshot. ') + response.message);
-      } else {
-        EventNotifications.error(__('Error reverting snapshot. ') + response.message);
-      }
+    function success(response) {
+      ActionNotifications.add({results: [response]}, __('Reverting snapshot.'), __('Error reverting snapshot.'));
       resolveSnapshots();
+    }
+
+    function failure(response) {
+      EventNotifications.error(response.data.error.message);
     }
   }
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1440966
https://www.pivotaltracker.com/story/show/143492819

This work adds ActionNotificationsFactory for handling action responses. Action responses are always returned as a 200 (except in the case of a malformed url, or a validation error) with a staus and results array, this  factory iterates and displays those results with the correct eventnotification type

In the event `ActionNotifications.add(` is only passed the response object, only server feedback will be displayed

The followup to this work be to ensure (pre 🐝 :zzz:) that all action notifications are correctly displayed.

No new visuals to see here, but....
![image](https://cloud.githubusercontent.com/assets/6640236/24916962/b3a5fad2-1ea9-11e7-9b97-7f3788af5fd7.png)
![image](https://cloud.githubusercontent.com/assets/6640236/24917667/e19849a2-1eab-11e7-8352-11a148cb4b41.png)
![image](https://cloud.githubusercontent.com/assets/6640236/24917995/d90a4e42-1eac-11e7-8a2b-ab5cfdda59d8.png)

