### PR TITLE
BZ31443346PT#144028481-Ensure  vm and retired tooltip align with content

### DIFF
--- a/client/app/services/service-explorer/service-explorer.html
+++ b/client/app/services/service-explorer/service-explorer.html
@@ -62,7 +62,7 @@
         <span class="no-wrap" uib-tooltip="{{ '[[number]] VMs'|translate|substitute:{number: item.v_total_vms} }}"
               tooltip-append-to-body="true"
               tooltip-popup-delay="1000"
-              tooltip-placement="bottom">
+              tooltip-placement="bottom-left">
            <i class="pficon pficon-screen"></i>
           <span>
             {{ item.v_total_vms }}
@@ -93,7 +93,7 @@
              uib-tooltip="{{item.retires_on ? (item.retires_on | date : 'medium') : ('Never' | translate)}}"
              tooltip-append-to-body="true"
              tooltip-popup-delay="1000"
-             tooltip-placement="bottom">
+             tooltip-placement="bottom-left">
           <strong translate>Retires</strong>&nbsp;
           <div>
             {{item.retires_on ? (item.retires_on | date : 'short') : ('Never' | translate)}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,7 +26,7 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@angular/upgrade/-/upgrade-4.0.2.tgz#89e760a797f888f50dff0b1e8336722ef3609b53"
 
-"@manageiq/manageiq-api-mock@^1.0.1":
+"@manageiq/manageiq-api-mock@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@manageiq/manageiq-api-mock/-/manageiq-api-mock-1.0.1.tgz#b9137af4b26af543dd8d96d20d50ca8aa2b2ad5f"
   dependencies:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443346
https://www.pivotaltracker.com/story/show/144028481

ignore the color gnome is on drugs

![screenshot from 2017-04-20 13-44-20](https://cloud.githubusercontent.com/assets/6640236/25244681/b12b12d8-25cf-11e7-9e64-a142e13d2a79.png)
![screenshot from 2017-04-20 13-44-14](https://cloud.githubusercontent.com/assets/6640236/25244682/b12cd8ac-25cf-11e7-83c4-1d9ff5b8bebe.png)
