### PR TITLE
Ensure unique url for service.resource-details, update all instances

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -11,8 +11,8 @@ export const ServiceDetailsComponent = {
 
 /** @ngInject */
 function ComponentController ($stateParams, $state, $window, CollectionsApi, EventNotifications, Chargeback, Consoles,
-                             TagEditorModal, ModalService, PowerOperations, ServicesState, TaggingService, lodash,
-                             Polling, LONG_POLLING_INTERVAL, UsageGraphsService) {
+                              TagEditorModal, ModalService, PowerOperations, ServicesState, TaggingService, lodash,
+                              Polling, LONG_POLLING_INTERVAL, UsageGraphsService) {
   const vm = this
   vm.$onInit = activate
   vm.$onDestroy = onDestroy
@@ -286,14 +286,24 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
 
     /** @ngInject */
     function resolveUsers (CollectionsApi) {
-      const options = {expand: 'resources', attributes: ['userid', 'name'], sort_by: 'name', sort_options: 'ignore_case'}
+      const options = {
+        expand: 'resources',
+        attributes: ['userid', 'name'],
+        sort_by: 'name',
+        sort_options: 'ignore_case'
+      }
 
       return CollectionsApi.query('users', options)
     }
 
     /** @ngInject */
     function resolveGroups (CollectionsApi) {
-      const options = {expand: 'resources', attributes: ['description'], sort_by: 'description', sort_options: 'ignore_case'}
+      const options = {
+        expand: 'resources',
+        attributes: ['description'],
+        sort_by: 'description',
+        sort_options: 'ignore_case'
+      }
 
       return CollectionsApi.query('groups', options)
     }
@@ -356,7 +366,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   }
 
   function gotoComputeResource (resource) {
-    $state.go('services.resource-details', {vmId: resource.id})
+    $state.go('services.resource-details', {serviceId: vm.serviceId, vmId: resource.id})
   }
 
   function startVM (item, isDisabled) {

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -355,8 +355,11 @@
                             Details</a>
                         </li>
                         <li role="menuitem">
-                          <a ui-sref="services.resource-details({vmId: item.id, viewType: 'graphsView'})" translate>View
-                            Graphs</a>
+                          <a
+                            ui-sref="services.resource-details({serviceId: vm.service.id, vmId: item.id, viewType: 'graphsView'})"
+                            translate>
+                            View Graphs
+                          </a>
                         </li>
                       </ul>
                     </div>

--- a/client/app/services/vms/snapshots.html
+++ b/client/app/services/vms/snapshots.html
@@ -9,7 +9,7 @@
         <a ng-if="!vm.vm.service.name" ui-sref="dashboard" translate>No Service</a>
       </li>
       <li>
-        <a ui-sref="services.resource-details({vmId: vm.vm.id})"> {{vm.vm.name}} </a>
+        <a ui-sref="services.resource-details({serviceId: vm.vm.service.id, vmId: vm.vm.id})"> {{vm.vm.name}} </a>
       </li>
       <li class="active" translate>
         Snapshots

--- a/client/app/states/services/resource-details/details.state.js
+++ b/client/app/states/services/resource-details/details.state.js
@@ -6,7 +6,7 @@ export function VmsDetailsState (routerHelper) {
 function getStates () {
   return {
     'services.resource-details': {
-      url: '/:vmId',
+      url: '/:serviceId/resource=:vmId',
       params: { viewType: null },
       template: '<vm-details>',
       title: N_('Resource Details')


### PR DESCRIPTION
In support of a task in this pt: https://www.pivotaltracker.com/story/show/147640893

No UX? I don't know what counts anymore, seems to me to be just a simple url change

**TL;DR** `services.resource-details` now has url of `/services/:serviceId/resource=:vmId` (used to be `/services/:vmId`)

This was getting terribly annoying, refreshing the resource details page only to have this happen: 
<img width="1105" alt="screen shot 2017-08-31 at 10 21 03 am" src="https://user-images.githubusercontent.com/6640236/29928118-1ff949cc-8e36-11e7-9a15-b8cffb65bafb.png">

Cuz our resource details url isn't unique 😭 

## Before: can you tell which one is a service details vs a resource details? 
<img width="1104" alt="screen shot 2017-08-31 at 9 59 06 am" src="https://user-images.githubusercontent.com/6640236/29928006-e533d938-8e35-11e7-9466-9fe172be87c3.png">
<img width="1113" alt="screen shot 2017-08-31 at 9 59 16 am" src="https://user-images.githubusercontent.com/6640236/29928004-e47db36a-8e35-11e7-9607-85b2aa8692b2.png">

## After: unique!  also doesn't mind being reloaded or navigated to directly (via url)
<img width="1104" alt="screen shot 2017-08-31 at 10 22 52 am" src="https://user-images.githubusercontent.com/6640236/29928238-76b04b12-8e36-11e7-897f-4f440a96392f.png">
