### PR TITLE
Left align various elements in explorer views

### DIFF
--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -35,7 +35,7 @@ body
     .col-sm-12
       padding-left: 15px
 
-    .form-group
+    .toolbar-apf-filter
       padding-left: 0
 
       .filter-fields

--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -31,6 +31,20 @@ body
   border-bottom: 1px solid $color-light-gray-approx
   border-top: 1px solid $color-light-gray-approx
 
+  .toolbar-pf
+    .col-sm-12
+      padding-left: 15px
+
+    .form-group
+      padding-left: 0
+
+      .filter-fields
+        margin-left: 0
+
+  .toolbar-pf-results
+    .col-sm-12
+      padding-left: 20px
+
   &.section-toolbar-right-actions
     .toolbar-actions
       border-right: 0

--- a/client/assets/sass/_explorer.sass
+++ b/client/assets/sass/_explorer.sass
@@ -6,6 +6,10 @@
     .power-icon
       cursor: default
 
+  .list-group-item-header
+    .pf-expand-placeholder
+      display: none
+
   .list-view-pf
     height: calc(100vh - 237px)
     overflow-y: auto


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/143875833

@miq-bot add_label fine/yes, bug, services, orders, ux/review

Services Explorer:
<img width="865" alt="screen shot 2017-04-19 at 12 57 54 pm" src="https://cloud.githubusercontent.com/assets/6842753/25192163/279fba7a-2500-11e7-92c2-0356019a9033.png">

Orders Explorer:
<img width="845" alt="screen shot 2017-04-19 at 12 57 47 pm" src="https://cloud.githubusercontent.com/assets/6842753/25192165/29b2fafc-2500-11e7-9766-f3463045de1f.png">