### PR TITLE
BUG#1167-Restores rbac permissiosn and camera eventicon

### DIFF
--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -76,7 +76,7 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       actionName: 'delete',
       title: __('Delete Snapshot'),
       actionFn: deleteSnapshot,
-      permissions: vm.permissions.delete
+      permissions: vm.permissions.snapshotsDelete
     }]
 
     return menuActions.filter((item) => item.permissions)
@@ -120,7 +120,7 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       title: __('Create snapshot'),
       actionFn: processSnapshot,
       isDisabled: false,
-      permissions: vm.permissions.create
+      permissions: vm.permissions.snapshotsAdd
     }, {
       name: __('Delete All Snapshots'),
       actionName: 'delete',
@@ -189,6 +189,7 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       vm.tlOptions = {
         start: new Date(start.setHours(start.getHours() - 2)),
         end: new Date(end.setHours(end.getHours() + 2)),
+        eventShape: '\uf030',
         eventHover: showTooltip,
         eventGrouping: 60000,
         minScale: (week / month),


### PR DESCRIPTION
closes #1167 

Look camera icon is back!  also we have create in the main dropdown and delete in the row kebab

<img width="1259" alt="screen shot 2017-10-26 at 12 29 22 pm" src="https://user-images.githubusercontent.com/6640236/32065173-f4a3fc50-ba49-11e7-9172-b2451179a78a.png">
<img width="1258" alt="screen shot 2017-10-26 at 12 29 13 pm" src="https://user-images.githubusercontent.com/6640236/32065174-f4b07df4-ba49-11e7-92ff-7e81cc051106.png">

@Loicavenel @serenamarie125 did i miss anything on this page?
