### PR TITLE
BZ#1503287-Ensure we only fetch those services with display set to true

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.spec.js
+++ b/client/app/services/service-explorer/service-explorer.component.spec.js
@@ -75,7 +75,7 @@ describe('Component: serviceExplorer', () => {
   it('should make a query for services', () => {
     collectionsApiMock
       .expects('query')
-      .withArgs('services', {filter: ['ancestry=null']})
+      .withArgs('services', {filter: ['ancestry=null', 'display=true']})
       .returns(Promise.resolve())
 
     ctrl.resolveServices(20, 0)

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -266,7 +266,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
 
   // Private
   function getQueryFilters (filters = []) {
-    const queryFilters = ['ancestry=null']
+    const queryFilters = ['ancestry=null', 'display=true']
 
     filters.forEach((nextFilter) => {
       if (nextFilter.id === 'name') {

--- a/client/app/services/services-state.service.spec.js
+++ b/client/app/services/services-state.service.spec.js
@@ -34,7 +34,7 @@ describe('Services-state Service', function () {
     it('should be able to get a record count', () => {
       const collectionsApiSpy = sinon.stub(CollectionsApi, 'query').returns(Promise.resolve(successResponse));
       ServicesState.getServicesMinimal();
-      expect(collectionsApiSpy).to.have.been.calledWith('services', {filter: ['ancestry=null']});
+      expect(collectionsApiSpy).to.have.been.calledWith('services', {filter: ['ancestry=null', 'display=true']});
     });
     it('should be able to get service credentials', () => {
       const collectionsApiSpy = sinon.stub(CollectionsApi, 'get').returns(Promise.resolve(successResponse));
@@ -106,7 +106,7 @@ describe('Services-state Service', function () {
         attributes: ["picture", "picture.image_href", "chargeback_report", "evm_owner.userid", "v_total_vms", "power_state", "all_service_children", "tags"],
         auto_refresh: false,
         expand: "resources",
-        filter: ["ancestry=null"],
+        filter: ["ancestry=null", 'display=true'],
         limit: 5,
         offset: "0",
         sort_by: "name",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1503287

So the bz points out we don't filter services based on display, best place to do it is in the request, otherwise the pagination will get wacky (imagine, fetching first 20 services and if 18 of them were display none!!)