### PR TITLE
BZ#1439309 - Not able to see orders when not enough permission to see catalogs

### DIFF
--- a/client/app/core/rbac.service.js
+++ b/client/app/core/rbac.service.js
@@ -21,8 +21,7 @@ export function RBACFactory(lodash) {
 
     const navPermissions = {
       services: {show: angular.isDefined(productFeatures.service_view)},
-      orders: {show: angular.isDefined(productFeatures.miq_request_view)},
-      requests: {show: angular.isDefined(productFeatures.miq_request_view)},
+      orders: {show: angular.isDefined(productFeatures.svc_catalog_provision)},
       catalogs: {show: angular.isDefined(productFeatures.catalog_items_view)},
       // reports: {show: angular.isDefined(productFeatures.miq_report_saved_reports_view || productFeatures.miq_report_view)},
     };

--- a/client/app/core/session.service.spec.js
+++ b/client/app/core/session.service.spec.js
@@ -69,14 +69,14 @@ describe('Session', function() {
       var navFeatures = RBAC.getNavFeatures();
 
       expect(navFeatures.services.show).to.eq(true);
-      expect(navFeatures.requests.show).to.eq(false);
+      expect(navFeatures.orders.show).to.eq(false);
       expect(navFeatures.catalogs.show).to.eq(false);
     });
 
     it('sets visibility for "Service Catalogs" and "Requests" only on navbar and enables "Service Request" button', function() {
       var response = {authorization: {product_features: {
         catalog_items_view: {},
-        miq_request_view: {},
+        svc_catalog_provision: {},
       }}, identity: {}};
       gettextCatalog.loadAndSet = function() {};
       $httpBackend.whenGET('/api?attributes=authorization').respond(response);
@@ -85,7 +85,6 @@ describe('Session', function() {
       var navFeatures = RBAC.getNavFeatures();
 
       expect(navFeatures.services.show).to.eq(false);
-      expect(navFeatures.requests.show).to.eq(true);
       expect(navFeatures.orders.show).to.eq(true);
       expect(navFeatures.catalogs.show).to.eq(true);
     });


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439309
https://www.pivotaltracker.com/story/show/144469337

Update orders  nav to derive action from order services product feature rather than requests