### PR TITLE
Address bithound lint issues for webpack dev config

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,11 +1,9 @@
 {
   "ignore": [
     "**/node_modules/**",
-    "**/**-min-**",
-    "**/**-min.**",
-    "**/**.min.**",
     "**/**.spec.**",
-    "**/**.e2e.**"
+    "**/**.e2e.**",
+    "**/**.ts"
   ],
   "critics": {
     "lint": {"engine": "eslint"}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "env": {
     "browser": true,
+    "node": true,
     "amd": true,
     "jquery": true,
     "es6": true,
@@ -207,7 +208,7 @@
     "no-param-reassign": "off",
     "no-path-concat": "error",
     "no-plusplus": "off",
-    "no-process-env": "error",
+    "no-process-env": "off",
     "no-process-exit": "error",
     "no-proto": "error",
     "no-prototype-builtins": "off",
@@ -222,7 +223,7 @@
     "no-shadow": "off",
     "no-shadow-restricted-names": "error",
     "no-spaced-func": "error",
-    "no-sync": "error",
+    "no-sync": "off",
     "no-tabs": "off",
     "no-template-curly-in-string": "error",
     "no-ternary": "off",

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -1,3 +1,5 @@
+/* eslint-disable angular/log, no-console */
+
 const fs = require('fs');
 const path = require('path');
 const webpack = require('webpack');
@@ -9,9 +11,11 @@ const root = path.resolve(__dirname, '../client');
 const outputPath = process.env.BUILD_OUTPUT || '../../manageiq/public/ui/service';
 const dist = path.resolve(__dirname, outputPath);
 const nodeModules = path.resolve(__dirname, '../node_modules');
-const host = process.env.PROXY_HOST || process.env.MOCK_API_HOST || '[::1]:3000'
+const host = process.env.PROXY_HOST || process.env.MOCK_API_HOST || '[::1]:3000';
 const hasSkinImages = fs.existsSync(`${root}/skin/images`);
-console.log("Backend proxied on "+host);
+
+console.log("Backend proxied on " + host);
+
 module.exports = {
   context: root,
   entry: {
@@ -94,8 +98,9 @@ module.exports = {
 
               // Determine publicPath dynamically because in production, assets
               // must be relative to `/ui/service/`
-              publicPath: url => {
+              publicPath: (url) => {
                 const path = process.env.NODE_ENV === 'production' ? '/ui/service/' : '/';
+
                 return path + url;
               },
             },
@@ -157,7 +162,7 @@ module.exports = {
     new webpack.ContextReplacementPlugin(
       /angular(\\|\/)core(\\|\/)@angular/,
       root
-    )
+    ),
   ],
 
   resolve: {


### PR DESCRIPTION
Update .bithoundrc to ignore .ts files (eslint rules don't map cleanly
to typescript files).

Disable eslint rules prohibiting use of process.env and sync operations.
These rules are not very useful for this project since there are no
production facing node components.

@miq-bot add_label fine/no, refactoring