### PR TITLE
[FINE] Restores catalog scroll bar, no change to explorers

### DIFF
--- a/client/assets/sass/_explorer.sass
+++ b/client/assets/sass/_explorer.sass
@@ -8,7 +8,6 @@
 
   .list-view-pf
     height: calc(100vh - 237px)
-    overflow-y: auto
 
   .explorer-children-list
     .list-view-pf

--- a/client/assets/sass/_list-view.sass
+++ b/client/assets/sass/_list-view.sass
@@ -3,7 +3,6 @@
   height: calc(100vh - 208px)
   margin-top: 1px
   overflow-x: hidden
-  overflow-y: auto
 
   .alert
     margin: 20px 0
@@ -22,12 +21,10 @@
 
     &.paged-container
       height: calc(100vh - 237px)
-      overflow-y: hidden
 
 .list-view-pf
   line-height: 45px
-  overflow-y: hidden // Adding so tooltips don't cause a second scrollbar in the data list
-  padding-bottom: 30px // Adding so tooltips on the last row don't get cut off
+  margin-top: 0
 
   .no-wrap
     display: block


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148488889
https://bugzilla.redhat.com/show_bug.cgi?id=1466049

Removes extraneous margin, pf list view now displays in viewport (on top of other elements)

## PROOF
![catalognostroll](https://user-images.githubusercontent.com/6640236/27967540-69a3a4d2-6311-11e7-9808-ffc2eb1f199f.gif)

