### PR TITLE
BZ#1447789 - catalog results shows number of templates, not catalogs

### DIFF
--- a/client/app/catalogs/catalog-explorer.e2e.js
+++ b/client/app/catalogs/catalog-explorer.e2e.js
@@ -12,6 +12,6 @@ describe('Component: catalogExplorer', function() {
   });
   it('should have expected number of rows', function() {
     const list = element.all(by.css('.list-view-container .card-view-pf .card'));
-    expect(list.count()).toBe(26);
+    expect(list.count()).toBe(20);
   });
 });

--- a/client/app/catalogs/catalog-explorer.e2e.js
+++ b/client/app/catalogs/catalog-explorer.e2e.js
@@ -8,10 +8,10 @@ describe('Component: catalogExplorer', function() {
   });
   it('should have expected number of results', function() {
     const results = element.all(by.css('.toolbar-pf-results h5'));
-    expect(results.get(0).getText()).toBe("10 Results");
+    expect(results.get(0).getText()).toBe("26 Results");
   });
   it('should have expected number of rows', function() {
     const list = element.all(by.css('.list-view-container .card-view-pf .card'));
-    expect(list.count()).toBe(23);
+    expect(list.count()).toBe(26);
   });
 });

--- a/client/app/catalogs/catalogs-state.service.js
+++ b/client/app/catalogs/catalogs-state.service.js
@@ -2,8 +2,6 @@
 
 /** @ngInject */
 export function CatalogsStateFactory(CollectionsApi, RBAC) {
-  const collection = 'service_catalogs';
-
   const sort = {
     isAscending: true,
     currentField: {id: 'name', title: __('Name'), sortType: 'alpha'},
@@ -13,6 +11,7 @@ export function CatalogsStateFactory(CollectionsApi, RBAC) {
   return {
     getMinimal: getMinimal,
     getCatalogs: getCatalogs,
+    getServiceTemplates: getServiceTemplates,
     getSort: getSort,
     setSort: setSort,
     getFilters: getFilters,
@@ -38,13 +37,18 @@ export function CatalogsStateFactory(CollectionsApi, RBAC) {
   }
 
   function getQueryFilters(filters) {
-    const queryFilters = [];
+    const queryFilters = ["display=true"];
 
     angular.forEach(filters, function(nextFilter) {
-      if (nextFilter.id === 'name') {
-        queryFilters.push("name='%" + nextFilter.value + "%'");
-      } else {
-        queryFilters.push(nextFilter.id + '=' + nextFilter.value);
+      switch (nextFilter.id) {
+        case 'name':
+          queryFilters.push("name='%" + nextFilter.value + "%'");
+          break;
+        case 'description':
+          queryFilters.push("description='%" + nextFilter.value + "%'");
+          break;
+        default:
+          queryFilters.push(nextFilter.id + '=' + nextFilter.value);
       }
     });
 
@@ -61,10 +65,18 @@ export function CatalogsStateFactory(CollectionsApi, RBAC) {
     return permissions;
   }
 
-  function getCatalogs(limit, offset) {
+  function getCatalogs() {
     const options = {
-      expand: ['resources', 'service_templates'],
-      attributes: ['tenant', 'picture', 'picture.image_href', 'service_template_catalog.name', 'dialogs'],
+      expand: ['resources'],
+    };
+
+    return CollectionsApi.query('service_catalogs', options);
+  }
+
+  function getServiceTemplates(limit, offset) {
+    const options = {
+      expand: ['resources'],
+      attributes: ['picture', 'picture.image_href', 'service_template_catalog'],
       limit: limit,
       offset: offset,
       filter: getQueryFilters(getFilters()),
@@ -74,10 +86,10 @@ export function CatalogsStateFactory(CollectionsApi, RBAC) {
     options.sort_options = getSort().currentField.sortType === 'alpha' ? 'ignore_case' : '';
     options.sort_order = getSort().isAscending ? 'asc' : 'desc';
 
-    return CollectionsApi.query(collection, options);
+    return CollectionsApi.query('service_templates', options);
   }
 
-  function getMinimal() {
+  function getMinimal(collection) {
     const options = {
       filter: getQueryFilters(getFilters()),
       hide: 'resources',

--- a/client/app/core/navigation.config.js
+++ b/client/app/core/navigation.config.js
@@ -124,10 +124,10 @@ export function navInit(lodash, CollectionsApi, Navigation, NavCounts, POLLING_I
 
   function fetchServiceCatalogs() {
     angular.extend(options, {
-      filter: ['id>0'],
+      filter: ['display=true'],
     });
 
-    CollectionsApi.query('service_catalogs', options)
+    CollectionsApi.query('service_templates', options)
       .then(lodash.partial(updateCount, 'catalogs'));
   }
 

--- a/client/app/shared/pagination/pagination.e2e.js
+++ b/client/app/shared/pagination/pagination.e2e.js
@@ -12,11 +12,11 @@ describe('Component: pagination', function() {
     changeLimit();
 
     const limit = element.all(by.css('.pagination-footer .pagination-controls'));
-    expect(limit.get(0).getText()).toBe("1 - 5 of 10");
+    expect(limit.get(0).getText()).toBe("1 - 5 of 26");
 
     pageNext();
     const updatedIndex = element.all(by.css('.pagination-footer .pagination-controls li:nth-child(3) span'));
-    expect(updatedIndex.get(0).getText()).toBe("6 - 10 of 10");
+    expect(updatedIndex.get(0).getText()).toBe("6 - 10 of 26");
   }, 1200000);
 
   it('should successfully page backward', function() {
@@ -24,15 +24,15 @@ describe('Component: pagination', function() {
     changeLimit();
 
     const limit = element.all(by.css('.pagination-footer .pagination-controls'));
-    expect(limit.get(0).getText()).toBe("1 - 5 of 10");
+    expect(limit.get(0).getText()).toBe("1 - 5 of 26");
 
     pageNext();
     const updatedIndex = element.all(by.css('.pagination-footer .pagination-controls li:nth-child(3) span'));
-    expect(updatedIndex.get(0).getText()).toBe("6 - 10 of 10");
+    expect(updatedIndex.get(0).getText()).toBe("6 - 10 of 26");
 
     element.all(by.css('.pagination-footer .pagination-controls ul.pagination span[alt="Previous"]')).click();
     const previousIndex = element.all(by.css('.pagination-footer .pagination-controls li:nth-child(3) span'));
-    expect(previousIndex.get(0).getText()).toBe("1 - 5 of 10");
+    expect(previousIndex.get(0).getText()).toBe("1 - 5 of 26");
   }, 1200000);
 });
 

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "zone.js": "0.8.9"
   },
   "devDependencies": {
-    "@manageiq/manageiq-api-mock": "1.2.3",
+    "@manageiq/manageiq-api-mock": "1.3.1",
     "angular-mocks": "1.6.4",
     "axios": "0.16.1",
     "bardjs": "0.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,9 +26,9 @@
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@angular/upgrade/-/upgrade-4.1.0.tgz#ddede070c83e21abae823d560ae3518ecc76b742"
 
-"@manageiq/manageiq-api-mock@1.2.3":
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/@manageiq/manageiq-api-mock/-/manageiq-api-mock-1.2.3.tgz#b8766354962357c06d17c6c7741a843457669f68"
+"@manageiq/manageiq-api-mock@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@manageiq/manageiq-api-mock/-/manageiq-api-mock-1.3.1.tgz#a7a55d558e65d394c190ea9367d5049f7dbeb416"
   dependencies:
     commander "^2.9.0"
     glob "^7.1.1"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1447789
https://www.pivotaltracker.com/story/show/144856485

Refactor catalogs display service_templates rather than service_catalogs
All original functionality preserved, indluding filtering by catalog
Nav count is now = initial result count = pagination count

### check it, filters n junk working
![screenshot from 2017-05-04 17-14-57](https://cloud.githubusercontent.com/assets/6640236/25725324/77967dd6-30ed-11e7-9cde-201a849ca6a5.png)
![screenshot from 2017-05-04 17-15-09](https://cloud.githubusercontent.com/assets/6640236/25725326/7957a514-30ed-11e7-99fc-b0cfd9e4138e.png)
![screenshot from 2017-05-04 17-15-18](https://cloud.githubusercontent.com/assets/6640236/25725329/7b8fe6ca-30ed-11e7-9c40-964393475b39.png)
