### PR TITLE
Adds deps for bithound to mute, we can't upgrade these at the moment

### DIFF
--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,4 +1,7 @@
 {
+ "ignore": [
+    "**/**.spec.js"
+    ],
   "dependencies": {
     "mute": ["d3", "angular-datatables", "chai", "chai-as-promised"]
   }

--- a/.bithoundrc
+++ b/.bithoundrc
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "mute": ["d3", "angular-datatables", "chai", "chai-as-promised"]
+  }
+}


### PR DESCRIPTION
In support of reducing the number of things bithound complains about, these four deps can not be upgraded at this time