### PR TITLE
Ensure correct noVNC location is used

### DIFF
--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -80,7 +80,7 @@ export function ConsolesFactory ($window, CollectionsApi, $timeout, $location, E
   }
 
   function openVnc (results) {
-    var url = '/ui/service/vendor/no-vnc/vnc_auto.html' +
+    var url = '/ui/service/vendor/noVNC/vnc_auto.html' +
       '?host=' + $location.host() +
       '&port=' + $location.port() +
       '&path=' + results.url +

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -160,7 +160,7 @@ module.exports = {
     new CopyWebpackPlugin([
       {from: `${root}/assets`},
       {from: `${root}/gettext`, to: 'gettext'},
-      {from: `${nodeModules}/no-vnc`, to: 'vendor/no-vnc'},
+      {from: `${nodeModules}/noVNC`, to: 'vendor/noVNC'},
       {from: `${nodeModules}/spice-html5-bower`, to: 'vendor/spice-html5-bower'},
 
       // Override images with skin replacements if they exist


### PR DESCRIPTION
This pr updated no-vnc to noVNC (as per repo rename), this is a followup to that hotfix: https://github.com/ManageIQ/manageiq-ui-service/pull/1207