### PR TITLE
clear user name field on failed login

### DIFF
--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -76,6 +76,7 @@ function StateController (exception, $state, Text, RBAC, API_LOGIN, API_PASSWORD
     })
     .catch((response) => {
       if (response.status === 401) {
+        vm.credentials.login = ''
         vm.credentials.password = ''
         const message = response.data.error.message
         Notifications.message('danger', '', __('Login failed, possibly invalid credentials. ') + `(${message})`, false)


### PR DESCRIPTION
based on discussion on a similar PR on the ops UI (https://github.com/ManageIQ/manageiq-ui-classic/pull/2514#issuecomment-339520635)
I'm suggesting we align across the two.

I would also appericiate help in how to test the fact
the field is actually empty.