### PR TITLE
Reorder build commands, production env now set correctly for webpacking

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "version": "1.0.1",
   "scripts": {
-    "build": "NODE_ENV=\"production\" yarn build:git-hash && webpack --bail --progress --profile --config config/webpack.prod.js",
+    "build": "yarn build:git-hash && NODE_ENV=\"production\" webpack --bail --progress --profile --config config/webpack.prod.js",
     "build:git-hash": "node config/githash.js",
     "build:static": "webpack --bail --progress --profile --config config/webpack.static.js",
     "available-languages": "cd ./config/ && node available-languages.js",


### PR DESCRIPTION
closes #1036 

### Saul looking goooood here (image shows built, icons and git hash all present)
<img width="1001" alt="screen shot 2017-09-29 at 10 18 50 am" src="https://user-images.githubusercontent.com/6640236/31020031-b86ffeaa-a4ff-11e7-9b85-dbe357ac032a.png">
