### PR TITLE
BZ#1439632 - Pretty credential 

### DIFF
--- a/client/app/core/collections-api.factory.js
+++ b/client/app/core/collections-api.factory.js
@@ -2,17 +2,18 @@
 
 /** @ngInject */
 export function CollectionsApiFactory($http, API_BASE) {
-  var service = {
+  const service = {
     query: query,
     get: get,
     post: post,
+    options: options,
     delete: remove,
   };
 
   return service;
 
   function query(collection, options) {
-    var url = API_BASE + '/api/' + collection;
+    const url = API_BASE + '/api/' + collection;
 
     // $log.debug("query = " + url + buildQuery(options));
 
@@ -25,7 +26,7 @@ export function CollectionsApiFactory($http, API_BASE) {
   }
 
   function get(collection, id, options) {
-    var url = API_BASE + '/api/' + collection + '/' + id;
+    const url = API_BASE + '/api/' + collection + '/' + id;
 
     // $log.debug("get = " + url + buildQuery(options));
 
@@ -38,7 +39,7 @@ export function CollectionsApiFactory($http, API_BASE) {
   }
 
   function post(collection, id, options, data) {
-    var url = API_BASE + '/api/' + collection + '/' + (id || "") + buildQuery(options);
+    const url = API_BASE + '/api/' + collection + '/' + (id || "") + buildQuery(options);
 
     // $log.debug("post = " + url + buildQuery(options));
 
@@ -50,9 +51,20 @@ export function CollectionsApiFactory($http, API_BASE) {
     }
   }
 
+  function options(collection) {
+    const url = API_BASE + '/api/' + collection;
+
+    return $http.get(url + buildQuery(options))
+      .then(handleSuccess);
+
+    function handleSuccess(response) {
+      return response.data;
+    }
+  }
+
   // delete is a reserved word in JS
   function remove(collection, id, options) {
-    var url = API_BASE + '/api/' + collection + '/' + (id || "") + buildQuery(options);
+    const url = API_BASE + '/api/' + collection + '/' + (id || "") + buildQuery(options);
 
     // $log.debug("post = " + url + buildQuery(options));
 
@@ -67,7 +79,7 @@ export function CollectionsApiFactory($http, API_BASE) {
   // Private
 
   function buildQuery(options) {
-    var params = [];
+    const params = [];
     options = options || {};
 
     if (options.expand) {
@@ -125,7 +137,7 @@ export function CollectionsApiFactory($http, API_BASE) {
   }
 
   function buildConfig(options) {
-    var config = {};
+    const config = {};
     options = options || {};
 
     if (options.auto_refresh) {

--- a/client/app/services/service-details/service-details-ansible.component.js
+++ b/client/app/services/service-details/service-details-ansible.component.js
@@ -1,5 +1,5 @@
 /* eslint camelcase: "off" */
-import templateUrl from './service-details-ansible.html';
+import templateUrl from "./service-details-ansible.html";
 
 export const ServiceDetailsAnsibleComponent = {
   controller: ComponentController,
@@ -51,6 +51,7 @@ function ComponentController(ModalService, ServicesState, lodash) {
         credentialTypes.forEach((credential) => {
           if (angular.isDefined(vm.service.options.config_info[resourceName][credential])) {
             ServicesState.getServiceCredential(vm.service.options.config_info[resourceName][credential]).then((response) => {
+              response.type = response.type.substring(response.type.lastIndexOf('::') + 2, response.type.lastIndexOf('Credential'));
               vm.orcStacks[resourceName].credentials.push(response);
             });
           }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439632
https://www.pivotaltracker.com/story/show/143831475

<img width="961" alt="screen shot 2017-04-21 at 10 08 37 am" src="https://cloud.githubusercontent.com/assets/6640236/25281216/9f1e8e48-267a-11e7-991b-584e65f1b9a9.png">

Original approach was to get api to serve up feature rich credential information: https://github.com/ManageIQ/manageiq/pull/14783  but this was shot down.

Adding yet another call  to essentially parse a string is overkill, so until that future need arises, we'll parse the string. This isn't an issue because presently all credentials follow the following pattern:
* "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"
* "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential"
* "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential"
* "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential"