### PR TITLE
Adds "View Graphs" link to service details

### DIFF
--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -337,6 +337,10 @@
                           <a ng-click="$ctrl.customScope.gotoComputeResource(item)" translate>View
                             Details</a>
                         </li>
+                        <li role="menuitem">
+                          <a ui-sref="vms.details({vmId: item.id, viewType: 'graphsView'})" translate>View
+                            Graphs</a>
+                        </li>
                         <li role="menuitem" ng-if="$ctrl.customScope.permissions.viewSnapshots">
                           <a ui-sref="vms.snapshots({vmId: item.id})" translate>View
                             Snapshots</a>

--- a/client/app/services/vm-details/vm-details.component.js
+++ b/client/app/services/vm-details/vm-details.component.js
@@ -41,7 +41,7 @@ function ComponentController($stateParams, VmsService, ServicesState, sprintf, l
       availableText: __('Available'),
       notAvailable: __("Not Available"),
       vmDetails: {},
-      viewType: 'detailsView',
+      viewType: $stateParams.viewType || 'detailsView',
       viewSelected: viewSelected,
       instance: {},
       cpuChart: UsageGraphsService.getChartConfig(vm.cpuChartConfigOptions),

--- a/client/app/states/vms/details/details.state.js
+++ b/client/app/states/vms/details/details.state.js
@@ -7,6 +7,7 @@ function getStates() {
   return {
     'vms.details': {
       url: '/:vmId',
+      params: { viewType: null },
       template: '<vm-details \>',
       title: N_('VM Details'),
     },


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/146157721

Transitions user to vms-details state with a defalut viewType specified
At the moment, graphs component does not appear to be working correctly, can't handle being the default view, following up with pr to fix

<img width="1187" alt="screen shot 2017-06-19 at 10 30 37 am" src="https://user-images.githubusercontent.com/6640236/27290221-9390f3fc-54da-11e7-946d-d94bc878efcf.png">

### gif of the bug i'll be working on next
![graph-issue](https://user-images.githubusercontent.com/6640236/27290451-4f4259c4-54db-11e7-9a5e-313a3b75a547.gif)
