### PR TITLE
Adds loading spinner using pf-empty-state

### DIFF
--- a/client/app/shared/loading.component.js
+++ b/client/app/shared/loading.component.js
@@ -2,6 +2,13 @@ export const LoadingComponent = {
   bindings: {
     status: '<'
   },
-  template: '<div ng-if="$ctrl.status" class="drawer-pf-loading text-center">' +
-    '<span class="spinner spinner-xs spinner-inline"></span> {{ "Loading More" | translate }}  </div>'
+  controllerAs: 'vm',
+  controller: function () {
+    const vm = this
+    vm.config = {icon: 'spinner spinner-lg spinner-inline', title: __('Loading')}
+  },
+  template:
+    `
+    <pf-empty-state ng-if="vm.status" config="vm.config"></pf-empty-state>
+   `
 }


### PR DESCRIPTION
closes #1149 

## after
![loading](https://user-images.githubusercontent.com/6640236/32012959-8ea4f4bc-b987-11e7-912f-b3196886531b.gif)


## before
![orgload](https://user-images.githubusercontent.com/6640236/32012949-8912c2d6-b987-11e7-9c66-6d074cccc3af.gif)


as per https://github.com/patternfly/patternfly-design/issues/466

I know this design doesn't use words.... but it costs us nothing to add them, and only adds further clarity