### PR TITLE
CollectionsApi refactored for extensibility (infinite options), conciseness

### DIFF
--- a/client/app/core/collections-api.factory.js
+++ b/client/app/core/collections-api.factory.js
@@ -1,136 +1,56 @@
-/* eslint camelcase: "off" */
-
 /** @ngInject */
-export function CollectionsApiFactory ($http, API_BASE) {
-  const service = {
+export function CollectionsApiFactory ($http, API_BASE, lodash) {
+  return {
     query: query,
     get: get,
     post: post,
-    options: options,
     delete: remove
   }
 
-  return service
-
   function query (collection, options) {
-    const url = API_BASE + '/api/' + collection
-
-    // $log.debug("query = " + url + buildQuery(options));
-
-    return $http.get(url + buildQuery(options), buildConfig(options))
+    return $http.get(`${API_BASE}/api/${collection}${buildQuery(options)}`, buildConfig(options))
       .then(handleSuccess)
-
-    function handleSuccess (response) {
-      return response.data
-    }
   }
 
   function get (collection, id, options) {
-    const url = API_BASE + '/api/' + collection + '/' + id
-
-    // $log.debug("get = " + url + buildQuery(options));
-
-    return $http.get(url + buildQuery(options), buildConfig(options))
+    return $http.get(`${API_BASE}/api/${collection}/${id}${buildQuery(options)}`, buildConfig(options))
       .then(handleSuccess)
-
-    function handleSuccess (response) {
-      return response.data
-    }
   }
 
   function post (collection, id, options, data) {
-    const url = API_BASE + '/api/' + collection + '/' + (id || '') + buildQuery(options)
-
-    // $log.debug("post = " + url + buildQuery(options));
-
-    return $http.post(url, data, buildConfig(options))
+    return $http.post(`${API_BASE}/api/${collection}/${id || ''}${buildQuery(options)}`, data, buildConfig(options))
       .then(handleSuccess)
-
-    function handleSuccess (response) {
-      return response.data
-    }
   }
 
-  function options (collection) {
-    const url = API_BASE + '/api/' + collection
-
-    return $http.get(url + buildQuery(options))
-      .then(handleSuccess)
-
-    function handleSuccess (response) {
-      return response.data
-    }
-  }
-
-  // delete is a reserved word in JS
   function remove (collection, id, options) {
-    const url = API_BASE + '/api/' + collection + '/' + (id || '') + buildQuery(options)
-
-    // $log.debug("post = " + url + buildQuery(options));
-
-    return $http.delete(url, buildConfig(options))
+    return $http.delete(`${API_BASE}/api/${collection}/${id || ''}${buildQuery(options)}`, buildConfig(options))
       .then(handleSuccess)
-
-    function handleSuccess (response) {
-      return response.data
-    }
   }
 
   // Private
+  function handleSuccess (response) {
+    return response.data
+  }
 
   function buildQuery (options) {
     const params = []
-    options = options || {}
 
-    if (options.expand) {
-      if (angular.isArray(options.expand)) {
-        options.expand = options.expand.join(',')
+    lodash.forEach(options, (value, key) => {
+      switch (key) {
+        case 'filter':
+          lodash.forEach(value, (filter) => {
+            params.push('filter[]=' + encodeURIComponent(filter))
+          })
+          break
+        case 'auto_refresh':
+          break
+        default:
+          params.push(`${key}=${encodeURIComponent(joinArray(value))}`)
       }
-      params.push('expand=' + encodeURIComponent(options.expand))
-    }
+    })
 
-    if (options.attributes) {
-      if (angular.isArray(options.attributes)) {
-        options.attributes = options.attributes.join(',')
-      }
-      params.push('attributes=' + encodeURIComponent(options.attributes))
-    }
-
-    if (options.format_attributes) {
-      if (angular.isArray(options.format_attributes)) {
-        options.format_attributes = options.format_attributes.join(',')
-      }
-      params.push('format_attributes=' + encodeURIComponent(options.format_attributes))
-    }
-
-    if (options.filter) {
-      angular.forEach(options.filter, function (filter) {
-        params.push('filter[]=' + encodeURIComponent(filter))
-      })
-    }
-
-    if (options.limit) {
-      params.push('limit=' + encodeURIComponent(options.limit))
-    }
-
-    if (options.offset) {
-      params.push('offset=' + encodeURIComponent(options.offset))
-    }
-
-    if (options.hide) {
-      params.push('hide=' + encodeURIComponent(options.hide))
-    }
-
-    if (options.sort_by) {
-      params.push('sort_by=' + encodeURIComponent(options.sort_by))
-    }
-
-    if (options.sort_order) {
-      params.push('sort_order=' + encodeURIComponent(options.sort_order))
-    }
-
-    if (options.sort_options) {
-      params.push('sort_options=' + encodeURIComponent(options.sort_options))
+    function joinArray (value) {
+      return Array.isArray(value) ? value.join(',') : value
     }
 
     return params.length ? '?' + params.join('&') : ''

--- a/client/app/core/collections-api.factory.spec.js
+++ b/client/app/core/collections-api.factory.spec.js
@@ -1,52 +1,57 @@
-describe('Collections API', function() {
-    beforeEach(function() {
-        module('app.core');
-        bard.inject('CollectionsApi', '$http');
-    });
-    const successResponse = {
-     'data':{
-            'status': 'success' 
-            } 
-    };
+describe('Collections API', function () {
+  beforeEach(function () {
+    module('app.core')
+    bard.inject('CollectionsApi', '$http')
+  })
+  const successResponse = {
+    'data': {
+      'status': 'success'
+    }
+  }
 
-    it('should allow a query to be run', () => {
-      const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse));
-        return CollectionsApi.query('services', '1', {}).then((data) => {
-        expect(data).to.eql({'status':'success'});
-        });
-    });
-    it('should allow a get request to be run', () => {
-      const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse));
-        return CollectionsApi.get('services', {}).then((data) => {
-        expect(data).to.eql({'status':'success'});
-        });
-    });
-    it('should allow a post request to be run', () => {
-      const postSpy = sinon.stub($http, 'post').returns(Promise.resolve(successResponse));
-        return CollectionsApi.post('services', {}).then((data) => {
-        expect(data).to.eql({'status':'success'});
-        });
-    });
-    it('should allow a options request to be run', () => {
-      const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse));
-        return CollectionsApi.options('services', {}).then((data) => {
-        expect(data).to.eql({'status':'success'});
-        });
-    });
-    it('should allow a delete request to be run', () => {
-      const deleteSpy = sinon.stub($http, 'delete').returns(Promise.resolve(successResponse));
-        return CollectionsApi.delete('services','1',{}).then((data) => {
-        expect(data).to.eql({'status':'success'});
-        });
-    });
-    it('should build up a get request', () => {
-        const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse)); 
-        const options = {
-            limit: 10,
-            offset: 10,
-            format_attributes: ['option1','option2']
-        }
-         CollectionsApi.get('services', '1', options);
-         expect(getSpy).to.have.been.calledWith('http://localhost:9876/api/services/1?format_attributes=option1%2Coption2&limit=10&offset=10',{});
-    });
-});
+  it('should allow a query to be run', () => {
+    const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse))
+    return CollectionsApi.query('services', '1', {}).then((data) => {
+      expect(data).to.eql({'status': 'success'})
+    })
+  })
+  it('should allow a get request to be run', () => {
+    const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse))
+    return CollectionsApi.get('services', {}).then((data) => {
+      expect(data).to.eql({'status': 'success'})
+    })
+  })
+  it('should allow a post request to be run', () => {
+    const postSpy = sinon.stub($http, 'post').returns(Promise.resolve(successResponse))
+    return CollectionsApi.post('services', {}).then((data) => {
+      expect(data).to.eql({'status': 'success'})
+    })
+  })
+  it('should allow a delete request to be run', () => {
+    const deleteSpy = sinon.stub($http, 'delete').returns(Promise.resolve(successResponse))
+    return CollectionsApi.delete('services', '1', {}).then((data) => {
+      expect(data).to.eql({'status': 'success'})
+    })
+  })
+  it('should build up a delete request with id', () => {
+    const getSpy = sinon.stub($http, 'delete').returns(Promise.resolve(successResponse))
+    const options = {auto_refresh: true}
+    CollectionsApi.delete('services', '101', options)
+    expect(getSpy.getCall(0).args[0]).to.eq('http://localhost:9876/api/services/101')
+  })
+  it('should build up a delete request without id', () => {
+    const getSpy = sinon.stub($http, 'delete').returns(Promise.resolve(successResponse))
+    CollectionsApi.delete('services')
+    expect(getSpy.getCall(0).args[0]).to.eq('http://localhost:9876/api/services/')
+  })
+  it('should build up a get request', () => {
+    const getSpy = sinon.stub($http, 'get').returns(Promise.resolve(successResponse))
+    const options = {
+      limit: 10,
+      offset: 10,
+      format_attributes: ['option1', 'option2']
+    }
+    CollectionsApi.get('services', '1', options)
+    expect(getSpy).to.have.been.calledWith('http://localhost:9876/api/services/1?limit=10&offset=10&format_attributes=option1%2Coption2')
+  })
+})

--- a/client/app/states/catalogs/details/details.state.spec.js
+++ b/client/app/states/catalogs/details/details.state.spec.js
@@ -1,36 +1,34 @@
-describe('Catalogs.details', function() {
-  beforeEach(function() {
-    module('app.states');
-  });
+describe('Catalogs.details', function () {
+  beforeEach(function () {
+    module('app.states')
+  })
 
-  describe('#resolveDialogs', function() {
-    var collectionsApiSpy;
+  describe('#resolveDialogs', function () {
+    var collectionsApiSpy
 
-    beforeEach(function() {
-      bard.inject('$state', '$stateParams', 'CollectionsApi');
+    beforeEach(function () {
+      bard.inject('$state', '$stateParams', 'CollectionsApi')
 
-      $stateParams.serviceTemplateId = 123;
-      collectionsApiSpy = sinon.spy(CollectionsApi, 'query');
-    });
+      $stateParams.serviceTemplateId = 123
+      collectionsApiSpy = sinon.spy(CollectionsApi, 'query')
+    })
 
-    it('should query the API with the correct template id and options', function() {
-      var options = {expand: 'resources', attributes: 'content'};
-      $state.get('catalogs.details').resolve.dialogs($stateParams, CollectionsApi);
-      expect(collectionsApiSpy).to.have.been.calledWith('service_templates/123/service_dialogs', options);
-    });
-    
-    it('should query the API for service templates', function() {
-      const serviceTemplateSpy = sinon.spy(CollectionsApi, 'get');
-      var options = { attributes: "picture,picture.image_href" };
-      $state.get('catalogs.details').resolve.serviceTemplate($stateParams, CollectionsApi);
-      expect(serviceTemplateSpy).to.have.been.calledWith('service_templates',123, options);
-    });
-  });
+    it('should query the API with the correct template id and options', function () {
+      var options = {expand: 'resources', attributes: 'content'}
+      $state.get('catalogs.details').resolve.dialogs($stateParams, CollectionsApi)
+      expect(collectionsApiSpy).to.have.been.calledWith('service_templates/123/service_dialogs', options)
+    })
 
-  describe('controller', function() {
-    var collectionsApiSpy;
-    var controller;
-    var refreshSingleFieldSpy;
+    it('should query the API for service templates', function () {
+      const serviceTemplateSpy = sinon.stub(CollectionsApi, 'get')
+      const options = {attributes: ['picture', 'picture.image_href']}
+      $state.get('catalogs.details').resolve.serviceTemplate($stateParams, CollectionsApi)
+      expect(serviceTemplateSpy).to.have.been.calledWith('service_templates', 123, options)
+    })
+  })
+
+  describe('controller', function () {
+    var controller
 
     var dialogFields = [{
       name: 'dialogField1',
@@ -38,7 +36,7 @@ describe('Catalogs.details', function() {
     }, {
       name: 'dialogField2',
       default_value: '2'
-    }];
+    }]
 
     var dialogs = {
       subcount: 1,
@@ -51,94 +49,94 @@ describe('Catalogs.details', function() {
           }]
         }]
       }]
-    };
+    }
 
-    var serviceTemplate = {id: 123, service_template_catalog_id: 321, name: 'test template'};
+    var serviceTemplate = {id: 123, service_template_catalog_id: 321, name: 'test template'}
 
     var controllerResolves = {
       dialogs: dialogs,
       serviceTemplate: serviceTemplate
-    };
+    }
 
-    beforeEach(function() {
-      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'EventNotifications', 'DialogFieldRefresh', 'ShoppingCart');
-   });
+    beforeEach(function () {
+      bard.inject('$controller', '$log', '$state', '$rootScope', 'CollectionsApi', 'EventNotifications', 'DialogFieldRefresh', 'ShoppingCart')
+    })
 
-    describe('controller initialization', function() {
-      it('is created successfully', function() {
-        controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-        expect(controller).to.be.defined;
-      });
+    describe('controller initialization', function () {
+      it('is created successfully', function () {
+        controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+        expect(controller).to.be.defined
+      })
       it('it allows a field to be refreshed', () => {
-        controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-        const refreshSpy = sinon.stub(DialogFieldRefresh, 'refreshDialogField').returns(Promise.resolve({'status':'success'}));
+        controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+        const refreshSpy = sinon.stub(DialogFieldRefresh, 'refreshDialogField').returns(Promise.resolve({'status': 'success'}))
         const dialogData = {
-          "dialogField1": '1',
-          "dialogField2": '2'
-        };
-        const field = {"name":"dialogField1"};
-        controller.dialogData = dialogData;
-         return controller.refreshField(field).then((data) => {
-          expect(refreshSpy).to.have.been.calledWith(dialogData, ["dialogField1"], 'service_catalogs/321/service_templates', 123 );
-         });
-        
-      });
-      it('allows dialog data to be updated' ,()  => {
+          'dialogField1': '1',
+          'dialogField2': '2'
+        }
+        const field = {'name': 'dialogField1'}
+        controller.dialogData = dialogData
+        return controller.refreshField(field).then((data) => {
+          expect(refreshSpy).to.have.been.calledWith(dialogData, ['dialogField1'], 'service_catalogs/321/service_templates', 123)
+        })
+
+      })
+      it('allows dialog data to be updated', () => {
         const testData = {
-          validations:{ isValid: true },
+          validations: {isValid: true},
           data: {
-            "dialogField1": '1',
-            "dialogField2": '2'
+            'dialogField1': '1',
+            'dialogField2': '2'
           }
-        };
-        controller.setDialogData(testData);
-        expect(controller.dialogData).to.deep.equal({"dialogField1": '1', "dialogField2": '2'});
-      });
+        }
+        controller.setDialogData(testData)
+        expect(controller.dialogData).to.deep.equal({'dialogField1': '1', 'dialogField2': '2'})
+      })
 
-      describe('#addToCartDisabled', function() {
+      describe('#addToCartDisabled', function () {
 
-        context('when the cart is not allowed', function() {
-          beforeEach(function() {
-            sinon.stub(ShoppingCart, 'allowed').callsFake(function() {
-              return false;
-            });
+        context('when the cart is not allowed', function () {
+          beforeEach(function () {
+            sinon.stub(ShoppingCart, 'allowed').callsFake(function () {
+              return false
+            })
 
-            controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-          });
+            controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+          })
 
-          it('returns true', function() {
-            expect(controller.addToCartDisabled()).to.equal(true);
-          });
+          it('returns true', function () {
+            expect(controller.addToCartDisabled()).to.equal(true)
+          })
           it('fails to add to cart', () => {
-            const addToCart = controller.addToCart();
-            expect(addToCart).to.equal(undefined);
-          });
-        });
+            const addToCart = controller.addToCart()
+            expect(addToCart).to.equal(undefined)
+          })
+        })
 
-        context('when the cart is allowed', function() {
-          beforeEach(function() {
-            sinon.stub(ShoppingCart, 'allowed').callsFake(function() {
-              return true;
-            });
-          });
+        context('when the cart is allowed', function () {
+          beforeEach(function () {
+            sinon.stub(ShoppingCart, 'allowed').callsFake(function () {
+              return true
+            })
+          })
 
-          context('when addingToCart is true', function() {
-            beforeEach(function() {
-              controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-              controller.addingToCart = true;
+          context('when addingToCart is true', function () {
+            beforeEach(function () {
+              controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+              controller.addingToCart = true
               controller.dialogData = {
-              "dialogField1": '1',
-              "dialogField2": '2'
-            };
-            });
+                'dialogField1': '1',
+                'dialogField2': '2'
+              }
+            })
 
-            it('returns true', function() {
-              expect(controller.addToCartDisabled()).to.equal(true);
-            });
+            it('returns true', function () {
+              expect(controller.addToCartDisabled()).to.equal(true)
+            })
 
             it('add to cart successfully', () => {
-              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.resolve(""));
-              controller.addToCart();
+              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.resolve(''))
+              controller.addToCart()
               const expectedObject = {
                 data: {
                   dialogField1: '1',
@@ -146,70 +144,70 @@ describe('Catalogs.details', function() {
                   service_template_href: '/api/service_templates/123'
                 },
                 description: 'test template'
-              };
-              expect(addSpy).to.have.been.calledWith(expectedObject);
-            });
-            it('adds successfully but is a duplicate', () => {
-              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.resolve({"duplicate":true}));
-              const notificationsSuccessSpy = sinon.spy(EventNotifications, 'success');
-
-              return controller.addToCart().then((data) =>{
-                expect(notificationsSuccessSpy).to.have.been.calledWith(`Item added to shopping cart, but it's a duplicate of an existing item`);
-              });
-            });
-            it('fails to add to cart', () => {
-              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.reject('generic error'));
-              const notificationsErrorSpy = sinon.spy(EventNotifications, 'error');
-              return controller.addToCart().then((data) => {
-                expect(notificationsErrorSpy).to.have.been.calledWith(`There was an error adding to shopping cart: generic error`);
-              });
-            });
-          });
-          context('when you check for a duplicate cart', () => {
-             beforeEach(function() {
-              controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-              controller.addingToCart = true;
-            });
-            it ('checks for a duplicate cart', () => {
-              const shoppingCartSpy = sinon.stub(ShoppingCart, 'isDuplicate').returns(false);
-              controller.dialogData = {
-                "dialogField1": '1',
-                "dialogField2": '2'
-              };
-              const expectedData = controller.dialogData;
-              expectedData.service_template_href = '/api/service_templates/123';
-              controller.alreadyInCart();
-              expect(shoppingCartSpy).to.have.been.calledWith(expectedData);
+              }
+              expect(addSpy).to.have.been.calledWith(expectedObject)
             })
-          });
-          context('when addingToCart is false', function() {
-            context('when any dialogs are being refreshed', function() {
-              beforeEach(function() {
-                dialogs.resources[0].content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].beingRefreshed = true;
+            it('adds successfully but is a duplicate', () => {
+              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.resolve({'duplicate': true}))
+              const notificationsSuccessSpy = sinon.spy(EventNotifications, 'success')
 
-                controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-                controller.addingToCart = false;
-              });
+              return controller.addToCart().then((data) => {
+                expect(notificationsSuccessSpy).to.have.been.calledWith(`Item added to shopping cart, but it's a duplicate of an existing item`)
+              })
+            })
+            it('fails to add to cart', () => {
+              const addSpy = sinon.stub(ShoppingCart, 'add').returns(Promise.reject('generic error'))
+              const notificationsErrorSpy = sinon.spy(EventNotifications, 'error')
+              return controller.addToCart().then((data) => {
+                expect(notificationsErrorSpy).to.have.been.calledWith(`There was an error adding to shopping cart: generic error`)
+              })
+            })
+          })
+          context('when you check for a duplicate cart', () => {
+            beforeEach(function () {
+              controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+              controller.addingToCart = true
+            })
+            it('checks for a duplicate cart', () => {
+              const shoppingCartSpy = sinon.stub(ShoppingCart, 'isDuplicate').returns(false)
+              controller.dialogData = {
+                'dialogField1': '1',
+                'dialogField2': '2'
+              }
+              const expectedData = controller.dialogData
+              expectedData.service_template_href = '/api/service_templates/123'
+              controller.alreadyInCart()
+              expect(shoppingCartSpy).to.have.been.calledWith(expectedData)
+            })
+          })
+          context('when addingToCart is false', function () {
+            context('when any dialogs are being refreshed', function () {
+              beforeEach(function () {
+                dialogs.resources[0].content[0].dialog_tabs[0].dialog_groups[0].dialog_fields[0].beingRefreshed = true
 
-              it('returns true', function() {
-                expect(controller.addToCartDisabled()).to.equal(true);
-              });
-            });
+                controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+                controller.addingToCart = false
+              })
 
-            context('when no dialogs are being refreshed', function() {
-              beforeEach(function() {
-                controller = $controller($state.get('catalogs.details').controller, controllerResolves);
-                controller.addingToCart = false;
-                controller.addToCartEnabled = true;
-              });
+              it('returns true', function () {
+                expect(controller.addToCartDisabled()).to.equal(true)
+              })
+            })
 
-              it('returns false', function() {
-                expect(controller.addToCartDisabled()).to.equal(false);
-              });
-            });
-          });
-        });
-      });
-    });
-  });
-});
+            context('when no dialogs are being refreshed', function () {
+              beforeEach(function () {
+                controller = $controller($state.get('catalogs.details').controller, controllerResolves)
+                controller.addingToCart = false
+                controller.addToCartEnabled = true
+              })
+
+              it('returns false', function () {
+                expect(controller.addToCartDisabled()).to.equal(false)
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
Behavior remains identical to before
No need to specify an option to be added to factory (ie filter, attributes), this wasn't sustainable, Needed for `metric_rollups` work, but too good to pigeon hole in that pr 😏  
Fixes tests that probably shouldn't have been passing

🌮 💃 

required by #920 , closes #978 