### PR TITLE
Removes accidential title  as a result of using reserved word

### DIFF
--- a/client/app/services/detail-reveal/detail-reveal.component.js
+++ b/client/app/services/detail-reveal/detail-reveal.component.js
@@ -5,7 +5,7 @@ export const DetailRevealComponent = {
   controller: ComponentController,
   controllerAs: 'vm',
   bindings: {
-    title: '@',
+    detailTitle: '@',
     detail: '@',
     icon: '@',
     translateTitle: '<',
@@ -22,7 +22,7 @@ function ComponentController($transclude) {
 
   function activate() {
     vm.translateTitle = (angular.isUndefined(vm.translateTitle) ? true : vm.translateTitle);
-    vm.title = (vm.translateTitle === true ? __(vm.title) : vm.title);
+    vm.detailTitle = (vm.translateTitle === true ? __(vm.detailTitle) : vm.detailTitle);
     vm.rowClass = (angular.isDefined(vm.rowClass) ? vm.rowClass : 'row detail-row');
     vm.toggleDetails = false;
     vm.hasMoreDetails = $transclude().length > 0;

--- a/client/app/services/detail-reveal/detail-reveal.html
+++ b/client/app/services/detail-reveal/detail-reveal.html
@@ -3,7 +3,7 @@
 		<div class="detail-reveal-arrow-container" ng-class="vm.hasMoreDetails ? '' : 'no-details' ">
 			<i class="fa fa-lg detail-reveal-arrow" ng-class="(vm.toggleDetails===true ? 'fa-angle-down' : 'fa-angle-right')"></i>
 		</div>
-		<span>{{vm.title}}</span>
+		<span>{{vm.detailTitle}}</span>
 	</div>
 	<div class="col-xs-6 col-md-9">
 		<i ng-if="vm.icon" class="{{vm.icon}}"></i> 

--- a/client/app/services/vm-details/vm-details.html
+++ b/client/app/services/vm-details/vm-details.html
@@ -13,7 +13,8 @@
       </ol>
   </span>
 </div>
-<div ng-if="vm.listActions.length" pf-toolbar class="section-toolbar section-toolbar-right-actions" config="vm.headerConfig">
+<div ng-if="vm.listActions.length" pf-toolbar class="section-toolbar section-toolbar-right-actions"
+     config="vm.headerConfig">
   <actions>
     <div class="ss-details-header__actions">
       <div uib-dropdown class="ss-details-header__actions__inner dropdown-kebab-pf">
@@ -32,35 +33,36 @@
     <div class="row title">
       <div>{{ 'Properties'|translate }}</div>
     </div>
-    <detail-reveal ng-if="vm.vmDetails.retired" title="Status" icon="pf pficon-warning-triangle-o"
+    <detail-reveal ng-if="vm.vmDetails.retired" detail-title="Status" icon="pf pficon-warning-triangle-o"
                    detail="{{ 'Retired' | translate }}"></detail-reveal>
-    <detail-reveal title="Name" detail="{{ vm.vmDetails.name }}"></detail-reveal>
-    <detail-reveal title="Hostnames" detail="{{ vm.vmDetails.hostnames.join(',') }}"></detail-reveal>
-    <detail-reveal title="IP Addresses" detail="{{ vm.vmDetails.ipaddresses.join(',') }}"></detail-reveal>
-    <detail-reveal title="MAC Address" detail="{{ vm.vmDetails.mac_addresses.join(',') }}"
+    <detail-reveal detail-title="Name" detail="{{ vm.vmDetails.name }}"></detail-reveal>
+    <detail-reveal detail-title="Hostnames" detail="{{ vm.vmDetails.hostnames.join(',') }}"></detail-reveal>
+    <detail-reveal detail-title="IP Addresses" detail="{{ vm.vmDetails.ipaddresses.join(',') }}"></detail-reveal>
+    <detail-reveal detail-title="MAC Address" detail="{{ vm.vmDetails.mac_addresses.join(',') }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Container" detail="{{ vm.vmDetails.containerSpecsText }}"></detail-reveal>
-    <detail-reveal title="Parent Host/Node Platform" detail="{{ vm.vmDetails.host.vmm_product }}"
+    <detail-reveal detail-title="Container" detail="{{ vm.vmDetails.containerSpecsText }}"></detail-reveal>
+    <detail-reveal detail-title="Parent Host/Node Platform" detail="{{ vm.vmDetails.host.vmm_product }}"
                    ng-if="vm.vmDetails.host"></detail-reveal>
-    <detail-reveal title="Platform Tools" detail="{{ vm.vmDetails.tools_status }}"></detail-reveal>
-    <detail-reveal title="Operating System" detail="{{ vm.vmDetails.hardware.guest_os_full_name }}"></detail-reveal>
-    <detail-reveal title="Architecture" detail="{{ vm.vmDetails.hardware.bitness }} bit"
+    <detail-reveal detail-title="Platform Tools" detail="{{ vm.vmDetails.tools_status }}"></detail-reveal>
+    <detail-reveal detail-title="Operating System"
+                   detail="{{ vm.vmDetails.hardware.guest_os_full_name }}"></detail-reveal>
+    <detail-reveal detail-title="Architecture" detail="{{ vm.vmDetails.hardware.bitness }} bit"
                    ng-if="vm.vmDetails.hardware.bitness"></detail-reveal>
-    <detail-reveal title="Devices" icon="fa fa-hdd-o fa-lg" detail="{{ 3 + vm.vmDetails.num_disks }}"
+    <detail-reveal detail-title="Devices" icon="fa fa-hdd-o fa-lg" detail="{{ 3 + vm.vmDetails.num_disks }}"
                    ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-    <detail-reveal title="CPU Affinity" detail="{{ vm.vmDetails.cpu_affinity }}"
+    <detail-reveal detail-title="CPU Affinity" detail="{{ vm.vmDetails.cpu_affinity }}"
                    ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-    <detail-reveal title="Snapshots" icon="fa fa-camera fa-lg"
+    <detail-reveal detail-title="Snapshots" icon="fa fa-camera fa-lg"
                    detail="{{ vm.vmDetails.v_total_snapshots }}"></detail-reveal>
-    <detail-reveal title="Advanced Settings" icon="fa fa-wrench fa-lg"
+    <detail-reveal detail-title="Advanced Settings" icon="fa fa-wrench fa-lg"
                    detail="{{ vm.vmDetails.advanced_settings.length }}"></detail-reveal>
-    <detail-reveal title="Resources" detail="{{ vm.vmDetails.resourceAvailability }}"></detail-reveal>
-    <detail-reveal title="Management Engine GUID" detail="{{ vm.vmDetails.guid }}"></detail-reveal>
-    <detail-reveal title="Virtualization" detail="{{ vm.vmDetails.hardware.virtualization_type }}"
+    <detail-reveal detail-title="Resources" detail="{{ vm.vmDetails.resourceAvailability }}"></detail-reveal>
+    <detail-reveal detail-title="Management Engine GUID" detail="{{ vm.vmDetails.guid }}"></detail-reveal>
+    <detail-reveal detail-title="Virtualization" detail="{{ vm.vmDetails.hardware.virtualization_type }}"
                    ng-if="vm.vmDetails.hardware.virtualization_type"></detail-reveal>
-    <detail-reveal title="Root Device Type" detail="{{ vm.vmDetails.hardware.root_device_type }}"
+    <detail-reveal detail-title="Root Device Type" detail="{{ vm.vmDetails.hardware.root_device_type }}"
                    ng-if="vm.vmDetails.hardware.root_device_type"></detail-reveal>
-    <detail-reveal title="ID within Provider" detail="{{ vm.vmDetails.uid_ems }}"
+    <detail-reveal detail-title="ID within Provider" detail="{{ vm.vmDetails.uid_ems }}"
                    ng-if="vm.vmDetails.uid_ems"></detail-reveal>
   </div>
 
@@ -68,83 +70,86 @@
     <div class="row title">
       <div>{{ 'Lifecycle'|translate }}</div>
     </div>
-    <detail-reveal title="Discovered on" detail="{{  vm.vmDetails.created_on | date:'medium'  }}"></detail-reveal>
-    <detail-reveal title="Last Analyzed" icon="fa fa-search fa-lg"
+    <detail-reveal detail-title="Discovered on"
+                   detail="{{  vm.vmDetails.created_on | date:'medium'  }}"></detail-reveal>
+    <detail-reveal detail-title="Last Analyzed" icon="fa fa-search fa-lg"
                    detail="{{  vm.vmDetails.lastSyncOn | date:'medium'  }}"></detail-reveal>
-    <detail-reveal title="Retirement Date" icon="fa fa-clock-o fa-lg"
+    <detail-reveal detail-title="Retirement Date" icon="fa fa-clock-o fa-lg"
                    detail="{{  vm.vmDetails.retiresOn | date:'medium'  }}"></detail-reveal>
-    <detail-reveal title="Provisioned On" detail="{{  vm.vmDetails.provisionDate | date:'medium'  }}"></detail-reveal>
-    <detail-reveal title="Owner" detail="{{ vm.vmDetails.evm_owner.name }}"></detail-reveal>
-    <detail-reveal title="Group" detail="{{ vm.vmDetails.miq_group.description }}"></detail-reveal>
+    <detail-reveal detail-title="Provisioned On"
+                   detail="{{  vm.vmDetails.provisionDate | date:'medium'  }}"></detail-reveal>
+    <detail-reveal detail-title="Owner" detail="{{ vm.vmDetails.evm_owner.name }}"></detail-reveal>
+    <detail-reveal detail-title="Group" detail="{{ vm.vmDetails.miq_group.description }}"></detail-reveal>
   </div>
   <div class="container-fluid vm-details-container">
     <div class="row title">
       <div>{{ 'Relationships'|translate }}</div>
     </div>
-    <detail-reveal title="Availability Zone" detail="{{ vm.vmDetails.instance.availabilityZone }}"
+    <detail-reveal detail-title="Availability Zone" detail="{{ vm.vmDetails.instance.availabilityZone }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Cloud Tenants" detail="{{ vm.vmDetails.instance.cloudTenant }}"
+    <detail-reveal detail-title="Cloud Tenants" detail="{{ vm.vmDetails.instance.cloudTenant }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Flavor" detail="{{ vm.vmDetails.instance.flavor.name }}"
+    <detail-reveal detail-title="Flavor" detail="{{ vm.vmDetails.instance.flavor.name }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="VM Template" detail="{{ vm.vmDetails.instance.miq_provision_template.name }}"
+    <detail-reveal detail-title="VM Template" detail="{{ vm.vmDetails.instance.miq_provision_template.name }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Infrastructure provider" detail="{{ vm.vmDetails.ext_management_system.name }}"
+    <detail-reveal detail-title="Infrastructure provider" detail="{{ vm.vmDetails.ext_management_system.name }}"
                    ng-if="vm.vmDetails.ext_management_system.name"></detail-reveal>
-    <detail-reveal title="{{ 'Cluster'|translate }} / {{ 'Deployment Role'|translate }}"
+    <detail-reveal detail-title="{{ 'Cluster'|translate }} / {{ 'Deployment Role'|translate }}"
                    icon="fa fa-lg pficon pficon-cluster" detail="{{ vm.vmDetails.ems_cluster.name }}"
                    ng-if="vm.vmDetails.ems_cluster.name"></detail-reveal>
-    <detail-reveal title="Host / Node" icon="fa fa-lg pficon pficon-screen" detail="{{ vm.vmDetails.host.name }}"
+    <detail-reveal detail-title="Host / Node" icon="fa fa-lg pficon pficon-screen" detail="{{ vm.vmDetails.host.name }}"
                    ng-if="vm.vmDetails.host.name"></detail-reveal>
-    <detail-reveal title="Resource Pool" icon="fa fa-lg pficon pficon-resource-pool"
+    <detail-reveal detail-title="Resource Pool" icon="fa fa-lg pficon pficon-resource-pool"
                    detail="{{ vm.vmDetails.parent_resource_pool.name }}"
                    ng-if="vm.vmDetails.parent_resource_pool"></detail-reveal>
-    <detail-reveal title="Datastores" icon="fa fa-lg fa-database" detail="{{ vm.vmDetails.storages.length }}"
+    <detail-reveal detail-title="Datastores" icon="fa fa-lg fa-database" detail="{{ vm.vmDetails.storages.length }}"
                    ng-if="vm.vmDetails.storages.length > 0"></detail-reveal>
-    <detail-reveal title="Service" icon="fa fa-lg pficon pficon-service"
+    <detail-reveal detail-title="Service" icon="fa fa-lg pficon pficon-service"
                    detail="{{ vm.vmDetails.service.name }}"></detail-reveal>
-    <detail-reveal title="Virtual Private Cloud" detail="{{ vm.vmDetails.instance.cloud_networks[0].name }}"
+    <detail-reveal detail-title="Virtual Private Cloud" detail="{{ vm.vmDetails.instance.cloud_networks[0].name }}"
                    ng-if="vm.vmDetails.instance.cloud_networks.length > 0"></detail-reveal>
-    <detail-reveal title="Cloud Subnet" detail="{{ vm.vmDetails.instance.cloud_subnets[0].name }}"
+    <detail-reveal detail-title="Cloud Subnet" detail="{{ vm.vmDetails.instance.cloud_subnets[0].name }}"
                    ng-if="vm.vmDetails.instance.cloud_subnets.length > 0"></detail-reveal>
-    <detail-reveal title="Stack" detail="{{ vm.vmDetails.instance.orchestrationStack.name }}"
+    <detail-reveal detail-title="Stack" detail="{{ vm.vmDetails.instance.orchestrationStack.name }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Cloud Networks" detail="{{ vm.vmDetails.instance.cloud_networks.length }}"
+    <detail-reveal detail-title="Cloud Networks" detail="{{ vm.vmDetails.instance.cloud_networks.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Cloud Subnets" detail="{{ vm.vmDetails.instance.cloud_subnets.length }}"
+    <detail-reveal detail-title="Cloud Subnets" detail="{{ vm.vmDetails.instance.cloud_subnets.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Network Routers" detail="{{ vm.vmDetails.instance.network_routers.length }}"
+    <detail-reveal detail-title="Network Routers" detail="{{ vm.vmDetails.instance.network_routers.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Security Groups" detail="{{ vm.vmDetails.security_groups.length }}"
+    <detail-reveal detail-title="Security Groups" detail="{{ vm.vmDetails.security_groups.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Floating IPs" detail="{{ vm.vmDetails.instance.floating_ip_addresses.length }}"
+    <detail-reveal detail-title="Floating IPs" detail="{{ vm.vmDetails.instance.floating_ip_addresses.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Network Ports" detail="{{ vm.vmDetails.instance.network_ports.length }}"
+    <detail-reveal detail-title="Network Ports" detail="{{ vm.vmDetails.instance.network_ports.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Load Balancers" detail="{{ vm.vmDetails.instance.load_balancers.length }}"
+    <detail-reveal detail-title="Load Balancers" detail="{{ vm.vmDetails.instance.load_balancers.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Cloud Volumes" detail="{{ vm.vmDetails.instance.cloud_volumes.length }}"
+    <detail-reveal detail-title="Cloud Volumes" detail="{{ vm.vmDetails.instance.cloud_volumes.length }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
-    <detail-reveal title="Genealogy" detail="{{ 'Show parent and child VMs'|translate }}"
+    <detail-reveal detail-title="Genealogy" detail="{{ 'Show parent and child VMs'|translate }}"
                    ng-if="vm.vmDetails.cloud===false"></detail-reveal>
-    <detail-reveal title="Drift History" detail="{{ vm.vmDetails.driftHistory }}"></detail-reveal>
-    <detail-reveal title="Analysis History" detail="{{ vm.vmDetails.scanHistoryCount }}"></detail-reveal>
+    <detail-reveal detail-title="Drift History" detail="{{ vm.vmDetails.driftHistory }}"></detail-reveal>
+    <detail-reveal detail-title="Analysis History" detail="{{ vm.vmDetails.scanHistoryCount }}"></detail-reveal>
   </div>
   <div class="container-fluid vm-details-container">
     <div class="row title">
       <div>{{ 'Compliance'|translate }}</div>
     </div>
-    <detail-reveal title="Status" detail="{{ vm.vmDetails.lastComplianceStatus }}"></detail-reveal>
-    <detail-reveal title="History" detail="{{ vm.vmDetails.complianceHistory }}"></detail-reveal>
+    <detail-reveal detail-title="Status" detail="{{ vm.vmDetails.lastComplianceStatus }}"></detail-reveal>
+    <detail-reveal detail-title="History" detail="{{ vm.vmDetails.complianceHistory }}"></detail-reveal>
   </div>
 
   <div class="container-fluid vm-details-container">
     <div class="row title">
       <div>{{ 'Power Management'|translate }}</div>
     </div>
-    <detail-reveal title="Power State" detail="{{ vm.vmDetails.power_state }}"></detail-reveal>
-    <detail-reveal title="Last Boot Time" detail="{{  vm.vmDetails.boot_time | date:'medium'  }}"></detail-reveal>
-    <detail-reveal title="State Changed On"
+    <detail-reveal detail-title="Power State" detail="{{ vm.vmDetails.power_state }}"></detail-reveal>
+    <detail-reveal detail-title="Last Boot Time"
+                   detail="{{  vm.vmDetails.boot_time | date:'medium'  }}"></detail-reveal>
+    <detail-reveal detail-title="State Changed On"
                    detail="{{  vm.vmDetails.state_changed_on | date:'medium'  }}"></detail-reveal>
   </div>
 
@@ -152,19 +157,20 @@
     <div class="row title">
       <div>{{ 'Security'|translate }}</div>
     </div>
-    <detail-reveal title="Users" icon="fa fa-lg pficon pficon-user"
+    <detail-reveal detail-title="Users" icon="fa fa-lg pficon pficon-user"
                    detail="{{  vm.vmDetails.users.length  }}"></detail-reveal>
-    <detail-reveal title="Groups" icon="fa fa-lg pficon pficon-users"
+    <detail-reveal detail-title="Groups" icon="fa fa-lg pficon pficon-users"
                    detail="{{  vm.vmDetails.groups.length  }}"></detail-reveal>
-    <detail-reveal title="Key Pairs" detail="{{  vm.vmDetails.instance.keyPairLabels.join(',')  }}"
+    <detail-reveal detail-title="Key Pairs" detail="{{  vm.vmDetails.instance.keyPairLabels.join(',')  }}"
                    ng-if="vm.vmDetails.instance"></detail-reveal>
   </div>
   <div class="container-fluid vm-details-container">
     <div class="row title">
       <div>{{ 'Configuration'|translate }}</div>
     </div>
-    <detail-reveal title="Packages" detail="{{  vm.vmDetails.guest_applications.length  }}"></detail-reveal>
-    <detail-reveal title="Init Processes" detail="{{  vm.vmDetails.linux_initprocesses.length  }}"></detail-reveal>
-    <detail-reveal title="Files" detail="{{  vm.vmDetails.files.length  }}"></detail-reveal>
+    <detail-reveal detail-title="Packages" detail="{{  vm.vmDetails.guest_applications.length  }}"></detail-reveal>
+    <detail-reveal detail-title="Init Processes"
+                   detail="{{  vm.vmDetails.linux_initprocesses.length  }}"></detail-reveal>
+    <detail-reveal detail-title="Files" detail="{{  vm.vmDetails.files.length  }}"></detail-reveal>
   </div>
 </div>


### PR DESCRIPTION
Hover over any field would display a caption that does not align with ux, (tooltips is our jam n stuff), this changes up the offending component param name.

again ignore the color, gnome is on drugs...

### before, you'll notice the text bubble by the mouse
<img width="1920" alt="screen shot 2017-04-20 at 1 59 51 pm" src="https://cloud.githubusercontent.com/assets/6640236/25245219/b44247b4-25d1-11e7-81ff-1234cb320b4c.png">

### after, no text bubble by the mouse
![screenshot from 2017-04 -20 13-48-12](https://cloud.githubusercontent.com/assets/6640236/25244827/3d852cb4-25d0-11e7-9bb3-d47268643554.png)

@serenamarie125 if this isn't a bug we can just close this pr