### PR TITLE
Unify console names between ops & service UI - VM Console & Web Console

### DIFF
--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -286,12 +286,12 @@
                         <li role="menuitem"
                             ng-class="{'disabled': !item['supports_console?'] || item.power_state !== 'on' || !$ctrl.customScope.permissions.console}"
                             ng-click="$ctrl.customScope.openConsole(item)">
-                          <a href="#" translate>Open VM Console</a>
+                          <a href="#" translate>VM Console</a>
                         </li>
                         <li role="menuitem"
                             ng-class="{'disabled': !item['supports_launch_cockpit?'] || item.power_state !== 'on' || !$ctrl.customScope.permissions.cockpit}"
                             ng-click="$ctrl.customScope.openCockpit(item)">
-                          <a href="#" translate>Open Cockpit Console</a>
+                          <a href="#" translate>Web Console</a>
                         </li>
                       </ul>
                     </div>


### PR DESCRIPTION
This comes from the discussion in https://bugzilla.redhat.com/show_bug.cgi?id=1441321 and https://github.com/ManageIQ/manageiq-ui-classic/pull/1429 - see details there.

But, per [Cockpit intergration guidelines](https://github.com/cockpit-project/cockpit/wiki/Product-Integration), "Cockpit Console" should be named "Web Console".

I'm also chaning the button from "Open * Console" to "* Console" for consistency with Ops UI.

https://bugzilla.redhat.com/show_bug.cgi?id=1441321

Cc @chriskacerguis, @Loicavenel 