### PR TITLE
BZ#1441861-Displays server feedback when there's an error opening a console

### DIFF
--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -47,8 +47,8 @@ export function ConsolesFactory($window, CollectionsApi, $timeout, $location, Ev
     }
   }
 
-  function consoleError(_error) {
-    EventNotifications.error(__("There was an error opening the console"));
+  function consoleError(error) {
+    EventNotifications.error(__("There was an error opening the console. " + error.message));
   }
 
   function consoleOpen(results) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1441861
https://www.pivotaltracker.com/story/show/143813823

original bug wasn't so much a bug (see below) but sui was not adequately displaying server feedback on console open error
![response](https://cloud.githubusercontent.com/assets/6640236/25096330/c777a524-236d-11e7-9c97-3e1bc16b4994.png)

## no ux changes, for giggles, verification that we display message body when there is an error opening a console
![consolemessage](https://cloud.githubusercontent.com/assets/6640236/25096299/aeead062-236d-11e7-8fc6-90f01eaecfa1.png)
