### PR TITLE
BZ#1469802 - Buttons are updated on power operations, but don't disappear

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -42,9 +42,6 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
       viewSelected: viewSelected,
       disableSuspendButton: disableSuspendButton,
       disableStartButton: disableStartButton,
-      startService: startService,
-      stopService: stopService,
-      suspendService: suspendService,
       toggleOpenResourceGroup: toggleOpenResourceGroup,
       openCockpit: openCockpit,
       openConsole: openConsole,
@@ -223,17 +220,17 @@ function ComponentController($stateParams, $state, $window, CollectionsApi, Even
 
   function startService() {
     PowerOperations.startService(vm.service);
-    vm.listActions = getListActions();
+    getListActions();
   }
 
   function stopService() {
     PowerOperations.stopService(vm.service);
-    vm.listActions = getListActions();
+    getListActions();
   }
 
   function suspendService() {
     PowerOperations.suspendService(vm.service);
-    vm.listActions = getListActions();
+    getListActions();
   }
 
   function getHeaderConfig() {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1469802
https://www.pivotaltracker.com/story/show/148785143

Original intent appeared to be, after taking power option on a service, the buttons might change. getlistActions() doesn't return anything, so the assignment of that function to the button array was kinda... no bueno...

### Buttons are updated on power operations, but don't disappear

![customdropdown](https://user-images.githubusercontent.com/6640236/28136349-61eef7b4-6717-11e7-831c-26b5f5e328e5.gif)
