### PR TITLE
Set leftBoundary as zero if there is nothing to display

### DIFF
--- a/client/app/shared/pagination/pagination.component.js
+++ b/client/app/shared/pagination/pagination.component.js
@@ -93,7 +93,7 @@ function ComponentController() {
   }
 
   function leftBoundary() {
-    vm.leftBoundary = vm.offset + 1;
+    vm.leftBoundary = vm.count === 0 ? 0 : vm.offset + 1;
   }
 
   function rightBoundary() {


### PR DESCRIPTION
**Before:**
![screenshot from 2017-08-18 13-51-38](https://user-images.githubusercontent.com/649130/29457815-68176c26-841c-11e7-99a5-e60d5587c6b1.png)

**After:**
![screenshot from 2017-08-18 13-51-17](https://user-images.githubusercontent.com/649130/29457821-6b4eb2f0-841c-11e7-8034-77c8eba844e2.png)

This fixes https://github.com/ManageIQ/manageiq/issues/15847