### PR TITLE
PT#143511261-Where possible, update responses to batch operations

### DIFF
--- a/client/app/catalogs/catalog-explorer.component.js
+++ b/client/app/catalogs/catalog-explorer.component.js
@@ -10,7 +10,7 @@ export const CatalogExplorerComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, CatalogsState, sprintf, ListView, EventNotifications, lodash) {
+function ComponentController($state, CatalogsState, sprintf, ListView, EventNotifications, lodash, ActionNotifications) {
   var vm = this;
   vm.permissions = CatalogsState.getPermissions();
 
@@ -83,17 +83,18 @@ function ComponentController($state, CatalogsState, sprintf, ListView, EventNoti
     }
 
     if (deleteCatalogs.length > 0) {
-      CatalogsState.deleteCatalogs(deleteCatalogs).then(removeSuccess,
-        removeFailure);
+      CatalogsState.deleteCatalogs(deleteCatalogs).then(removeSuccess, removeFailure);
     }
     vm.confirmDelete = false;
     vm.catalogsToDelete.splice(0, vm.catalogsToDelete.length);
 
-    function removeSuccess() {
+    function removeSuccess(response) {
+      ActionNotifications.add(response, __('Deleting catalog.', 'Error deleting catalog.'));
       resolveCatalogs(vm.limit, 0);
     }
 
     function removeFailure() {
+      EventNotifications.error(__('There was an error deleting catalogs.'));
       resolveCatalogs(vm.limit, 0);
     }
   }

--- a/client/app/catalogs/catalogs-state.service.js
+++ b/client/app/catalogs/catalogs-state.service.js
@@ -247,15 +247,7 @@ export function CatalogsStateFactory(CollectionsApi, EventNotifications, sprintf
       resources: catalogIds,
     };
 
-    function success() {
-      EventNotifications.success(__('Catalog(s) were successfully deleted.'));
-    }
-
-    function failure() {
-      EventNotifications.error(__('There was an error deleting the catalog(s).'));
-    }
-
-    return CollectionsApi.post('service_catalogs', null, {}, options).then(success, failure);
+    return CollectionsApi.post('service_catalogs', null, {}, options);
   }
 
   function viewType(viewType) {

--- a/client/app/requests/process-order-modal/process-order-modal.component.js
+++ b/client/app/requests/process-order-modal/process-order-modal.component.js
@@ -12,7 +12,7 @@ export const ProcessOrderModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, sprintf, CollectionsApi, EventNotifications) {
+function ComponentController($state, CollectionsApi, EventNotifications, ActionNotifications) {
   var vm = this;
 
   angular.extend(vm, {
@@ -32,14 +32,14 @@ function ComponentController($state, sprintf, CollectionsApi, EventNotifications
     };
     CollectionsApi.post('service_orders', '', {}, data).then(saveSuccess, saveFailure);
 
-    function saveSuccess() {
+    function saveSuccess(response) {
       vm.close();
-      EventNotifications.success(sprintf(__('%s was deleted.'), vm.order.name));
+      ActionNotifications.add(response, __('Deleting order.'), __('Error deleting order.'));
       $state.go($state.current, {}, {reload: true});
     }
 
     function saveFailure() {
-      EventNotifications.error(sprintf(__('There was an error deleting %s.'), vm.order.name));
+      EventNotifications.error(__('There was an error removing order'));
     }
   }
 }

--- a/client/app/requests/process-requests-modal/process-requests-modal.component.js
+++ b/client/app/requests/process-requests-modal/process-requests-modal.component.js
@@ -13,7 +13,7 @@ export const ProcessRequestsModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, $controller, lodash, CollectionsApi, EventNotifications) {
+function ComponentController($state, $controller, lodash, CollectionsApi, EventNotifications, ActionNotifications) {
   var vm = this;
 
   angular.extend(vm, {
@@ -40,14 +40,14 @@ function ComponentController($state, $controller, lodash, CollectionsApi, EventN
       item.reason = vm.modalData.reason;
     }
 
-    function saveSuccess() {
+    function saveSuccess(response) {
       vm.close();
       switch (vm.modalType) {
         case "approve":
-          EventNotifications.success(__("Requests Approved"));
+          ActionNotifications.add(response, __('Request approved.'), __('Error approving request.'));
           break;
         case "deny":
-          EventNotifications.success(__("Requests Denied"));
+          ActionNotifications.add(response, __('Request denied.'), __('Error denying request.'));
           break;
       }
       $state.go($state.current, {}, {reload: true});

--- a/client/app/services/ownership-service-modal/ownership-service-modal.component.js
+++ b/client/app/services/ownership-service-modal/ownership-service-modal.component.js
@@ -13,7 +13,7 @@ export const OwnershipServiceModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, lodash, CollectionsApi, EventNotifications) {
+function ComponentController($state, lodash, CollectionsApi, EventNotifications, ActionNotifications) {
   var vm = this;
 
   angular.extend(vm, {
@@ -62,14 +62,14 @@ function ComponentController($state, lodash, CollectionsApi, EventNotifications)
 
     CollectionsApi.post('services', '', {}, data).then(saveSuccess, saveFailure);
 
-    function saveSuccess() {
+    function saveSuccess(response) {
       vm.close();
-      EventNotifications.success(__("Ownership was saved."));
+      ActionNotifications.add(response, __('Setting ownership.'), __('Error setting ownership.'));
       $state.go($state.current, {}, {reload: true});
     }
 
     function saveFailure() {
-      EventNotifications.error(__('There was an error saving ownership of this service.'));
+      EventNotifications.error(__('There was an error saving ownership.'));
     }
 
     function setOwnership(service) {

--- a/client/app/services/retire-remove-service-modal/retire-remove-service-modal.component.js
+++ b/client/app/services/retire-remove-service-modal/retire-remove-service-modal.component.js
@@ -12,7 +12,7 @@ export const RetireRemoveServiceModalComponent = {
 };
 
 /** @ngInject */
-function ComponentController($state, CollectionsApi, EventNotifications) {
+function ComponentController($state, CollectionsApi, EventNotifications, ActionNotifications) {
   var vm = this;
 
   angular.extend(vm, {
@@ -34,14 +34,14 @@ function ComponentController($state, CollectionsApi, EventNotifications) {
     };
     CollectionsApi.post('services', '', {}, data).then(saveSuccess, saveFailure);
 
-    function saveSuccess() {
+    function saveSuccess(response) {
       vm.close();
       switch (vm.resolve.modalType) {
         case "retire":
           EventNotifications.success(__("Services Retired"));
           break;
         case "remove":
-          EventNotifications.success(__("Services Removed"));
+          ActionNotifications.add(response, __('Service deleting.'), __('Error deleting service.'));
           break;
       }
       $state.go($state.current, {}, {reload: true});


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/143511261
depends on https://github.com/ManageIQ/manageiq-ui-service/pull/664

Affects
- delete catalogs
- delete orders
- approve/deny requests/orders
- set-ownership services
- remove services

A number of api actions still return an object instead of a results array, notifications for these actions have remained intact

a few ss of the action

![ownership](https://cloud.githubusercontent.com/assets/6640236/24923854/e1d9cff2-1ec0-11e7-81ef-5e828b0359d0.png)
![service-delete](https://cloud.githubusercontent.com/assets/6640236/24923860/e5d6b26e-1ec0-11e7-8042-a0743adb6986.png)
![order-removing](https://cloud.githubusercontent.com/assets/6640236/24923861/e7c0626e-1ec0-11e7-97e9-7c7d2660ff1f.png)
![catalog-delete](https://cloud.githubusercontent.com/assets/6640236/24923869/ec94a4bc-1ec0-11e7-8e81-b97cde769c17.png)
