### PR TITLE
Display colored fonticons before custom buttons

### DIFF
--- a/client/app/services/custom-button/custom-button.html
+++ b/client/app/services/custom-button/custom-button.html
@@ -4,6 +4,7 @@
           ng-click="vm.invokeCustomAction(button)"
           uib-tooltip="{{button.description}}"
           tooltip-placement="top">
+    <i ng-class="button.options.button_icon" ng-style="{color: button.options.button_color }"></i>
     {{ button.name }}
   </button>
 </span>
@@ -14,6 +15,7 @@
             uib-dropdown-toggle
             uib-tooltip="{{buttonGroup.description}}"
             tooltip-placement="top">
+      <i ng-class="buttonGroup.set_data.button_icon" ng-style="{color: buttonGroup.set_data.button_color }"></i>
       {{ buttonGroup.name.split('|')[0] }}
       <span class="caret"></span>
     </button>
@@ -26,6 +28,7 @@
            ng-click="vm.invokeCustomAction(button)"
            uib-tooltip="{{button.description}}"
            tooltip-placement="left">
+          <i ng-class="button.options.button_icon" ng-style="{color: button.options.button_color }"></i>
           {{ button.name }}
         </a>
       </li>


### PR DESCRIPTION
Pivotal story in the OPS UI: https://www.pivotaltracker.com/story/show/147779325
Depends on: https://github.com/ManageIQ/manageiq-schema/pull/39
Some icons might be not displayed becauseof this: https://github.com/ManageIQ/manageiq-ui-service/issues/850

![screenshot from 2017-07-22 11-43-45](https://user-images.githubusercontent.com/649130/28490153-0ef6b07e-6ed3-11e7-8798-9d98170e6bc8.png)
