### PR TITLE
 PT#144881747-Addresss inability to scroll in catalog explorer, removes unused class and unnecssary padding

### DIFF
--- a/client/app/catalogs/catalog-explorer.html
+++ b/client/app/catalogs/catalog-explorer.html
@@ -7,7 +7,7 @@
 </div>
 <div pf-toolbar class="section-toolbar section-toolbar-right-actions" config="vm.toolbarConfig">
 </div>
-<div class="list-view-container section-container paged-container">
+<div class="list-view-container section-container">
   <loading status="vm.loading"></loading>
   <div class="container-fluid"
        id="cardView"

--- a/client/app/reports/reports-explorer.html
+++ b/client/app/reports/reports-explorer.html
@@ -18,7 +18,7 @@
     </custom-dropdown>
   </actions>
 </div>
-<div class="list-view-container section-container paged-container explorer-list">
+<div class="list-view-container section-container explorer-list">
   <loading status="vm.loading"></loading>
   <div ng-if="!vm.loading"
        pf-list-view id="reportsList"

--- a/client/app/requests/order-explorer/order-explorer.html
+++ b/client/app/requests/order-explorer/order-explorer.html
@@ -18,7 +18,7 @@
     </custom-dropdown>
   </actions>
 </div>
-<div class="list-view-container section-container paged-container explorer-list">
+<div class="list-view-container section-container explorer-list">
   <loading status="vm.loading"></loading>
   <div ng-if="!vm.loading"
        pf-list-view id="orderList"

--- a/client/app/services/service-explorer/service-explorer.html
+++ b/client/app/services/service-explorer/service-explorer.html
@@ -26,7 +26,7 @@
     </custom-dropdown>
   </actions>
 </div>
-<div ng-if="vm.viewType == 'listView'" class="list-view-container section-container paged-container explorer-list">
+<div ng-if="vm.viewType == 'listView'" class="list-view-container section-container explorer-list">
   <loading status="vm.loading"></loading>
   <div ng-if="!vm.loading" pf-list-view id="serviceList" config="vm.listConfig"
        items="vm.servicesList"

--- a/client/app/templates/template-explorer.html
+++ b/client/app/templates/template-explorer.html
@@ -18,7 +18,7 @@
     </custom-dropdown>
   </actions>
 </div>
-<div class="list-view-container section-container paged-container explorer-list"
+<div class="list-view-container section-container explorer-list"
        confirmation
        confirmation-id="confirmDeleteTemplate"
        confirmation-trigger-value="vm.confirmDelete"

--- a/client/assets/sass/_explorer.sass
+++ b/client/assets/sass/_explorer.sass
@@ -60,6 +60,8 @@
       padding: 4px 0
 
 .card-view-pf
+  padding-bottom: 40px
+
   .card
     cursor: pointer
 

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -5,9 +5,6 @@
   overflow-x: hidden
   overflow-y: auto
 
-  .alert
-    margin: 20px 0
-
   &.-in-a-tab
     height: calc(100vh - 184px)
 
@@ -20,17 +17,13 @@
   &.section-container
     height: calc(100vh - 187px)
 
-    &.paged-container
-      height: calc(100vh - 237px)
-      overflow-y: hidden
-
 .list-view-pf
   line-height: 45px
-  overflow-y: hidden // Adding so tooltips don't cause a second scrollbar in the data list
-  padding-bottom: 30px // Adding so tooltips on the last row don't get cut off
+  margin-top: 0
 
   .no-wrap
     display: block
+
     overflow: hidden
     text-overflow: ellipsis
     white-space: nowrap


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/144881747

We don't have a bz for this yet if it isn't backported, i'm sure one will follow soon enough :P
Checked to confirm that: 
* issue exists on fine
* this pr can be back ported without any pain

So whats it do? 
- removes unnecessary padding/classes from explorer views
### before
![screenshot from 2017-05-04 13-57-29](https://cloud.githubusercontent.com/assets/6640236/25717807/afe69d18-30d1-11e7-8745-78c5fc5698ed.png)
### after, you'll notice we also don't clip final row
![screenshot from 2017-05-04 13-58-57](https://cloud.githubusercontent.com/assets/6640236/25717847/d72f84e8-30d1-11e7-8be7-421efaf1885a.png)
![screenshot from 2017-05-04 13-59-15](https://cloud.githubusercontent.com/assets/6640236/25717855/dfcf4e94-30d1-11e7-85bd-1d920d0ea393.png)
- restores scrolling to catalog list 
### before
![screenshot from 2017-05-04 13-52-07](https://cloud.githubusercontent.com/assets/6640236/25717893/01294d1a-30d2-11e7-8ab7-18841c6f97fc.png)
### after, you'll notice we don't cut off bottom of list
![screenshot from 2017-05-04 14-00-34](https://cloud.githubusercontent.com/assets/6640236/25717903/116b507e-30d2-11e7-9fae-9a1fe21c581b.png)



