### PR TITLE
BZ#1451052-Adds support for custom brand

### DIFF
--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -1,6 +1,7 @@
 // Product overrides of Boostrap & Patternfly variables
 
-$modal-about-pf-bg-color:  #083c5a // sets background color of 'About' modal
+$modal-about-pf-bg-color: #083c5a
+// sets background color of 'About' modal
 
 
 // Product overrides for 'About' Modal
@@ -8,7 +9,6 @@ $modal-about-pf-bg-color:  #083c5a // sets background color of 'About' modal
 .about-modal-pf
   background-color: $modal-about-pf-bg-color
   background-image: url('../images/bg-modal-about-pf.png')
-
 
 // @font-face
 //  font-family: 'FontAwesome'
@@ -18,7 +18,8 @@ $modal-about-pf-bg-color:  #083c5a // sets background color of 'About' modal
 
 
 body
-  overflow: hidden // Adding so tooltips don't cause a scrollbar to appear
+  overflow: hidden
+// Adding so tooltips don't cause a scrollbar to appear
 
 .layout-application
   height: 100%
@@ -77,3 +78,11 @@ body
       position: fixed
       right: 0
       top: 60px
+
+li
+  &.brand-white-label
+    background: url('~/../../../upload/custom_logo.png') right top no-repeat
+    background-size: auto 38px
+    height: 38px
+    margin-top: 10px
+    width: 320px

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -20,6 +20,7 @@
 
     <div>
       <ul class="nav navbar-nav navbar-right navbar-iconic">
+        <li class="dropdown brand-white-label"></li>
         <li ng-if="vm.shoppingCart.allowed()">
           <a title="{{'Shopping cart' | translate}}" class="nav-item-iconic indicator"
              ng-click="vm.shoppingCart.open()">


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1451052
https://www.pivotaltracker.com/story/show/145545717

This brings custom brand support in sui to parity with ops ui, identical styling was used so itzah the same...

FUN NOTE!  webpack css-loader freaks out if it can't resolve a `url()` path, by throwing the `url('~/...)` in front, it calms down. 

### Custom Image present, (sui/opsui)
<img width="954" alt="screen shot 2017-05-16 at 2 25 54 pm" src="https://cloud.githubusercontent.com/assets/6640236/26122112/641775ca-3a44-11e7-8684-27dc421cd280.png">
<img width="961" alt="screen shot 2017-05-16 at 2 26 07 pm" src="https://cloud.githubusercontent.com/assets/6640236/26122102/585b7c86-3a44-11e7-85c7-ec5fcccd972a.png">

### Custom image absent from sui
<img width="959" alt="screen shot 2017-05-16 at 2 25 40 pm" src="https://cloud.githubusercontent.com/assets/6640236/26122101/584f580c-3a44-11e7-8195-1be1c4169e1a.png">
