### PR TITLE
PT#143875421 hide reports tab

### DIFF
--- a/client/app/core/navigation.config.js
+++ b/client/app/core/navigation.config.js
@@ -44,33 +44,33 @@ export function navConfig(NavigationProvider) {
     badgeTooltip: N_('The total number of available catalogs'),
     originalTooltip: 'The total number of available catalogs',
   });
-/*
-  const dialogs = createItem({
-    title: N_('Dialogs'),
-    originalTitle: 'Dialogs',
-    state: 'dialogs',
-    iconClass: 'pficon pficon-build',
-    badgeTooltip: N_('Total available dialogs'),
-    originalTooltip: 'Total available dialogs',
-  });
-*/
-  const reports = createItem({
-    title: N_('Reports'),
-    originalTitle: 'Reports',
-    state: 'reports',
-    iconClass: 'fa fa-area-chart',
-    badgeTooltip: N_('Reports'),
-    originalTooltip: 'Reports',
-  });
+  /*
+   const dialogs = createItem({
+   title: N_('Dialogs'),
+   originalTitle: 'Dialogs',
+   state: 'dialogs',
+   iconClass: 'pficon pficon-build',
+   badgeTooltip: N_('Total available dialogs'),
+   originalTooltip: 'Total available dialogs',
+   });
 
-  /* const templates = createItem({
-    title: N_('Templates'),
-    originalTitle: 'Templates',
-    state: 'templates',
-    iconClass: 'pficon pficon-builder-image',
-    badgeTooltip: N_('Total available Templates'),
-    originalTooltip: 'Total available Templates',
-  }); */
+   const reports = createItem({
+   title: N_('Reports'),
+   originalTitle: 'Reports',
+   state: 'reports',
+   iconClass: 'fa fa-area-chart',
+   badgeTooltip: N_('Reports'),
+   originalTooltip: 'Reports',
+   });
+
+   const templates = createItem({
+   title: N_('Templates'),
+   originalTitle: 'Templates',
+   state: 'templates',
+   iconClass: 'pficon pficon-builder-image',
+   badgeTooltip: N_('Total available Templates'),
+   originalTooltip: 'Total available Templates',
+   }); */
 
   NavigationProvider.configure({
     items: {
@@ -79,9 +79,9 @@ export function navConfig(NavigationProvider) {
       orders: orders,
       requests: requests,
       catalogs: catalogs,
-   //   dialogs: dialogs,
-      reports: reports,
-   //   templates: templates,
+      //   dialogs: dialogs,
+      //    reports: reports,
+      //   templates: templates,
     },
   });
 
@@ -150,20 +150,21 @@ export function navInit(lodash, CollectionsApi, Navigation, NavCounts) {
     CollectionsApi.query('service_catalogs', options)
       .then(lodash.partial(updateCount, 'catalogs'));
   }
-/*
-  function fetchDialogs() {
-    angular.extend(options, {
-      filter: ['id>0'],
-    });
-    CollectionsApi.query('service_dialogs', options)
-      .then(lodash.partial(updateCount, 'dialogs'));
-  }
 
-  function fetchTemplates() {
-    CollectionsApi.query('orchestration_templates', options)
-      .then(lodash.partial(updateCount, 'templates'));
-  }
-*/
+  /*
+   function fetchDialogs() {
+   angular.extend(options, {
+   filter: ['id>0'],
+   });
+   CollectionsApi.query('service_dialogs', options)
+   .then(lodash.partial(updateCount, 'dialogs'));
+   }
+
+   function fetchTemplates() {
+   CollectionsApi.query('orchestration_templates', options)
+   .then(lodash.partial(updateCount, 'templates'));
+   }
+   */
   function updateCount(item, data) {
     Navigation.items[item].badges[0].count = data.subcount;
   }

--- a/client/app/reports/reports-details.component.spec.js
+++ b/client/app/reports/reports-details.component.spec.js
@@ -23,10 +23,9 @@ describe('Component: reportsDetails', function() {
       scope.$apply();
     }));
 
-    it('should work with $state.go', function() {
+    xit('should work with $state.go', function() {
       $state.go('reports.details',{reportId:'10000000000375'});
       expect($state.is('reports.details'));
     });
   });
-
 });

--- a/client/app/reports/reports-details.e2e.js
+++ b/client/app/reports/reports-details.e2e.js
@@ -1,17 +1,17 @@
-describe('Component: reportsDetails', function() {
-  beforeEach(function() {
-    browser.get('/reports/10000000000375');
-  });
-  it('should have correct breadcrumb for a sample report', function() {
-    const breadcrumb = element.all(by.css('.breadcrumb > .active'));
-    expect(breadcrumb.get(0).getText()).toBe("1 - Lifecycle Activity");
-  });
-  it('should have expected number of rows', function() {
-    const list = element.all(by.css('#reportDetails .list-group-item'));
-    expect(list.count()).toBe(4);
-  });
-  it('should show first row as a queued report',function(){
-      const list = element.all(by.css('#reportDetails .list-group-item .column-label'));
-      expect(list.get(0).getText()).toBe("Report Queued");
-  })
-});
+// describe('Component: reportsDetails', function() {
+//   beforeEach(function() {
+//     browser.get('/reports/10000000000375');
+//   });
+//   xit('should have correct breadcrumb for a sample report', function() {
+//     const breadcrumb = element.all(by.css('.breadcrumb > .active'));
+//     expect(breadcrumb.get(0).getText()).toBe("1 - Lifecycle Activity");
+//   });
+//   xit('should have expected number of rows', function() {
+//     const list = element.all(by.css('#reportDetails .list-group-item'));
+//     expect(list.count()).toBe(4);
+//   });
+//   xit('should show first row as a queued report', function() {
+//     const list = element.all(by.css('#reportDetails .list-group-item .column-label'));
+//     expect(list.get(0).getText()).toBe("Report Queued");
+//   })
+// });

--- a/client/app/reports/reports-explorer.component.js
+++ b/client/app/reports/reports-explorer.component.js
@@ -111,7 +111,7 @@ function ComponentController(ListView, ReportsService, EventNotifications, Polli
         onSortChange: sortChange,
         isAscending: ReportsService.listActions.getSort().isAscending,
         currentField: ReportsService.listActions.getSort().currentField,
-      }
+      },
     };
 
     return toolbarConfig;

--- a/client/app/reports/reports-explorer.component.spec.js
+++ b/client/app/reports/reports-explorer.component.spec.js
@@ -18,7 +18,7 @@ describe('Component: reportsExplorer', function() {
       scope.$apply();
     }));
 
-    it('should work with $state.go', function() {
+    xit('should work with $state.go', function() {
       $state.go('reports');
       expect($state.is('reports.explorer'));
     });
@@ -32,7 +32,7 @@ describe('Component: reportsExplorer', function() {
       ctrl = $componentController('reportsExplorer', {$scope: scope}, {});
     }));
 
-    it('is defined', function() {
+    xit('is defined', function() {
       expect(ctrl).to.be.defined;
     });
   });

--- a/client/app/reports/reports-explorer.e2e.js
+++ b/client/app/reports/reports-explorer.e2e.js
@@ -1,17 +1,17 @@
-describe('Component: reportsExplorer', function() {
-  beforeEach(function() {
-    browser.get('/reports');
-  });
-  it('should have correct breadcrumb for Reports', function() {
-    const breadcrumb = element.all(by.css('.breadcrumb > .active'));
-    expect(breadcrumb.get(0).getText()).toBe("Reports");
-  });
-  it('should have expected number of results', function() {
-    const results = element.all(by.css('.toolbar-pf-results h5'));
-    expect(results.get(0).getText()).toBe("5 Results");
-  });
-  it('should have expected number of rows', function() {
-    const list = element.all(by.css('#reportsList .list-group-item'));
-    expect(list.count()).toBe(5);
-  });
-});
+// describe('Component: reportsExplorer', function() {
+//   beforeEach(function() {
+//     // browser.get('/reports');
+//   });
+//   it('should have correct breadcrumb for Reports', function() {
+//     const breadcrumb = element.all(by.css('.breadcrumb > .active'));
+//     expect(breadcrumb.get(0).getText()).toBe("Reports");
+//   });
+//   it('should have expected number of results', function() {
+//     const results = element.all(by.css('.toolbar-pf-results h5'));
+//     expect(results.get(0).getText()).toBe("5 Results");
+//   });
+//   it('should have expected number of rows', function() {
+//     const list = element.all(by.css('#reportsList .list-group-item'));
+//     expect(list.count()).toBe(5);
+//   });
+// });

--- a/client/app/reports/reports.service.js
+++ b/client/app/reports/reports.service.js
@@ -1,9 +1,10 @@
 /* eslint camelcase: "off" */
 
 /** @ngInject */
-export function ReportsServiceFactory(CollectionsApi, RBAC) {
+export function ReportsServiceFactory(ListConfiguration, CollectionsApi, RBAC) {
   const collection = 'reports';
   const service = {
+    listActions: {},
     getMinimal: getMinimal,
     getReports: getReports,
     getReportRuns: getReportRuns,
@@ -11,7 +12,10 @@ export function ReportsServiceFactory(CollectionsApi, RBAC) {
     getPermissions: getPermissions,
   };
 
+  ListConfiguration.setupListFunctions(service.listActions, {id: 'updated_on', title: __('Updated'), sortType: 'numeric'});
+
   return service;
+
   function getMinimal(filters) {
     const options = {
       filter: getQueryFilters(filters),
@@ -20,6 +24,7 @@ export function ReportsServiceFactory(CollectionsApi, RBAC) {
 
     return CollectionsApi.query(collection, options);
   }
+
   function getPermissions() {
     const permissions = {
       'view': RBAC.hasAny(['miq_report', 'miq_report_view']),
@@ -28,19 +33,17 @@ export function ReportsServiceFactory(CollectionsApi, RBAC) {
 
     return permissions;
   }
-  function getReports(limit, offset, filters, sorting) {
+
+  function getReports(limit, offset, filters) {
     const options = {
       expand: ['resources'],
       limit: limit,
       offset: String(offset),
       filter: getQueryFilters(filters),
+      sort_by: service.listActions.getSort().currentField.id,
+      sort_options: service.listActions.getSort().currentField.sortType === 'alpha' ? 'ignore_case' : '',
+      sort_order: service.listActions.getSort().isAscending ? 'asc' : 'desc',
     };
-
-    if (angular.isDefined(sorting)) {
-      options.sort_by = sorting.field;
-      options.sort_options = sorting.sortOptions;
-      options.sort_order = sorting.direction;
-    }
 
     return CollectionsApi.query(collection, options);
   }
@@ -69,7 +72,7 @@ export function ReportsServiceFactory(CollectionsApi, RBAC) {
   function getQueryFilters(filters) {
     const queryFilters = [];
 
-    angular.forEach(filters, function (nextFilter) {
+    angular.forEach(filters, function(nextFilter) {
       if (nextFilter.id === 'name') {
         queryFilters.push("name='%" + nextFilter.value + "%'");
       } else {
@@ -79,7 +82,8 @@ export function ReportsServiceFactory(CollectionsApi, RBAC) {
 
     return queryFilters;
   }
-  function queueReport(reportId, options ) {
+
+  function queueReport(reportId, options) {
     return CollectionsApi.post(collection, reportId, {}, options);
   }
 }

--- a/client/app/states/reports/view/report.e2e.js
+++ b/client/app/states/reports/view/report.e2e.js
@@ -1,17 +1,17 @@
-describe('Component: reportsDetails', function() {
-  beforeEach(function() {
-    browser.get('/reports/view/10000000000375/10000000000289');
-  });
-  it('should have correct breadcrumb for a sample report', function() {
-    const breadcrumb = element.all(by.css('.breadcrumb > .active'));
-    expect(breadcrumb.get(0).getText()).toBe("Run - 10000000000289");
-  });
-  it('should have expected number of rows', function() {
-    const list = element.all(by.css('.table tr'));
-    expect(list.count()).toBe(28);
-  });
-  it('should only have 6 fields selected',function(){
-      const list = element.all(by.css('.service-details-resource-group-title'));
-      expect(list.get(0).getText()).toBe("Report fields displayed (6 of 24)");
-  })
-});
+// describe('Component: reportsDetails', function() {
+//   beforeEach(function() {
+//     browser.get('/reports/view/10000000000375/10000000000289');
+//   });
+//   it('should have correct breadcrumb for a sample report', function() {
+//     const breadcrumb = element.all(by.css('.breadcrumb > .active'));
+//     expect(breadcrumb.get(0).getText()).toBe("Run - 10000000000289");
+//   });
+//   it('should have expected number of rows', function() {
+//     const list = element.all(by.css('.table tr'));
+//     expect(list.count()).toBe(28);
+//   });
+//   it('should only have 6 fields selected',function(){
+//       const list = element.all(by.css('.service-details-resource-group-title'));
+//       expect(list.get(0).getText()).toBe("Report fields displayed (6 of 24)");
+//   })
+// });

--- a/client/app/states/states.module.js
+++ b/client/app/states/states.module.js
@@ -13,10 +13,6 @@ import {NotFoundState} from "./404/404.state.js";
 import {OrdersDetailsState} from "./orders/details/details.state.js";
 import {OrdersExplorerState} from "./orders/explorer/explorer.state.js";
 import {OrdersState} from "./orders/orders.state.js";
-import {ReportState} from "./reports/view/report.state.js";
-import {ReportsDetailsState} from "./reports/details/details.state.js";
-import {ReportsExplorerState} from "./reports/explorer/explorer.state.js";
-import {ReportsState} from "./reports/reports.state.js";
 import {RequestsDetailsState} from "./requests/details/details.state.js";
 import {RequestsExplorerState} from "./requests/explorer/explorer.state.js";
 import {RequestsState} from "./requests/requests.state.js";
@@ -47,10 +43,6 @@ export const AppRoutingModule = angular
   .run(OrdersDetailsState)
   .run(OrdersExplorerState)
   .run(OrdersState)
-  .run(ReportState)
-  .run(ReportsDetailsState)
-  .run(ReportsExplorerState)
-  .run(ReportsState)
   .run(RequestsDetailsState)
   .run(RequestsExplorerState)
   .run(RequestsState)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/143875421

this hides reports tab, ignores reports tests, removes report state and supporting components
this updates reports explorer to sort by latest updated

no ux required