### PR TITLE
[EUWE] Fix for service dialog being submitted before entry point code on dynamic fields has completed execution

### DIFF
--- a/client/app/states/marketplace/details/details.html
+++ b/client/app/states/marketplace/details/details.html
@@ -28,7 +28,7 @@
             <div class="col-lg-4 col-md-4 col-sm-4 col-xs-4 ss-details-header__actions">
               <button type="button"
                       class="btn btn-primary"
-                      ng-disabled="! vm.cartAllowed() || vm.addingToCart"
+                      ng-disabled="vm.addToCartDisabled()"
                       confirmation
                       confirmation-if="vm.alreadyInCart()"
                       confirmation-title="{{'Duplicate Shopping Cart Item'|translate}}"

--- a/client/app/states/marketplace/details/details.state.js
+++ b/client/app/states/marketplace/details/details.state.js
@@ -52,6 +52,7 @@
     vm.addToCart = addToCart;
     vm.cartAllowed = ShoppingCart.allowed;
     vm.alreadyInCart = alreadyInCart;
+    vm.addToCartDisabled = addToCartDisabled;
 
     var autoRefreshableDialogFields = [];
     var allDialogFields = [];
@@ -72,6 +73,18 @@
       dialogUrl,
       vm.serviceTemplate.id
     );
+
+    function addToCartDisabled() {
+      return (!vm.cartAllowed() || vm.addingToCart) || anyDialogsBeingRefreshed();
+    }
+
+    function anyDialogsBeingRefreshed() {
+      function checkRefreshing(dialogField) {
+        return dialogField.beingRefreshed;
+      }
+
+      return allDialogFields.some(checkRefreshing);
+    }
 
     function dataForSubmit(href) {
       var dialogFieldData = {};

--- a/tests/marketplace-details.state.spec.js
+++ b/tests/marketplace-details.state.spec.js
@@ -53,15 +53,76 @@ describe('Marketplace.details', function() {
     };
 
     beforeEach(function() {
-      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'Notifications');
-
-      controller = $controller($state.get('marketplace.details').controller, controllerResolves);
-      $rootScope.$apply();
+      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'Notifications', 'DialogFieldRefresh', 'ShoppingCart');
     });
 
     describe('controller initialization', function() {
       it('is created successfully', function() {
+        controller = $controller($state.get('marketplace.details').controller, controllerResolves);
         expect(controller).to.be.defined;
+      });
+
+      describe('#addToCartDisabled', function() {
+        context('when the cart is not allowed', function() {
+          beforeEach(function() {
+            sinon.stub(ShoppingCart, 'allowed', function() {
+              return false;
+            });
+
+            controller = $controller($state.get('marketplace.details').controller, controllerResolves);
+          });
+
+          it('returns true', function() {
+            expect(controller.addToCartDisabled()).to.equal(true);
+          });
+        });
+
+        context('when the cart is allowed', function() {
+          beforeEach(function() {
+            sinon.stub(ShoppingCart, 'allowed', function() {
+              return true;
+            });
+          });
+
+          context('when addingToCart is true', function() {
+            beforeEach(function() {
+              controller = $controller($state.get('marketplace.details').controller, controllerResolves);
+              controller.addingToCart = true;
+            });
+
+            it('returns true', function() {
+              expect(controller.addToCartDisabled()).to.equal(true);
+            });
+          });
+
+          context('when addingToCart is false', function() {
+            context('when any dialogs are being refreshed', function() {
+              beforeEach(function() {
+                dialogs.resources[0].content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].beingRefreshed = true;
+
+                controller = $controller($state.get('marketplace.details').controller, controllerResolves);
+                controller.addingToCart = false;
+              });
+
+              it('returns true', function() {
+                expect(controller.addToCartDisabled()).to.equal(true);
+              });
+            });
+
+            context('when no dialogs are being refreshed', function() {
+              beforeEach(function() {
+                dialogs.resources[0].content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].beingRefreshed = false;
+
+                controller = $controller($state.get('marketplace.details').controller, controllerResolves);
+                controller.addingToCart = false;
+              });
+
+              it('returns false', function() {
+                expect(controller.addToCartDisabled()).to.equal(false);
+              });
+            });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Backport of #619, fixing conflicts from the cherry-pick.

Conflicts were minor, tests were using the incorrect path and the main file that changed in #619 was a different file in Euwe so the changes just needed to be moved over.

/cc @simaishi 