### PR TITLE
[WIP] PT#145115749 - Suppresses the creation of duplicate notifications (by message and type)

### DIFF
--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -157,20 +157,23 @@ export function EventNotificationsFactory($timeout, lodash, CollectionsApi, Sess
 // Private
   function add(notificationType, type, message, notificationData, id) {
     const group = lodash.find(state.groups, {notificationType: notificationType});
-    const newNotification = {
-      id: id,
-      notificationType: notificationType,
-      unread: angular.isDefined(notificationData) ? notificationData.unread : true,
-      type: type,
-      message: message,
-      data: notificationData || {},
-      href: id ? '/api/notifications/' + id : undefined,
-      timeStamp: (new Date()).getTime(),
-    };
+    // Ignoring duplicate notifications of the same type
+    if (!lodash.find(group.notifications, {message: message})) {
+      const newNotification = {
+        id: id,
+        notificationType: notificationType,
+        unread: angular.isDefined(notificationData) ? notificationData.unread : true,
+        type: type,
+        message: message,
+        data: notificationData || {},
+        href: id ? '/api/notifications/' + id : undefined,
+        timeStamp: (new Date()).getTime(),
+      };
 
-    group.notifications.unshift(newNotification);
-    updateUnreadCount(group);
-    showToast(newNotification);
+      group.notifications.unshift(newNotification);
+      updateUnreadCount(group);
+      showToast(newNotification);
+    }
   }
 
 


### PR DESCRIPTION
This pr affects when toasts appear, only if there is unique notification (by type and message), duplicate ones are suppressed.  That being said, if a polling error notification is made then cleared, it will appear again. 

This is gonna be great for e2e testing, no longer will we have to worry about toast elements overlapping buttons 🙌 

## The before case, death by toasts
<img width="902" alt="screen shot 2017-05-09 at 3 37 38 pm" src="https://cloud.githubusercontent.com/assets/6640236/25901288/4ea54198-3564-11e7-8fa8-91bd4e2e9d31.png">

## The after case, a world where toast only help
<img width="899" alt="screen shot 2017-05-10 at 9 34 24 am" src="https://cloud.githubusercontent.com/assets/6640236/25901313/62a635bc-3564-11e7-8e5a-c6d856fe5586.png">
