### PR TITLE
Fix for service catalog service dialog refresh function behaving differently

### DIFF
--- a/client/app/core/core.module.js
+++ b/client/app/core/core.module.js
@@ -23,6 +23,7 @@ import { BaseModalController } from './modal/base-modal-controller.js';
 import { BaseModalFactory } from './modal/base-modal.factory.js';
 import { ChargebackFactory } from './chargeback.service.js';
 import { CollectionsApiFactory } from './collections-api.factory.js';
+import { DialogFieldListenerFactory } from './dialog-field-listener.service.js';
 import { DialogFieldRefreshFactory } from './dialog-field-refresh.service.js';
 import { EventNotificationsFactory } from './event-notifications.service.js';
 import { ExceptionModule } from './exception/exception.module.js';
@@ -82,6 +83,7 @@ export const CoreModule = angular
   .factory('AuthenticationApi', AuthenticationApiFactory)
   .factory('Chargeback', ChargebackFactory)
   .factory('CollectionsApi', CollectionsApiFactory)
+  .factory('DialogFieldListener', DialogFieldListenerFactory)
   .factory('DialogFieldRefresh', DialogFieldRefreshFactory)
   .factory('EventNotifications', EventNotificationsFactory)
   .factory('Language', LanguageFactory)

--- a/client/app/core/dialog-field-listener.service.js
+++ b/client/app/core/dialog-field-listener.service.js
@@ -1,0 +1,39 @@
+/* eslint camelcase: "off" */
+/* eslint angular/angularelement: "off" */
+
+/** @ngInject */
+export function DialogFieldListenerFactory(DialogFieldRefresh) {
+  var service = {
+    listenForAutoRefreshMessages: listenForAutoRefreshMessages,
+  };
+
+  return service;
+
+  function listenForAutoRefreshMessages(allDialogFields, autoRefreshableDialogFields, url, resourceId) {
+    var nextFieldToRefresh = function(field, data, currentIndex) {
+      return (field.auto_refresh === true && data.initializingIndex !== currentIndex && data.currentIndex < currentIndex);
+    };
+
+    var listenerFunction = function(_event, data) {
+      var autoRefreshOptions = {
+        initializingIndex: data.initializingIndex,
+      };
+
+      var dialogFieldToRefresh = autoRefreshableDialogFields.filter(function(field, currentIndex) {
+        if (nextFieldToRefresh(field, data, currentIndex)) {
+          return field;
+        }
+      });
+
+      if (dialogFieldToRefresh.length > 0) {
+        dialogFieldToRefresh[0].beingRefreshed = true;
+        dialogFieldToRefresh[0].triggerOverride = true;
+        autoRefreshOptions.currentIndex = dialogFieldToRefresh[0].refreshableFieldIndex;
+        DialogFieldRefresh.refreshSingleDialogField(allDialogFields, dialogFieldToRefresh[0], url, resourceId, autoRefreshOptions);
+      }
+    };
+
+    $(document).off('dialog::autoRefresh'); // Unbind all previous message listeners
+    $(document).on('dialog::autoRefresh', listenerFunction);
+  }
+}

--- a/client/app/core/dialog-field-listener.service.spec.js
+++ b/client/app/core/dialog-field-listener.service.spec.js
@@ -1,0 +1,58 @@
+describe.only('DialogFieldListener', function() {
+  beforeEach(function() {
+    module('app.states');
+    bard.inject('DialogFieldRefresh', 'DialogFieldListener');
+  });
+
+  describe('#listenForAutoRefreshMessages', function() {
+    var eventListenerSpy;
+    var onListenerCallback;
+    var dialogField1;
+    var dialogField2;
+    var refreshSingleDialogFieldSpy;
+
+    beforeEach(function() {
+      $ = sinon.stub();
+      eventListenerSpy = sinon.stub({on: function() {}, off: function() {}});
+
+      $.withArgs(document).returns(eventListenerSpy);
+
+      refreshSingleDialogFieldSpy = sinon.stub(DialogFieldRefresh, 'refreshSingleDialogField');
+
+      dialogField1 = {auto_refresh: true, refreshableFieldIndex: 321};
+      dialogField2 = {auto_refresh: true, refreshableFieldIndex: 213};
+
+      DialogFieldListener.listenForAutoRefreshMessages([], [dialogField1, dialogField2], 'the_url', '123');
+      onListenerCallback = eventListenerSpy.on.getCall(0).args[1];
+    });
+
+    it('sets up a listener on the window', function() {
+      expect(eventListenerSpy.off).to.have.been.calledWith('dialog::autoRefresh');
+      expect(eventListenerSpy.on).to.have.been.calledWith('dialog::autoRefresh', onListenerCallback);
+    });
+
+    describe('listenerCallback', function() {
+      var _event, data;
+
+      beforeEach(function() {
+        data = {initializingIndex: 123, currentIndex: 0};
+        onListenerCallback(_event, data);
+      });
+
+      it('sets the being refreshed flag to true', function() {
+        expect(dialogField2.beingRefreshed).to.equal(true);
+      });
+
+      it('sets the trigger override flag to true', function() {
+        expect(dialogField2.triggerOverride).to.equal(true);
+      });
+
+      it('calls refreshSingleDialogField with the right arguments', function() {
+        expect(refreshSingleDialogFieldSpy).to.have.been.calledWith([], dialogField2, 'the_url', '123', {
+          initializingIndex: 123,
+          currentIndex: 213
+        });
+      });
+    });
+  });
+});

--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -4,7 +4,6 @@
 /** @ngInject */
 export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
   var service = {
-    listenForAutoRefreshMessages: listenForAutoRefreshMessages,
     refreshSingleDialogField: refreshSingleDialogField,
     setupDialogData: setupDialogData,
     triggerAutoRefresh: triggerAutoRefresh,
@@ -12,26 +11,7 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
 
   return service;
 
-  function listenForAutoRefreshMessages(allDialogFields, autoRefreshableDialogFields, url, resourceId) {
-    var listenerFunction = function(event) {
-      var dialogFieldToRefresh = autoRefreshableDialogFields.filter(function(field, currentIndex) {
-        if (field.auto_refresh === true && event.originalEvent.data.refreshableFieldIndex < currentIndex) {
-          return field;
-        }
-      });
-
-      if (dialogFieldToRefresh.length > 0) {
-        dialogFieldToRefresh[0].beingRefreshed = true;
-        dialogFieldToRefresh[0].triggerOverride = true;
-        refreshSingleDialogField(allDialogFields, dialogFieldToRefresh[0], url, resourceId);
-      }
-    };
-
-    $(document).off('dialog::autoRefresh'); // Unbind all previous message listeners
-    $(document).on('dialog::autoRefresh', listenerFunction);
-  }
-
-  function refreshSingleDialogField(allDialogFields, dialogField, url, resourceId) {
+  function refreshSingleDialogField(allDialogFields, dialogField, url, resourceId, autoRefreshOptions) {
     function refreshSuccess(result) {
       var resultObj = result.result[dialogField.name];
 
@@ -39,26 +19,10 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
       if (dialogField.type === 'DialogFieldDropDownList') {
         updateDialogSortOrder(dialogField);
       }
- 
-      triggerAutoRefresh(dialogField);
-    }
-    function updateDialogSortOrder(dialogField) {
-      var values = dialogField.values;
-      var sortDirection = dialogField.options.sort_order;
-      var sortByValue = 0; // These are constants that are used to refer to array positions
-      var sortByDescription = 1; // These are constants that are used to refer to array positions
-      var sortBy = (dialogField.options.sort_by === 'value' ? sortByValue : sortByDescription);
-      dialogField.values = values.sort((option1, option2) => {
-        var trueValue = -1;
-        var falseValue = 1;
-        if (sortDirection !== 'ascending') {
-          trueValue = 1;
-          falseValue = -1;
-        }
 
-        return option2[sortBy] > option1[sortBy]  ? trueValue : falseValue;
-      });
+      triggerAutoRefresh(dialogField, false, autoRefreshOptions);
     }
+
     function refreshFailure(result) {
       EventNotifications.error('There was an error refreshing this dialog: ' + result);
     }
@@ -103,7 +67,7 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
             }
 
             dialogField.triggerAutoRefresh = function() {
-              triggerAutoRefresh(dialogField);
+              triggerAutoRefresh(dialogField, true);
             };
           });
         });
@@ -111,9 +75,19 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
     });
   }
 
-  function triggerAutoRefresh(dialogField) {
+  function triggerAutoRefresh(dialogField, initialTrigger, autoRefreshOptions) {
     if (dialogField.trigger_auto_refresh === true || dialogField.triggerOverride === true) {
-      $(document).trigger('dialog::autoRefresh', {refreshableFieldIndex: dialogField.refreshableFieldIndex});
+      var triggerOptions = {};
+
+      if (initialTrigger === true) {
+        triggerOptions.initializingIndex = dialogField.refreshableFieldIndex;
+        triggerOptions.currentIndex = 0;
+      } else {
+        triggerOptions.initializingIndex = autoRefreshOptions.initializingIndex;
+        triggerOptions.currentIndex = autoRefreshOptions.currentIndex;
+      }
+
+      $(document).trigger('dialog::autoRefresh', triggerOptions);
     }
   }
 
@@ -132,6 +106,24 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
       currentDialogField.required = newDialogField.required;
       currentDialogField.visible = newDialogField.visible;
     }
+  }
+
+  function updateDialogSortOrder(dialogField) {
+    var values = dialogField.values;
+    var sortDirection = dialogField.options.sort_order;
+    var sortByValue = 0; // These are constants that are used to refer to array positions
+    var sortByDescription = 1; // These are constants that are used to refer to array positions
+    var sortBy = (dialogField.options.sort_by === 'value' ? sortByValue : sortByDescription);
+    dialogField.values = values.sort((option1, option2) => {
+      var trueValue = -1;
+      var falseValue = 1;
+      if (sortDirection !== 'ascending') {
+        trueValue = 1;
+        falseValue = -1;
+      }
+
+      return option2[sortBy] > option1[sortBy]  ? trueValue : falseValue;
+    });
   }
 
   function fetchDialogFieldInfo(allDialogFields, dialogFieldsToFetch, url, resourceId, successCallback, failureCallback) {

--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -27,8 +27,8 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
       }
     };
 
-    $(window).off('message'); // Unbind all previous message listeners
-    $(window).on('message', listenerFunction);
+    $(document).off('dialog::autoRefresh'); // Unbind all previous message listeners
+    $(document).on('dialog::autoRefresh', listenerFunction);
   }
 
   function refreshSingleDialogField(allDialogFields, dialogField, url, resourceId) {
@@ -113,7 +113,7 @@ export function DialogFieldRefreshFactory(CollectionsApi, EventNotifications) {
 
   function triggerAutoRefresh(dialogField) {
     if (dialogField.trigger_auto_refresh === true || dialogField.triggerOverride === true) {
-      parent.postMessage({refreshableFieldIndex: dialogField.refreshableFieldIndex}, '*');
+      $(document).trigger('dialog::autoRefresh', {refreshableFieldIndex: dialogField.refreshableFieldIndex});
     }
   }
 

--- a/client/app/core/dialog-field-refresh.service.spec.js
+++ b/client/app/core/dialog-field-refresh.service.spec.js
@@ -15,7 +15,7 @@ describe('DialogFieldRefresh', function() {
       $ = sinon.stub();
       eventListenerSpy = sinon.stub({on: function() {}, off: function() {}});
 
-      $.withArgs(window).returns(eventListenerSpy);
+      $.withArgs(document).returns(eventListenerSpy);
 
       refreshSingleDialogFieldSpy = sinon.stub(DialogFieldRefresh, 'refreshSingleDialogField');
 
@@ -27,8 +27,8 @@ describe('DialogFieldRefresh', function() {
     });
 
     it('sets up a listener on the window', function() {
-      expect(eventListenerSpy.off).to.have.been.calledWith('message');
-      expect(eventListenerSpy.on).to.have.been.calledWith('message', onListenerCallback);
+      expect(eventListenerSpy.off).to.have.been.calledWith('dialog::autoRefresh');
+      expect(eventListenerSpy.on).to.have.been.calledWith('dialog::autoRefresh', onListenerCallback);
     });
 
     describe('listenerCallback', function() {
@@ -436,16 +436,15 @@ describe('DialogFieldRefresh', function() {
   });
 
   describe('#triggerAutoRefresh', function() {
-    var postMessageSpy;
+    var triggerSpy;
     var dialogField = {};
 
     beforeEach(function() {
-      postMessageSpy = sinon.stub(parent, 'postMessage');
-      dialogField.name = 'dialogName';
-    });
+      $ = sinon.stub();
+      triggerSpy = sinon.stub({trigger: function(messageName, data) {}});
 
-    afterEach(function() {
-      parent.postMessage.restore();
+      $.withArgs(document).returns(triggerSpy);
+      dialogField.name = 'dialogName';
     });
 
     describe('when the dialog field triggers auto refreshes', function() {
@@ -456,7 +455,7 @@ describe('DialogFieldRefresh', function() {
 
       it('posts a message with the field name', function() {
         DialogFieldRefresh.triggerAutoRefresh(dialogField);
-        expect(postMessageSpy).to.have.been.calledWith({refreshableFieldIndex: 123}, '*');
+        expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {refreshableFieldIndex: 123});
       });
     });
 
@@ -472,7 +471,7 @@ describe('DialogFieldRefresh', function() {
 
         it('posts a message with the field name', function() {
           DialogFieldRefresh.triggerAutoRefresh(dialogField);
-          expect(postMessageSpy).to.have.been.calledWith({refreshableFieldIndex: 123}, '*');
+          expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {refreshableFieldIndex: 123});
         });
       });
 
@@ -483,7 +482,7 @@ describe('DialogFieldRefresh', function() {
 
         it('does not post a message', function() {
           DialogFieldRefresh.triggerAutoRefresh(dialogField);
-          expect(postMessageSpy).not.to.have.been.called;
+          expect(triggerSpy.trigger).not.to.have.been.called;
         });
       });
     });

--- a/client/app/core/dialog-field-refresh.service.spec.js
+++ b/client/app/core/dialog-field-refresh.service.spec.js
@@ -4,51 +4,6 @@ describe('DialogFieldRefresh', function() {
     bard.inject('CollectionsApi', 'Notifications', 'DialogFieldRefresh');
   });
 
-  describe('#listenForAutoRefreshMessages', function() {
-    var eventListenerSpy;
-    var onListenerCallback;
-    var dialogField1;
-    var dialogField2;
-    var refreshSingleDialogFieldSpy;
-
-    beforeEach(function() {
-      $ = sinon.stub();
-      eventListenerSpy = sinon.stub({on: function() {}, off: function() {}});
-
-      $.withArgs(document).returns(eventListenerSpy);
-
-      refreshSingleDialogFieldSpy = sinon.stub(DialogFieldRefresh, 'refreshSingleDialogField');
-
-      dialogField1 = {auto_refresh: true};
-      dialogField2 = {auto_refresh: true};
-
-      DialogFieldRefresh.listenForAutoRefreshMessages([], [dialogField1, dialogField2], 'the_url', '123');
-      onListenerCallback = eventListenerSpy.on.getCall(0).args[1];
-    });
-
-    it('sets up a listener on the window', function() {
-      expect(eventListenerSpy.off).to.have.been.calledWith('dialog::autoRefresh');
-      expect(eventListenerSpy.on).to.have.been.calledWith('dialog::autoRefresh', onListenerCallback);
-    });
-
-    describe('listenerCallback', function() {
-      var event;
-
-      beforeEach(function() {
-        event = {originalEvent: {data: {refreshableFieldIndex: 0}}};
-        onListenerCallback(event);
-      });
-
-      it('sets the being refreshed flag to true', function() {
-        expect(dialogField2.beingRefreshed).to.equal(true);
-      });
-
-      it('sets the trigger override flag to true', function() {
-        expect(dialogField2.triggerOverride).to.equal(true);
-      });
-    });
-  });
-
   describe('#refreshSingleDialogField with values not as an object', function() {
     var dialog1 = {name: 'dialog1', default_value: 'name1'};
     var dialog2 = {name: 'dialog2', default_value: 'name2'};
@@ -453,9 +408,35 @@ describe('DialogFieldRefresh', function() {
         dialogField.refreshableFieldIndex = 123;
       });
 
-      it('posts a message with the field name', function() {
-        DialogFieldRefresh.triggerAutoRefresh(dialogField);
-        expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {refreshableFieldIndex: 123});
+      describe('when the initial trigger is true', function() {
+        beforeEach(function() {
+          DialogFieldRefresh.triggerAutoRefresh(dialogField, true);
+        });
+
+        it('sends a dialog::autoRefresh message with a currentIndex of 0', function() {
+          expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {
+            initializingIndex: 123,
+            currentIndex: 0
+          });
+        });
+      });
+
+      describe('when the initial trigger is not true', function() {
+        beforeEach(function() {
+          var autoRefreshOptions = {
+            initializingIndex: 123,
+            currentIndex: 321
+          };
+
+          DialogFieldRefresh.triggerAutoRefresh(dialogField, false, autoRefreshOptions);
+        });
+
+        it('sends a dialog::autoRefresh message and passes along the autoRefreshOptions', function() {
+          expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {
+            initializingIndex: 123,
+            currentIndex: 321
+          });
+        });
       });
     });
 
@@ -469,9 +450,34 @@ describe('DialogFieldRefresh', function() {
           dialogField.triggerOverride = true;
         });
 
-        it('posts a message with the field name', function() {
-          DialogFieldRefresh.triggerAutoRefresh(dialogField);
-          expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {refreshableFieldIndex: 123});
+        describe('when the initial trigger is true', function() {
+          beforeEach(function() {
+            DialogFieldRefresh.triggerAutoRefresh(dialogField, true);
+          });
+
+          it('sends a dialog::autoRefresh message with a currentIndex of 0', function() {
+            expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {
+              initializingIndex: 123,
+              currentIndex: 0
+            });
+          });
+        });
+
+        describe('when the initial trigger is not true', function() {
+          beforeEach(function() {
+            var autoRefreshOptions = {
+              initializingIndex: 123,
+              currentIndex: 321
+            };
+            DialogFieldRefresh.triggerAutoRefresh(dialogField, false, autoRefreshOptions);
+          });
+
+          it('sends a dialog::autoRefresh message and passes along the autoRefreshOptions', function() {
+            expect(triggerSpy.trigger).to.have.been.calledWith('dialog::autoRefresh', {
+              initializingIndex: 123,
+              currentIndex: 321
+            });
+          });
         });
       });
 
@@ -480,7 +486,7 @@ describe('DialogFieldRefresh', function() {
           dialogField.triggerOverride = undefined;
         });
 
-        it('does not post a message', function() {
+        it('does not send a message', function() {
           DialogFieldRefresh.triggerAutoRefresh(dialogField);
           expect(triggerSpy.trigger).not.to.have.been.called;
         });

--- a/client/app/shared/dialog-content/dialog-content.html
+++ b/client/app/shared/dialog-content/dialog-content.html
@@ -28,7 +28,7 @@
                       ng-switch-when="DialogFieldTextBox"
                       ng-model="dialogField.default_value"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
-                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       ng-model-options="{debounce: {'default': 500}}"
                       class="form-control"
                       type="{{ dialogField.options.protected ? 'password' : 'text' }}"
@@ -39,7 +39,7 @@
                       ng-switch-when="DialogFieldTextAreaBox"
                       ng-model="dialogField.default_value"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
-                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       ng-model-options="{debounce: {'default': 500}}"
                       class="form-control"
                       uib-tooltip="{{ ::inputTitle }}"
@@ -50,7 +50,7 @@
                       ng-model="dialogField.default_value"
                       ng-true-value="'t'"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
-                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       class="form-control"
                       type="checkbox"
                       uib-tooltip="{{ ::inputTitle }}"
@@ -60,7 +60,7 @@
                       ng-switch-when="DialogFieldDropDownList"
                       ng-model="dialogField.default_value"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
-                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       class="form-control"
                       ng-options="fieldValue[0] as fieldValue[1] for fieldValue in dialogField.values">
                     </select>
@@ -70,7 +70,7 @@
                       ng-switch-when="DialogFieldTagControl"
                       ng-model="dialogField.default_value"
                       ng-disabled="dialogField.read_only || vm.inputDisabled"
-                      ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       class="form-control"
                       ng-options="fieldValue.id as fieldValue.description for fieldValue in dialogField.values">
                     </select>
@@ -81,7 +81,7 @@
                             ng-switch-when="DialogFieldTagControl"
                             ng-model="dialogField.default_value"
                             ng-disabled="dialogField.read_only || vm.inputDisabled"
-                            ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                            ng-change="dialogField.triggerAutoRefresh()"
                             class="form-control"
                             ng-options="fieldValue.id as fieldValue.description for fieldValue in dialogField.values">
                     </select>
@@ -101,7 +101,7 @@
                         <input
                           type="radio"
                           ng-model="dialogField.default_value"
-                          ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                          ng-change="dialogField.triggerAutoRefresh()"
                           ng-disabled="dialogField.read_only || vm.inputDisabled"
                           name="{{ dialogField.name }}"
                           value="{{ ::fieldValue[0] }}"/>
@@ -112,7 +112,7 @@
                     <input
                       ng-switch-when="DialogFieldDateControl"
                       ng-model="dialogField.default_value"
-                      ng-change="triggerAutoRefresh(dialogField)"
+                      ng-change="dialogField.triggerAutoRefresh()"
                       pf-datepicker options="vm.dateOptions"
                       date="dialogField.default_value">
 
@@ -120,7 +120,7 @@
                       <div class="col-sm-6 dateTimePadding">
                         <input
                           ng-model="dialogField.default_value"
-                          ng-change="dialogField.triggerAutoRefresh(dialogField)"
+                          ng-change="dialogField.triggerAutoRefresh()"
                           pf-datepicker options="vm.dateOptions"
                           date="dialogField.default_value">
                       </div>

--- a/client/app/states/catalogs/details/details.state.js
+++ b/client/app/states/catalogs/details/details.state.js
@@ -36,7 +36,7 @@ function resolveDialogs($stateParams, CollectionsApi) {
 }
 
 /** @ngInject */
-function Controller(dialogs, serviceTemplate, EventNotifications, DialogFieldRefresh, ShoppingCart) {
+function Controller(dialogs, serviceTemplate, EventNotifications, DialogFieldRefresh, DialogFieldListener, ShoppingCart) {
   var vm = this;
 
   vm.serviceTemplate = serviceTemplate;
@@ -63,7 +63,7 @@ function Controller(dialogs, serviceTemplate, EventNotifications, DialogFieldRef
     };
   });
 
-  DialogFieldRefresh.listenForAutoRefreshMessages(
+  DialogFieldListener.listenForAutoRefreshMessages(
     allDialogFields,
     autoRefreshableDialogFields,
     dialogUrl,

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -39,7 +39,7 @@ function resolveDialog($stateParams, CollectionsApi) {
 }
 
 /** @ngInject */
-function StateController($state, $stateParams, dialog, service, CollectionsApi, EventNotifications, DialogFieldRefresh) {
+function StateController($state, $stateParams, dialog, service, CollectionsApi, EventNotifications, DialogFieldRefresh, DialogFieldListener) {
   var vm = this;
   vm.title = __('Custom button action');
   vm.dialogs = dialog.content;
@@ -61,7 +61,7 @@ function StateController($state, $stateParams, dialog, service, CollectionsApi, 
     };
   });
 
-  DialogFieldRefresh.listenForAutoRefreshMessages(
+  DialogFieldListener.listenForAutoRefreshMessages(
     allDialogFields,
     autoRefreshableDialogFields,
     dialogUrl,

--- a/client/app/states/services/reconfigure/reconfigure.state.js
+++ b/client/app/states/services/reconfigure/reconfigure.state.js
@@ -33,7 +33,7 @@ function resolveService($stateParams, CollectionsApi) {
 }
 
 /** @ngInject */
-function StateController($state, $stateParams, CollectionsApi, service, EventNotifications, DialogFieldRefresh) {
+function StateController($state, $stateParams, CollectionsApi, service, EventNotifications, DialogFieldRefresh, DialogFieldListener) {
   var vm = this;
 
   vm.title = __('Service Details');
@@ -87,7 +87,7 @@ function StateController($state, $stateParams, CollectionsApi, service, EventNot
     };
   });
 
-  DialogFieldRefresh.listenForAutoRefreshMessages(
+  DialogFieldListener.listenForAutoRefreshMessages(
     allDialogFields,
     autoRefreshableDialogFields,
     dialogUrl,


### PR DESCRIPTION
This is the SUI complement to [this PR](https://github.com/ManageIQ/manageiq-ui-classic/pull/1349). More information can be found at that link.

@miq-bot add_label euwe/yes, fine/yes, bug
@miq-bot assign @chriskacerguis 

@AllenBW Can you review for me, or tag someone else to review? Thanks!