### PR TITLE
PT#149582399 - Adds font fabulous dep

### DIFF
--- a/client/assets/sass/styles.sass
+++ b/client/assets/sass/styles.sass
@@ -3,6 +3,10 @@ $img-base-path: '/' !default
 
 @import 'patternfly'
 
+// Include font-fabulous
+$ff-font-path: '~font-fabulous/assets/fonts/font-fabulous'
+@import 'font-fabulous'
+
 // BEM Support : See _bem-support/_index.sass for more information
 @import '_bem-support/index'
 

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -141,6 +141,7 @@ module.exports = {
                   `${nodeModules}/bootstrap-sass/assets/stylesheets`,
                   `${nodeModules}/patternfly-sass/assets/stylesheets`,
                   `${nodeModules}/font-awesome/scss`,
+                  `${nodeModules}/font-fabulous/assets/stylesheets`,
                 ],
               },
             },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "extract-text-webpack-plugin": "2.1.2",
     "file-loader": "0.11.2",
     "font-awesome": "4.7.0",
+    "font-fabulous": "ManageIQ/font-fabulous#master",
     "glob": "7.1.2",
     "html-loader": "0.4.5",
     "html-webpack-plugin": "2.29.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3250,6 +3250,10 @@ font-awesome@~4.6.3:
   version "4.6.3"
   resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.6.3.tgz#86933651540ee00874c664017f50f2172f6531a2"
 
+font-fabulous@ManageIQ/font-fabulous#master:
+  version "0.0.1"
+  resolved "https://codeload.github.com/ManageIQ/font-fabulous/tar.gz/447376ce2bf290c77d1946ca316ece36b882c264"
+
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/149582399

See that tiny little broom? proooooof it works! (ignore the ⌛️ its just playing around, not committed)
<img width="685" alt="screen shot 2017-07-27 at 9 58 53 am" src="https://user-images.githubusercontent.com/6640236/28674147-8bef8e9c-72b2-11e7-9dac-842166978b75.png">

but hold your 🐴's this is dependent on [changes that need to be made here](https://github.com/ManageIQ/font-fabulous/issues/43).  

once these are in, we'll see the above :broom: which is in turn work to support https://github.com/ManageIQ/manageiq-ui-service/issues/850, such a 🌀 of 💜 

🙇‍♀️ @skateman 

PS: once those changes are made ☝️ I'll have to relock the the ff dep (as in lieu of versions yarn grabs on to commit hashes)