### PR TITLE
Maintain row control alignment for list views

### DIFF
--- a/client/assets/sass/_explorer.sass
+++ b/client/assets/sass/_explorer.sass
@@ -6,10 +6,6 @@
     .power-icon
       cursor: default
 
-  .list-group-item-header
-    .pf-expand-placeholder
-      display: none
-
   .list-view-pf
     height: calc(100vh - 237px)
     overflow-y: auto

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -100,7 +100,7 @@
 
   .list-view-pf-main-info
     margin-left: 15px
-    padding: 0
+    padding: 5px 0 0
 
     & > .row
       width: 100%


### PR DESCRIPTION
Some list views contain a mix of rows that expandable and others that do
not. In these situations the vertical bar separating the row controls
should be aligned.

<img width="1201" alt="screen shot 2017-04-20 at 4 12 31 pm" src="https://cloud.githubusercontent.com/assets/6842753/25250670/999cc214-25e4-11e7-8289-1d035b27dae6.png">

@miq-bot add_label fine/yes, bug