### PR TITLE
BZ#1490510 - Recalibrates snapshot timeline start/end for better visibility

### DIFF
--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -170,8 +170,12 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       vm.toolbarConfig.filterConfig.resultsCount = response.subcount
       vm.snapshots = response.resources
 
-      const start = lodash.minBy(vm.snapshots, 'create_time')
-      const end = lodash.maxBy(vm.snapshots, 'create_time')
+      const hour = 60 * 60 * 1000
+      const day = 24 * hour
+      const week = 7 * day
+      const month = 30 * day
+      const start = new Date(lodash.minBy(vm.snapshots, 'create_time').create_time)
+      const end = new Date(lodash.maxBy(vm.snapshots, 'create_time').create_time)
       const tlSnapshots = vm.snapshots.map((item) => ({
         'date': new Date(item.create_time),
         'details': {'event': item.name, 'object': item.name, item}
@@ -183,10 +187,13 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       }]
 
       vm.tlOptions = {
-        start: new Date(start.create_time),
-        end: new Date(end.create_time),
+        start: new Date(start.setHours(start.getHours() - 2)),
+        end: new Date(end.setHours(end.getHours() + 2)),
         eventShape: '\uf030',
-        eventHover: showTooltip
+        eventHover: showTooltip,
+        eventGrouping: 60000,
+        minScale: (week / month),
+        maxScale: (day / 60000)
       }
     }
 
@@ -266,17 +273,25 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
     const fontSize = 12 // in pixels
     const tooltipWidth = 9 // in rem
     const tooltip = d3
-      .select('body')
-      .append('div')
-      .attr('class', 'popover fade bottom in')
-      .attr('role', 'tooltip')
-      .on('mouseout', () => {
-        d3.select('body').selectAll('.popover').remove()
-      })
+    .select('body')
+    .append('div')
+    .attr('class', 'popover fade bottom in')
+    .attr('role', 'tooltip')
+    .on('mouseout', () => {
+      d3.select('body').selectAll('.popover').remove()
+    })
     const rightOrLeftLimit = fontSize * tooltipWidth
     const direction = d3.event.pageX > rightOrLeftLimit ? 'right' : 'left'
     const left = direction === 'right' ? d3.event.pageX - rightOrLeftLimit : d3.event.pageX
-    const options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric'}
+    const options = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric'
+    }
 
     tooltip.html(
       `
@@ -289,8 +304,8 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
     )
 
     tooltip
-      .style('left', `${left}px`)
-      .style('top', `${d3.event.pageY + 8}px`)
-      .style('display', 'block')
+    .style('left', `${left}px`)
+    .style('top', `${d3.event.pageY + 8}px`)
+    .style('display', 'block')
   }
 }

--- a/client/app/shared/timeline/timeline.component.js
+++ b/client/app/shared/timeline/timeline.component.js
@@ -38,16 +38,11 @@ function TimelineController ($element, $window) {
   }
 
   function buildConfig (options = {}) {
-    const hour = 60 * 60 * 1000
-    const day = 24 * hour
-    const week = 7 * day
-    const month = 30 * day
-
     const {
       start = new Date(0),
       end = new Date(),
-      minScale = week / month,
-      maxScale = week / hour,
+      minScale = 0,
+      maxScale = Infinity,
       width = null,
       padding = {top: 30, left: 40, bottom: 40, right: 40},
       lineHeight = 40,
@@ -94,34 +89,37 @@ function TimelineController ($element, $window) {
       eventGrouping = 60000
     } = options
 
+    const dateFormat = locale ? locale.timeFormat('%a %x %I:%M %p') : d3.time.format('%a %x %I:%M %p')
+
     return d3.chart.timeline()
-      .start(start)
-      .end(end)
-      .minScale(minScale)
-      .maxScale(maxScale)
-      .width(width)
-      .padding(padding)
-      .lineHeight(lineHeight)
-      .contextHeight(contextHeight)
-      .locale(locale)
-      .axisFormat(axisFormat)
-      .tickFormat(tickFormat)
-      .eventHover(eventHover)
-      .eventZoom(eventZoom)
-      .eventClick(eventClick)
-      .eventColor(eventColor)
-      .eventLineColor(eventLineColor)
-      .eventShape(eventShape)
-      .eventPopover(eventPopover)
-      .context(context)
-      .slider(slider)
-      .eventGrouping(eventGrouping)
+    .start(start)
+    .end(end)
+    .minScale(minScale)
+    .maxScale(maxScale)
+    .width(width)
+    .padding(padding)
+    .lineHeight(lineHeight)
+    .contextHeight(contextHeight)
+    .locale(locale)
+    .axisFormat(axisFormat)
+    .tickFormat(tickFormat)
+    .eventHover(eventHover)
+    .eventZoom(eventZoom)
+    .eventClick(eventClick)
+    .eventColor(eventColor)
+    .eventLineColor(eventLineColor)
+    .eventShape(eventShape)
+    .eventPopover(eventPopover)
+    .context(context)
+    .slider(slider)
+    .eventGrouping(eventGrouping)
+    .dateFormat(dateFormat)
   }
 
   function buildTimeline (config, data) {
     d3.select($element[0])
-      .append('div').attr('class', 'timeline')
-      .datum(data)
-      .call(config)
+    .append('div').attr('class', 'timeline')
+    .datum(data)
+    .call(config)
   }
 }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1490510

Ensures dateFormat on d3.timeline is informed by local option flag
Removes min/max scale suggested defaults

No ux changes here, just addressing the bz

![snapshots](https://user-images.githubusercontent.com/6640236/30927318-1bb8da48-a386-11e7-8a24-6b14e34e914b.gif)



@sshveta