### PR TITLE
[Finishes #150828440] Reconfigures tag query to prevent explorer filter failure

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -48,6 +48,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
       stopService: stopService,
       suspendService: suspendService,
       paginationUpdate: paginationUpdate,
+      defaultFilterFields: defaultFilterFields,
       // Config setup
       viewType: 'listView',
       cardConfig: getCardConfig(),

--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -10,7 +10,7 @@ export const ServiceExplorerComponent = {
 
 /** @ngInject */
 function ComponentController ($state, ServicesState, Language, ListView, Chargeback, TaggingService, TagEditorModal,
-                             EventNotifications, ModalService, PowerOperations, lodash, Polling, POLLING_INTERVAL) {
+                              EventNotifications, ModalService, PowerOperations, lodash, Polling, POLLING_INTERVAL) {
   const vm = this
 
   vm.$onDestroy = function () {
@@ -22,9 +22,10 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
     $state.params.filter ? ServicesState.services.setFilters($state.params.filter) : ServicesState.services.setFilters([])
     ServicesState.services.setSort({id: 'created_at', title: 'Created', sortType: 'numeric'}, false)
 
-    TaggingService.queryAvailableTags().then((response) => {
-      vm.toolbarConfig.filterConfig.fields = getServiceFilterFields(response)
-    })
+    TaggingService.queryAvailableTags().then(
+      (response) => { vm.toolbarConfig.filterConfig.fields = getServiceFilterFields(response) },
+      () => { vm.toolbarConfig.filterConfig.fields = defaultFilterFields() }
+    )
 
     angular.extend(vm, {
       loading: false,
@@ -289,6 +290,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
     ]
 
     angular.forEach(menuOptions, hasPermission)
+
     function hasPermission (item) {
       if (item.permission) {
         menu.push(item)
@@ -323,6 +325,11 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
     resolveServices(vm.limit, 0)
   }
 
+  function defaultFilterFields () {
+    return [ListView.createFilterField('name', __('Name'), __('Filter by Name'), 'text'),
+      ListView.createFilterField('description', __('Description'), __('Filter by Description'), 'text')]
+  }
+
   function getServiceFilterFields (tags) {
     const filterValues = []
     const filterCategories = {}
@@ -348,9 +355,8 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
       }
     })
 
-    return [
-      ListView.createFilterField('name', __('Name'), __('Filter by Name'), 'text'),
-      ListView.createFilterField('description', __('Description'), __('Filter by Description'), 'text'),
+    const filterFields = defaultFilterFields()
+    filterFields.push(
       ListView.createGenericField(
         {
           id: 'tags.name',
@@ -364,7 +370,8 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
           filterCategories: filterCategories
         }
       )
-    ]
+    )
+    return filterFields
   }
 
   function getServiceSortFields () {

--- a/client/app/services/service-explorer/service-explorer.component.spec.js
+++ b/client/app/services/service-explorer/service-explorer.component.spec.js
@@ -1,15 +1,15 @@
 describe('Component: serviceExplorer', () => {
-  let scope, ctrl, collectionsApiMock;
+  let scope, ctrl, collectionsApiMock
 
   beforeEach(() => {
-    module('app.core', 'app.states', 'app.services');
-    bard.inject('$componentController', 'EventNotifications', 'ListView', 'ServicesState', '$state', 'CollectionsApi');
-    ctrl = $componentController('serviceExplorer', {$scope: scope}, {});
-    ctrl.$onInit();
-    collectionsApiMock = sinon.mock(CollectionsApi);
-  });
+    module('app.core', 'app.states', 'app.services')
+    bard.inject('$componentController', 'EventNotifications', 'ListView', 'ServicesState', '$state', 'CollectionsApi')
+    ctrl = $componentController('serviceExplorer', {$scope: scope}, {})
+    ctrl.$onInit()
+    collectionsApiMock = sinon.mock(CollectionsApi)
+  })
 
-  it('is defined', () => expect(ctrl).to.be.defined);
+  it('is defined', () => expect(ctrl).to.be.defined)
 
   it('should set permissions', () => {
     const expectedPermissions = {
@@ -38,53 +38,79 @@ describe('Component: serviceExplorer', () => {
       instance_show: false,
       vm_drift: false,
       vm_check_compliance: false
-    };
+    }
 
-    expect(ctrl.permissions).to.eql(expectedPermissions);
-  });
+    expect(ctrl.permissions).to.eql(expectedPermissions)
+  })
 
   it('should allow pagination to be updated', () => {
-    const limit = 40;
-    const offset = 10;
-    ctrl.paginationUpdate(limit, offset);
+    const limit = 40
+    const offset = 10
+    ctrl.paginationUpdate(limit, offset)
 
-    expect(ctrl.limit).to.eq(limit);
-    expect(ctrl.offset).to.eq(offset);
-  });
+    expect(ctrl.limit).to.eq(limit)
+    expect(ctrl.offset).to.eq(offset)
+  })
 
   it('should set toolbar', () => {
 
-    expect(ctrl.toolbarConfig.sortConfig.fields).to.have.lengthOf(3);
+    expect(ctrl.toolbarConfig.sortConfig.fields).to.have.lengthOf(3)
     expect(ctrl.toolbarConfig.sortConfig.currentField).to.eql({
       id: 'created_at',
       title: 'Created',
       sortType: 'numeric'
-    });
-  });
+    })
+  })
 
   it('should allow for sorting to be able to be updated', () => {
-    const catalogSpy = sinon.spy(ServicesState.services, 'setSort');
-    ctrl.toolbarConfig.sortConfig.onSortChange('name', true);
+    const catalogSpy = sinon.spy(ServicesState.services, 'setSort')
+    ctrl.toolbarConfig.sortConfig.onSortChange('name', true)
 
-    expect(catalogSpy).to.have.been.called.once;
-  });
+    expect(catalogSpy).to.have.been.called.once
+  })
 
   it('should make a query for services', () => {
     collectionsApiMock
       .expects('query')
-      .withArgs('services', { filter: ["ancestry=null"] })
-      .returns(Promise.resolve());
+      .withArgs('services', {filter: ['ancestry=null']})
+      .returns(Promise.resolve())
 
-    ctrl.resolveServices(20, 0);
+    ctrl.resolveServices(20, 0)
 
-    collectionsApiMock.verify();
-    ctrl.$onDestroy();
+    collectionsApiMock.verify()
+    ctrl.$onDestroy()
 
-  });
+  })
+
+  it('should had default filter fields', () => {
+    const defaultFields = [{
+      id: 'name',
+      title: 'Name',
+      placeholder: 'Filter by Name',
+      filterType: 'text',
+      filterValues: undefined
+    },
+      {
+        id: 'description',
+        title: 'Description',
+        placeholder: 'Filter by Description',
+        filterType: 'text',
+        filterValues: undefined
+      }]
+
+    expect(ctrl.defaultFilterFields()).to.eql(defaultFields)
+  })
+
+  it('should test service type is ansible', () => {
+    const isAnsible = ctrl.isAnsibleService({type: 'ansible', name: 'ansible'})
+    expect(isAnsible).to.be.true
+    const isNotAnsible = ctrl.isAnsibleService({type: 'vm'})
+    expect(isNotAnsible).to.be.false
+  })
 
   it('should change view type', () => {
-    expect(ctrl.viewType).to.equal("listView");
-    ctrl.viewSelected("tableView");
-    expect(ctrl.viewType).to.equal("tableView");
-  });
-});
+    expect(ctrl.viewType).to.equal('listView')
+    ctrl.viewSelected('tableView')
+    expect(ctrl.viewType).to.equal('tableView')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -995,7 +995,7 @@ babel-plugin-transform-es2015-literals@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-es2015-modules-amd@^6.22.0:
+babel-plugin-transform-es2015-modules-amd@^6.22.0, babel-plugin-transform-es2015-modules-amd@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz#3b3e54017239842d6d19c3011c4bd2f00a00d154"
   dependencies:


### PR DESCRIPTION
Without, when a user who does not have product features to see/use tags, no filter fields are presented.  No ux changes

## User with tag permissions
<img width="960" alt="screen shot 2017-09-05 at 5 22 00 pm" src="https://user-images.githubusercontent.com/6640236/30084538-d6ca55f0-9260-11e7-9ab1-3dab8cc3c5c1.png">

## User without tag permissions (before this fix)
<img width="962" alt="screen shot 2017-09-05 at 5 38 19 pm" src="https://user-images.githubusercontent.com/6640236/30084611-13b2d366-9261-11e7-96a0-6965d95190e2.png">

## User without tag permissions (fixed in this pr)
<img width="955" alt="screen shot 2017-09-05 at 5 34 15 pm" src="https://user-images.githubusercontent.com/6640236/30084550-de48ae3a-9260-11e7-9d53-3f3667736afc.png">
