### PR TITLE
BZ#1507108-"filter", is correct option, subquery_count (to display filter results)

### DIFF
--- a/client/app/core/navigation.service.js
+++ b/client/app/core/navigation.service.js
@@ -90,12 +90,12 @@ export function NavigationFactory (RBAC, Polling, POLLING_INTERVAL, CollectionsA
     const options = {
       hide: 'resources',
       auto_refresh: true,
-      filters: [filter]
+      filter: [filter]
     }
     return new Promise((resolve, reject) => {
       CollectionsApi.query(field, options)
       .then((data) => {
-        resolve(data.count)
+        resolve(data.subquery_count)
       })
     })
   }


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1507108

Looks like we had a regression from https://github.com/ManageIQ/manageiq-ui-service/pull/1117

CollectionsApi service uses "filter" as the option from which to build the filter chain
When filtering on a query, subquery_count will display the count of the query (where count will display the total results, sans influence of options)

### previously My Orders had a count of 7 😭, but checkit below, working!! 🙌 
<img width="1108" alt="screen shot 2017-11-06 at 4 51 34 pm" src="https://user-images.githubusercontent.com/6640236/32466010-7b8f36b8-c313-11e7-8a38-8697925161cf.png">
