### PR TITLE
Apply cross-browser fix for pagination vertical alignment

### DIFF
--- a/client/app/shared/pagination/_pagination.sass
+++ b/client/app/shared/pagination/_pagination.sass
@@ -1,13 +1,11 @@
 @import 'app_colors'
 
 .pagination-footer
-  align-items: center
   background-color: $app-color-white
   border-top: 1px solid $app-color-gray
   bottom: 0
-  display: flex
   height: 50px
-  padding: 5px 15px
+  padding: 12px 5px 15px 15px
   position: fixed
   width: 100%
 


### PR DESCRIPTION
The previous fix using flexbox worked correctly for Chrome but was not
aligning properly in Firefox. This change falls back to using static
pixel values for padding instead of flexbox.

https://www.pivotaltracker.com/story/show/143875655

@miq-bot add_label fine/yes, bug

<img width="1208" alt="screen shot 2017-04-24 at 10 55 15 am" src="https://cloud.githubusercontent.com/assets/6842753/25343301/a53b9aaa-28dc-11e7-970f-917228b1e8df.png">
