### PR TITLE
BZ#1466514 - Gracefully handle 403 state change error

### DIFF
--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -116,7 +116,7 @@ export function authInit($rootScope, $state, $log, Session, $sessionStorage, Lan
 
   function changeError(event, toState, _toParams, _fromState, _fromParams, error) {
     // If a 401 is encountered during a state change, then kick the user back to the login
-    if (401 === error.status) {
+    if (401 || 403 === error.status) {
       event.preventDefault();
       if (Session.active()) {
         $state.transitionTo('logout');


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1466514

When a user switches to a group that doesn't have sui rights, they are logged out.

Ends up the technical challenge of hiding groups that don't have roles with sufficient product features to view  the ui is a bit more involved, likely a ref

![statechangeerror](https://user-images.githubusercontent.com/6640236/27914792-3d34373e-6232-11e7-8008-4381dcc2be6b.gif)
