### PR TITLE
Replace 'Self Service' for 'Service UI' text

### DIFF
--- a/client/app/skin/skin.module.js
+++ b/client/app/skin/skin.module.js
@@ -1,9 +1,9 @@
 const text = {
   app: {
-    name: 'ManageIQ Self Service'
+    name: 'ManageIQ Service UI'
   },
   login: {
-    brand: '<strong>ManageIQ</strong> Self Service'
+    brand: '<strong>ManageIQ</strong> Service UI'
   }
 }
 

--- a/client/app/states/_states.sass
+++ b/client/app/states/_states.sass
@@ -4,7 +4,7 @@
 
 .splash__message
   &::before
-    content: 'ManageIQ Self Service'
+    content: 'ManageIQ Service UI'
 
 @import '404/404'
 @import 'login/login'

--- a/client/app/states/login/login.state.spec.js
+++ b/client/app/states/login/login.state.spec.js
@@ -22,7 +22,7 @@ describe('State: login', () => {
       });
 
       it('sets app brand', () => {
-        expect(ctrl.text.brand).to.equal('<strong>ManageIQ</strong> Self Service');
+        expect(ctrl.text.brand).to.equal('<strong>ManageIQ</strong> Service UI');
       });
     });
   });


### PR DESCRIPTION
Sooo it was pointed out 👉 : [September 28, 2017 5:52 AM](https://gitter.im/ManageIQ/manageiq-ui-service?at=59ccc64c177fb9fe7e11badc) we're still throwing out 'Self Service' in some places, this does not align with da past edict which state, 
> Thou shal now be the Service UI, sans all self

This pr fulfills that edict. 

Flagging ux to check that the words are alright. 