### PR TITLE
BZ#1440931-Refuse login for users with only dashboard role

### DIFF
--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -20,12 +20,11 @@ export function RBACFactory(lodash) {
     features = productFeatures || {};
 
     const navPermissions = {
-      dashboard: {show: angular.isDefined(productFeatures.dashboard_view)},
       services: {show: angular.isDefined(productFeatures.service_view)},
       orders: {show: angular.isDefined(productFeatures.miq_request_view)},
       requests: {show: angular.isDefined(productFeatures.miq_request_view)},
       catalogs: {show: angular.isDefined(productFeatures.catalog_items_view)},
-      reports: {show: angular.isDefined(productFeatures.miq_report_saved_reports_view || productFeatures.miq_report_view)},
+      // reports: {show: angular.isDefined(productFeatures.miq_report_saved_reports_view || productFeatures.miq_report_view)},
     };
     setNavFeatures(navPermissions);
   }

--- a/client/app/core/session.service.spec.js
+++ b/client/app/core/session.service.spec.js
@@ -68,7 +68,6 @@ describe('Session', function() {
       $httpBackend.flush();
       var navFeatures = RBAC.getNavFeatures();
 
-      expect(navFeatures.dashboard.show).to.eq(true);
       expect(navFeatures.services.show).to.eq(true);
       expect(navFeatures.requests.show).to.eq(false);
       expect(navFeatures.catalogs.show).to.eq(false);
@@ -76,10 +75,8 @@ describe('Session', function() {
 
     it('sets visibility for "Service Catalogs" and "Requests" only on navbar and enables "Service Request" button', function() {
       var response = {authorization: {product_features: {
-        dashboard_view: {},
         catalog_items_view: {},
         miq_request_view: {},
-        miq_report_view: {}
       }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
@@ -87,12 +84,10 @@ describe('Session', function() {
       $httpBackend.flush();
       var navFeatures = RBAC.getNavFeatures();
 
-      expect(navFeatures.dashboard.show).to.eq(true);
       expect(navFeatures.services.show).to.eq(false);
       expect(navFeatures.requests.show).to.eq(true);
       expect(navFeatures.orders.show).to.eq(true);
       expect(navFeatures.catalogs.show).to.eq(true);
-      expect(navFeatures.reports.show).to.eq(true);
     });
 
     it('returns false if user is not entitled to use ssui', function() {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1440931
https://www.pivotaltracker.com/story/show/143967955

also hides report login check, no ux changes here, refusal text was already written as requested
<img width="1078" alt="screen shot 2017-04-19 at 2 26 26 pm" src="https://cloud.githubusercontent.com/assets/6640236/25196474/d481ea2a-250e-11e7-9967-09b111080d55.png">
