### PR TITLE
PT#148515861 Service.custom_button_details state params cleaned

### DIFF
--- a/client/app/services/custom-button/custom-button.component.js
+++ b/client/app/services/custom-button/custom-button.component.js
@@ -28,7 +28,7 @@ function CustomButtonController($state, EventNotifications, CollectionsApi, RBAC
   function invokeCustomAction(button) {
     if (button.resource_action && button.resource_action.dialog_id) {
       $state.go('services.custom_button_details', {
-        button,
+        button: button,
         serviceId: vm.serviceId,
       });
     } else if (vm.vmId) { 

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -9,12 +9,19 @@ export function CustomButtonDetailsState(routerHelper) {
 function getStates() {
   return {
     'services.custom_button_details': {
-      url: '/:serviceId/custom_button_details/:buttonId',
+      url: '/{serviceId:int}/custom_button_details',
       templateUrl,
       controller: StateController,
       controllerAs: 'vm',
       title: N_('Service Custom Button Details'),
-      params: {dialogId: null, button: null, serviceTemplateCatalogId: null},
+      params: {
+        button: {
+          value: null,
+        },
+        serviceId: {
+          value: null,
+        },
+      },
       resolve: {
         dialog: resolveDialog,
         service: resolveService,


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/148515861

Discovered this nasty bug while working #837 (this isn't the same, that , prior to upping to 1.x angular-ui-router, the dep was disgustingly lax about params, we upped to 1.x, this mess wasn't updated, causes this error:

## broken
<img width="960" alt="screen shot 2017-07-07 at 5 00 59 pm" src="https://user-images.githubusercontent.com/6640236/27977084-38b82ffc-6337-11e7-898a-b21f01fa9335.png">

## BUT LOOK ITS NOW FIXED
![brokenmaster](https://user-images.githubusercontent.com/6640236/27977087-3be62ea4-6337-11e7-9862-03c76f4daf19.gif)


🌮 💃 