### PR TITLE
BZ#145849913 Allows for image assets to be dynamically skinned

### DIFF
--- a/client/app/core/shopping-cart/_shopping-cart.sass
+++ b/client/app/core/shopping-cart/_shopping-cart.sass
@@ -1,0 +1,2 @@
+.cart-duplicate-icon
+  padding: 0 .5em

--- a/client/app/core/shopping-cart/_shopping-cart.scss
+++ b/client/app/core/shopping-cart/_shopping-cart.scss
@@ -1,3 +1,0 @@
-.cart-duplicate-icon {
-  padding: 0 .5em;
-}

--- a/client/app/core/shopping-cart/shopping-cart.component.js
+++ b/client/app/core/shopping-cart/shopping-cart.component.js
@@ -1,4 +1,4 @@
-import './_shopping-cart.scss';
+import './_shopping-cart.sass';
 import templateUrl from './shopping-cart.html';
 
 export const ShoppingCartComponent = {

--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -1,5 +1,4 @@
 // Product overrides of Boostrap & Patternfly variables
-
 $modal-about-pf-bg-color: #083c5a
 // sets background color of 'About' modal
 
@@ -8,7 +7,7 @@ $modal-about-pf-bg-color: #083c5a
 
 .about-modal-pf
   background-color: $modal-about-pf-bg-color
-  background-image: url($imgBasePath + 'images/bg-modal-about-pf.png')
+  background-image: url('#{$img-base-path}images/bg-modal-about-pf.png')
 
 // @font-face
 //  font-family: 'FontAwesome'

--- a/client/app/layouts/_application.sass
+++ b/client/app/layouts/_application.sass
@@ -8,7 +8,7 @@ $modal-about-pf-bg-color: #083c5a
 
 .about-modal-pf
   background-color: $modal-about-pf-bg-color
-  background-image: url('../images/bg-modal-about-pf.png')
+  background-image: url($imgBasePath + 'images/bg-modal-about-pf.png')
 
 // @font-face
 //  font-family: 'FontAwesome'

--- a/client/app/layouts/_navigation.sass
+++ b/client/app/layouts/_navigation.sass
@@ -1,6 +1,6 @@
 .navbar-pf-vertical
   background-color: $app-color-dark-blue-gray
-  background-image: url($imgBasePath + 'images/bg-navbar.png')
+  background-image: url('#{$img-base-path}images/bg-navbar.png')
   background-repeat: no-repeat
   background-size: auto 100%
 

--- a/client/app/layouts/_navigation.sass
+++ b/client/app/layouts/_navigation.sass
@@ -1,6 +1,6 @@
 .navbar-pf-vertical
   background-color: $app-color-dark-blue-gray
-  background-image: url('../images/bg-navbar.png')
+  background-image: url($imgBasePath + 'images/bg-navbar.png')
   background-repeat: no-repeat
   background-size: auto 100%
 

--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -1,19 +1,20 @@
+@import '_bem-support/index'
+
 +block(login-pf)
   background-color: $app-color-deep-blue
-  background-image: url('../images/bg-login-2.png')
-  background-position: 100% 100%
-  background-repeat: no-repeat
-  background-size: auto
   height: calc(100vh)
   margin-bottom: -38px
   margin-top: -60px
 
-  &::before
-    background: transparent
-    background-position: 0% 0%
-    background-repeat: no-repeat
-    background-size: auto
-    content: url('../images/bg-login.png')
+  +element(img)
+    +modifier(top)
+      left: 0
+      top: 0
+    +modifier(bottom)
+      position: fixed
+      right: 0
+      bottom: 0
+
 
   .container
     background-color: transparent

--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -1,20 +1,20 @@
 @import '_bem-support/index'
 
 +block(login-pf)
-  background-color: $app-color-deep-blue
-  height: calc(100vh)
-  margin-bottom: -38px
-  margin-top: -60px
-
   +element(img)
     +modifier(top)
       left: 0
       top: 0
     +modifier(bottom)
+      bottom: 0
       position: fixed
       right: 0
-      bottom: 0
 
+
+  background-color: $app-color-deep-blue
+  height: calc(100vh)
+  margin-bottom: -38px
+  margin-top: -60px
 
   .container
     background-color: transparent

--- a/client/app/states/login/login.html
+++ b/client/app/states/login/login.html
@@ -1,6 +1,8 @@
 <div class="login-pf">
+  <img class="login-pf__img--top" src="./images/bg-login.png" alt="top-corner" />
+  <img class="login-pf__img--bottom" src="./images/bg-login-2.png" alt=" bottom-corner" />
   <span id="badge">
-    <img class="logo" src="images/login-screen-logo.png" alt=" logo" />
+    <img class="logo" src="./images/login-screen-logo.png" alt=" logo" />
   </span>
   <div class="container">
     <div class="row">

--- a/client/assets/sass/_patternfly.sass
+++ b/client/assets/sass/_patternfly.sass
@@ -1,0 +1,9 @@
+// Bootstrap path variables
+$icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/'
+// Font Awesome path variables
+$fa-font-path: '~font-awesome/fonts'
+// Patternfly path variables
+$img-path: '~patternfly-sass/assets/images/patternfly/'
+$font-path: '~patternfly-sass/assets/fonts/patternfly/'
+
+@import '~patternfly-sass/assets/stylesheets/patternfly'

--- a/client/assets/sass/_patternfly.scss
+++ b/client/assets/sass/_patternfly.scss
@@ -1,9 +1,0 @@
-// Bootstrap path variables
-$icon-font-path: '~bootstrap-sass/assets/fonts/bootstrap/';
-// Font Awesome path variables
-$fa-font-path: '~font-awesome/fonts';
-// Patternfly path variables
-$img-path: '~patternfly-sass/assets/images/patternfly/';
-$font-path: '~patternfly-sass/assets/fonts/patternfly/';
-
-@import '~patternfly-sass/assets/stylesheets/patternfly';

--- a/client/assets/sass/styles.sass
+++ b/client/assets/sass/styles.sass
@@ -1,3 +1,6 @@
+// Global constants
+$imgBasePath: '/' !default
+
 @import 'patternfly'
 
 // BEM Support : See _bem-support/_index.sass for more information

--- a/client/assets/sass/styles.sass
+++ b/client/assets/sass/styles.sass
@@ -1,5 +1,5 @@
 // Global constants
-$imgBasePath: '/' !default
+$img-base-path: '/' !default
 
 @import 'patternfly'
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -118,7 +118,7 @@ module.exports = {
         use: ExtractTextWebpackPlugin.extract({
           fallback: 'style-loader',
           allChunks: true,
-          loader: [
+          use: [
             'css-loader?importLoaders=1&sourceMap=true',
             'postcss-loader',
           ],
@@ -129,12 +129,12 @@ module.exports = {
         use: ExtractTextWebpackPlugin.extract({
           fallback: 'style-loader',
           allChunks: true,
-          loader: [
+          use: [
             'css-loader?importLoaders=1&sourceMap=true',
             {
               loader: 'sass-loader',
               options: {
-                data: `$imgBasePath: ${appBasePath}`,
+                data: `$img-base-path: ${appBasePath}`,
                 sourceMap: true,
                 includePaths: [
                   `${root}/assets/sass`,

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -14,6 +14,7 @@ const nodeModules = path.resolve(__dirname, '../node_modules');
 const protocol = process.env.PROXY_PROTOCOL || 'http://';
 const host = process.env.PROXY_HOST || process.env.MOCK_API_HOST || '[::1]:3000';
 const hasSkinImages = fs.existsSync(`${root}/skin/images`);
+const appBasePath = process.env.NODE_ENV === 'production' ? "'/ui/service/'" : "'/'";
 
 console.log("Backend proxied on " + protocol + host);
 
@@ -113,16 +114,27 @@ module.exports = {
 
       // css loaders: extract styles to a separate bundle
       {
-        test: /\.(css|s(a|c)ss)$/,
+        test: /\.(css)$/,
         use: ExtractTextWebpackPlugin.extract({
           fallback: 'style-loader',
           allChunks: true,
           loader: [
-            'css-loader?importLoaders=2&sourceMap=true',
+            'css-loader?importLoaders=1&sourceMap=true',
             'postcss-loader',
+          ],
+        }),
+      },
+      {
+        test: /\.(sass|scss)$/,
+        use: ExtractTextWebpackPlugin.extract({
+          fallback: 'style-loader',
+          allChunks: true,
+          loader: [
+            'css-loader?importLoaders=1&sourceMap=true',
             {
               loader: 'sass-loader',
               options: {
+                data: `$imgBasePath: ${appBasePath}`,
                 sourceMap: true,
                 includePaths: [
                   `${root}/assets/sass`,


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1452396
https://www.pivotaltracker.com/story/show/145849913

*TL;DR*
- (in production) all skinned image now change when the source file in `/images` change 
- bundling of assets is still possible by defining it by relative path
- the skinning process hasn't changed at all. still need to link to `client/app/skin` (for style sheets and the like).  
- again, nothing changed with link, this pr essentially configures webpack so that we dynamically set asset urls in sass based on deployment environment, so when we're in production, we'll use the appropriate /images folder assets vs development
- the process for adding a new image that supports skinning is to add build the url in the .sass file as follows:  `url('#{$img-base-path}images/foo.(jpg|png|etc)')` where foo is the file to be skinned and the extension is whatever checkout _navigation.sass for an example
- webpack output hasn't changed, though there is some work to be done there... (duplicate folders etc)


I can proudly say, no ux review is necessary as nothing visually changed 🤘 🌮 💃  (except those things that are supposed to change, ie skinned images).



### Production build file structure before, the second one is after, just showing nothing changed
![screenshot from 2017-05-24 16-07-11](https://cloud.githubusercontent.com/assets/6640236/26423446/bdd7779c-409b-11e7-9924-9a713a7d388e.png)
![screenshot from 2017-05-24 16-08-46](https://cloud.githubusercontent.com/assets/6640236/26424271/a18cf1cc-409e-11e7-9510-92d26751b808.png)


### Screenshots (before/after) showing support for replacing contents of `/ui/service/images` on the fly
but before you look at these I need you to do a few things
1. look at the url, we're on a production url (NOT dev)
2. in the *after shots, ignore the blue in the nav header*, all this pr touches is how the images are loaded not the css
3. ok now your ready to now 👀's
#### before skinning
![screenshot from 2017-05-24 17-20-41](https://cloud.githubusercontent.com/assets/6640236/26426154/f3219808-40c6-11e7-99d6-6c1c13e2176e.png)
![screenshot from 2017-05-24 17-20-58](https://cloud.githubusercontent.com/assets/6640236/26426157/f6214ce2-40c6-11e7-96c8-f88b4bbc6772.png)
#### after skinning
![screenshot from 2017-05-24 17-00-22](https://cloud.githubusercontent.com/assets/6640236/26425450/c9133946-40a2-11e7-9f60-abaf41901d80.png)
![screenshot from 2017-05-24 17-00-05](https://cloud.githubusercontent.com/assets/6640236/26425447/c697a7ba-40a2-11e7-86f0-f8050105d6d1.png)
![screenshot from 2017-05-24 17-00-37](https://cloud.githubusercontent.com/assets/6640236/26425451/cb0eae38-40a2-11e7-82e8-3c16314103b9.png)
