### PR TITLE
Ensure correct compliance icon, 7 day timeline, last hour utilization

### DIFF
--- a/client/app/services/usage-graphs/usage-graphs.component.spec.js
+++ b/client/app/services/usage-graphs/usage-graphs.component.spec.js
@@ -54,9 +54,9 @@ describe('Component: usageGraphs', () => {
   })
   it('Chart availble values match', () => {
     const graphs = element[0].querySelectorAll('.metric-number')
-    expect(graphs[0].innerHTML).to.eq('1000')
-    expect(graphs[1].innerHTML).to.eq('6')
-    expect(graphs[2].innerHTML).to.eq('38')
+    expect(graphs[0].innerHTML).to.eq('1,000.000')
+    expect(graphs[1].innerHTML).to.eq('6.000')
+    expect(graphs[2].innerHTML).to.eq('38.000')
   })
 })
 

--- a/client/app/services/usage-graphs/usage-graphs.html
+++ b/client/app/services/usage-graphs/usage-graphs.html
@@ -7,7 +7,7 @@
         <div class="metric-title" translate>CPU</div>
         <div ng-if="vm.cpuDataExists">
             <div class="metric-details-container">
-                <span class="metric-number">{{vm.availableCPU}}</span>
+                <span class="metric-number">{{vm.availableCPU | number:3}}</span>
                 <span class="metric-details">
                 <p>{{vm.cpuChart.config.units}} {{'Available' | translate}}</p>
                 <p>{{'of' | translate }} {{vm.cpuChart.data.total}}{{vm.cpuChart.config.units}}</p>
@@ -23,7 +23,7 @@
         <div class="metric-title" translate>Memory</div>
         <div ng-if="vm.memoryDataExists">
             <div class="metric-details-container">
-                <span class="metric-number">{{vm.availableMemory}}</span>
+                <span class="metric-number">{{vm.availableMemory | number:3}}</span>
                 <span class="metric-details">
                     <p>{{vm.memoryChart.config.units}} {{'Available' | translate}}</p>
                     <p>{{'of' | translate }} {{vm.memoryChart.data.total}}{{vm.memoryChart.config.units}}</p>
@@ -39,7 +39,7 @@
         <div class="metric-title" translate>Storage</div>
         <div ng-if="vm.storageDataExists">
             <div class="metric-details-container">
-                <span class="metric-number">{{vm.availableStorage}}</span>
+                <span class="metric-number">{{vm.availableStorage | number:3}}</span>
                 <span class="metric-details">
                     <p>{{vm.storageChart.config.units}} {{'Available' | translate}}</p>
                     <p>{{'of' | translate }} {{vm.storageChart.data.total}}{{vm.storageChart.config.units}}</p>

--- a/client/gettext/po/manageiq-ui-service.pot
+++ b/client/gettext/po/manageiq-ui-service.pot
@@ -8,21 +8,17 @@ msgstr ""
 msgid "$0"
 msgstr ""
 
+#: ./client/app/services/resource-details/resource-details.component.js:215
+msgid "%"
+msgstr ""
+
 #: ./client/app/components/notifications/notification-body.html:22
 #: ./client/app/components/notifications/notification-body.html:47
 msgid "% Complete"
 msgstr ""
 
-#: ./client/app/shared/action-button-group/action-button-group.component.js:31
+#: ./client/app/shared/action-button-group/action-button-group.component.js:32
 msgid "%s"
-msgstr ""
-
-#: ./client/app/services/vm-details/vm-details.component.js:123
-msgid "%s is a retired resource"
-msgstr ""
-
-#: ./client/app/requests/order-explorer/order-explorer.component.js:296
-msgid "%s was duplicated, id # %d."
 msgstr ""
 
 #: ./client/app/services/edit-service-modal/edit-service-modal.component.js:31
@@ -49,28 +45,24 @@ msgstr ""
 msgid "(Current Group)"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:38
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:37
 msgid "1 Week"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:39
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:38
 msgid "2 Weeks"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:40
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:39
 msgid "3 Weeks"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:41
+#: ./client/app/states/dashboard/dashboard.state.js:204
+msgid "30 Days"
+msgstr ""
+
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:40
 msgid "4 Weeks"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.html:281
-msgid "<i class=\"fa fa-camera\"></i>Snapshots"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.html:298
-msgid "<i class=\"fa fa-window-maximize \"></i>Access"
 msgstr ""
 
 #: ./client/app/layouts/application.html:59
@@ -82,7 +74,11 @@ msgstr ""
 msgid "About Me"
 msgstr ""
 
-#: ./client/app/services/custom-button/custom-button.component.js:55
+#: ./client/app/services/service-details/service-details.html:285
+msgid "Access"
+msgstr ""
+
+#: ./client/app/services/custom-button/custom-button.component.js:60
 msgid "Action not able to submit."
 msgstr ""
 
@@ -95,11 +91,11 @@ msgstr ""
 msgid "Add to Shopping Cart"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:118
+#: ./client/app/core/navigation/navigation-controller.js:123
 msgid "Administration UI"
 msgstr ""
 
-#: ./client/app/requests/process-order-modal/process-order-modal.html:11
+#: ./client/app/orders/process-order-modal/process-order-modal.html:11
 msgid "Affected Order"
 msgstr ""
 
@@ -108,6 +104,10 @@ msgstr ""
 #: ./client/app/services/retire-remove-service-modal/retire-remove-service-modal.html:13
 #: ./client/app/services/retire-service-modal/retire-service-modal.html:25
 msgid "Affected Services"
+msgstr ""
+
+#: ./client/app/services/generic-objects-list/generic-objects-list.component.js:42
+msgid "An error occured"
 msgstr ""
 
 #: ./client/app/states/dashboard/dashboard.html:115
@@ -122,6 +122,10 @@ msgstr ""
 msgid "Are you sure you want to remove this item from your shopping cart?"
 msgstr ""
 
+#: ./client/app/services/vms.service.js:280
+msgid "Are you sure you want to retire"
+msgstr ""
+
 #: ./client/app/shared/confirmation/confirmation.directive.js:112
 msgid "Are you sure you wish to proceed?"
 msgstr ""
@@ -130,15 +134,18 @@ msgstr ""
 msgid "Are you sure you would like to clear all [[heading]]?"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:342
+#: ./client/app/services/service-details/service-details.html:329
 msgid "Are you sure you would like to retire this resource?"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:41
+#: ./client/app/services/resource-details/resource-details.component.js:49
+#: ./client/app/services/usage-graphs/usage-graphs.html:12
+#: ./client/app/services/usage-graphs/usage-graphs.html:28
+#: ./client/app/services/usage-graphs/usage-graphs.html:44
 msgid "Available"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:269
+#: ./client/app/services/service-details/service-details.html:252
 msgid "Boot Time: Unknown"
 msgstr ""
 
@@ -146,7 +153,7 @@ msgstr ""
 msgid "Browser Default"
 msgstr ""
 
-#: ./client/app/services/usage-graphs/usage-graphs.html:6
+#: ./client/app/services/usage-graphs/usage-graphs.html:7
 msgid "CPU"
 msgstr ""
 
@@ -198,35 +205,26 @@ msgstr ""
 msgid "Close"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:120
-msgid "Cluster"
-msgstr ""
-
 #: ./client/app/components/notifications/notification-body.html:53
 msgid "Completed:"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:162
-msgid "Compliance"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.component.js:334
+#: ./client/app/services/service-details/service-details.component.js:363
 msgid "Compute"
 msgstr ""
 
+#: ./client/app/services/services-state.service.js:218
 #: ./client/app/services/services-state.service.js:223
-#: ./client/app/services/services-state.service.js:228
-#: ./client/app/services/vm-details/vm-details.html:194
-#: ./client/app/services/vms/snapshots.component.js:132
-#: ./client/app/services/vms/snapshots.component.js:133
+#: ./client/app/services/vms/snapshots.component.js:134
+#: ./client/app/services/vms/snapshots.component.js:135
 msgid "Configuration"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:251
+#: ./client/app/services/services-state.service.js:246
 msgid "Confirm, would you like to remove this service?"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:165
+#: ./client/app/services/services-state.service.js:160
 msgid "Confirm, would you like to retire this service?"
 msgstr ""
 
@@ -234,31 +232,36 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.html:114
+#: ./client/app/services/service-explorer/service-explorer.html:115
 msgid "Cost not available"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:290
+#: ./client/app/services/resource-details/resource-details.component.js:323
+#: ./client/app/services/service-details/service-details.html:275
 msgid "Create"
 msgstr ""
 
 #: ./client/app/services/process-snapshots-modal/process-snapshots-modal.html:5
-#: ./client/app/services/vms/snapshots.component.js:116
+#: ./client/app/services/vms/snapshots.component.js:118
 msgid "Create Snapshot"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:118
+#: ./client/app/services/vms/snapshots.component.js:120
 msgid "Create snapshot"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:334
-#: ./client/app/services/service-explorer/service-explorer.html:161
-#: ./client/app/services/service-explorer/service-explorer.html:85
-#: ./client/app/services/vms/snapshots.component.js:105
+#: ./client/app/services/resource-details/resource-details.component.js:325
+msgid "Create snapshots"
+msgstr ""
+
+#: ./client/app/services/service-explorer/service-explorer.component.js:379
+#: ./client/app/services/service-explorer/service-explorer.html:162
+#: ./client/app/services/service-explorer/service-explorer.html:86
+#: ./client/app/services/vms/snapshots.component.js:107
 msgid "Created"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:106
+#: ./client/app/services/service-details/service-details.html:91
 msgid "Created On"
 msgstr ""
 
@@ -286,46 +289,50 @@ msgstr ""
 msgid "Currently Selected Group"
 msgstr ""
 
+#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:15
+msgid "Custom Button Details"
+msgstr ""
+
 #: ./client/app/states/services/custom_button_details/custom_button_details.html:10
 msgid "Custom Button:"
 msgstr ""
 
-#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:51
+#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:53
 msgid "Custom button action"
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:6
+#: ./client/app/core/navigation.service.js:17
 #: ./client/app/states/dashboard/dashboard.state.js:16
 msgid "Dashboard"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:73
+#: ./client/app/services/vms/snapshots.component.js:75
 #: ./client/app/services/vms/snapshots.html:37
 msgid "Delete"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:123
+#: ./client/app/services/vms/snapshots.component.js:125
 msgid "Delete All Snapshots"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:226
+#: ./client/app/services/vms/snapshots.component.js:236
 msgid "Delete All Snapshots on VM %s"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:222
-#: ./client/app/services/vms/snapshots.component.js:75
+#: ./client/app/services/vms/snapshots.component.js:232
+#: ./client/app/services/vms/snapshots.component.js:77
 msgid "Delete Snapshot"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:125
+#: ./client/app/services/vms/snapshots.component.js:127
 msgid "Delete all snapshots"
 msgstr ""
 
-#: ./client/app/requests/process-order-modal/process-order-modal.component.js:37
+#: ./client/app/orders/process-order-modal/process-order-modal.component.js:37
 msgid "Deleting order."
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:146
+#: ./client/app/services/vms/snapshots.component.js:148
 msgid "Deleting snapshot."
 msgstr ""
 
@@ -333,16 +340,12 @@ msgstr ""
 msgid "Denied Requests"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:120
-msgid "Deployment Role"
-msgstr ""
-
 #: ./client/app/catalogs/catalog-explorer.component.js:57
 #: ./client/app/services/edit-service-modal/edit-service-modal.html:12
 #: ./client/app/services/process-snapshots-modal/process-snapshots-modal.html:15
-#: ./client/app/services/service-details/service-details.html:66
-#: ./client/app/services/service-explorer/service-explorer.component.js:323
-#: ./client/app/services/vms/snapshots.component.js:93
+#: ./client/app/services/service-details/service-details.html:51
+#: ./client/app/services/service-explorer/service-explorer.component.js:330
+#: ./client/app/services/vms/snapshots.component.js:95
 #: ./client/app/shared/ss-card/ss-card.html:8
 msgid "Description"
 msgstr ""
@@ -355,6 +358,10 @@ msgstr ""
 msgid "Discard Changes"
 msgstr ""
 
+#: ./client/app/services/resource-details/resource-details.html:154
+msgid "Disk Usage"
+msgstr ""
+
 #: ./client/app/layouts/application.html:49
 msgid "Documentation"
 msgstr ""
@@ -365,34 +372,33 @@ msgid "Don't Change"
 msgstr ""
 
 #: ./client/app/core/shopping-cart/shopping-cart.html:29
-#: ./client/app/requests/order-explorer/order-explorer.component.js:118
 msgid "Duplicate"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:120
-msgid "Duplicate Order"
+#: ./client/app/states/catalogs/details/details.state.js:27
+msgid "Duplicate Service"
 msgstr ""
 
 #: ./client/app/states/catalogs/details/details.html:37
 msgid "Duplicate Shopping Cart Item"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:216
-#: ./client/app/services/services-state.service.js:234
-#: ./client/app/services/services-state.service.js:236
+#: ./client/app/services/service-explorer/service-explorer.component.js:214
+#: ./client/app/services/services-state.service.js:229
+#: ./client/app/services/services-state.service.js:231
 msgid "Edit"
 msgstr ""
 
 #: ./client/app/services/edit-service-modal/edit-service-modal.html:5
-#: ./client/app/services/service-explorer/service-explorer.component.js:218
+#: ./client/app/services/service-explorer/service-explorer.component.js:216
 msgid "Edit Service"
 msgstr ""
 
 #: ./client/app/core/tag-editor-modal/tag-editor-modal.html:5
+#: ./client/app/services/service-explorer/service-explorer.component.js:222
 #: ./client/app/services/service-explorer/service-explorer.component.js:224
-#: ./client/app/services/service-explorer/service-explorer.component.js:226
-#: ./client/app/services/services-state.service.js:204
-#: ./client/app/services/services-state.service.js:206
+#: ./client/app/services/services-state.service.js:199
+#: ./client/app/services/services-state.service.js:201
 msgid "Edit Tags"
 msgstr ""
 
@@ -409,7 +415,7 @@ msgstr ""
 msgid "Error creating snapshot."
 msgstr ""
 
-#: ./client/app/requests/process-order-modal/process-order-modal.component.js:37
+#: ./client/app/orders/process-order-modal/process-order-modal.component.js:37
 msgid "Error deleting order."
 msgstr ""
 
@@ -417,19 +423,19 @@ msgstr ""
 msgid "Error deleting service."
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:146
+#: ./client/app/services/vms/snapshots.component.js:148
 msgid "Error deleting snapshot."
 msgstr ""
 
-#: ./client/app/core/authorization.config.js:113
+#: ./client/app/core/authorization.config.js:115
 msgid "Error retrieving user info"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:236
+#: ./client/app/services/vms/snapshots.component.js:246
 msgid "Error reverting snapshot."
 msgstr ""
 
-#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:67
+#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:73
 msgid "Error setting ownership."
 msgstr ""
 
@@ -438,23 +444,23 @@ msgid "Filter by Catalog Name"
 msgstr ""
 
 #: ./client/app/catalogs/catalog-explorer.component.js:57
-#: ./client/app/services/service-explorer/service-explorer.component.js:323
-#: ./client/app/services/vms/snapshots.component.js:93
+#: ./client/app/services/service-explorer/service-explorer.component.js:330
+#: ./client/app/services/vms/snapshots.component.js:95
 msgid "Filter by Description"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:101
+#: ./client/app/orders/order-explorer/order-explorer.component.js:103
 msgid "Filter by ID"
 msgstr ""
 
 #: ./client/app/catalogs/catalog-explorer.component.js:56
-#: ./client/app/requests/order-explorer/order-explorer.component.js:100
-#: ./client/app/services/service-explorer/service-explorer.component.js:322
-#: ./client/app/services/vms/snapshots.component.js:92
+#: ./client/app/orders/order-explorer/order-explorer.component.js:102
+#: ./client/app/services/service-explorer/service-explorer.component.js:329
+#: ./client/app/services/vms/snapshots.component.js:94
 msgid "Filter by Name"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:102
+#: ./client/app/orders/order-explorer/order-explorer.component.js:104
 msgid "Filter by Order Date"
 msgstr ""
 
@@ -468,22 +474,17 @@ msgstr ""
 msgid "For Sizing"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:26
-#: ./client/app/services/service-details/service-details.component.js:27
-#: ./client/app/services/usage-graphs/usage-graphs.html:36
-#: ./client/app/services/usage-graphs/usage-graphs.html:60
-#: ./client/app/services/vm-details/vm-details.component.js:25
-#: ./client/app/services/vm-details/vm-details.component.js:26
+#: ./client/app/services/resource-details/resource-details.component.js:221
+#: ./client/app/services/resource-details/resource-details.component.js:227
 msgid "GB"
 msgstr ""
 
-#: ./client/app/services/usage-graphs/usage-graphs.html:35
-#: ./client/app/services/usage-graphs/usage-graphs.html:59
-msgid "GB Available"
+#: ./client/app/services/service-details/service-details.html:57
+msgid "GUID"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:72
-msgid "GUID"
+#: ./client/app/core/navigation/navigation-controller.js:262
+msgid "Group switching error:"
 msgstr ""
 
 #: ./client/app/states/help/help.html:1
@@ -495,6 +496,10 @@ msgstr ""
 msgid "Hosts"
 msgstr ""
 
+#: ./client/app/orders/request-list/requests-list.html:16
+msgid "ID"
+msgstr ""
+
 #: ./client/app/services/service-details/service-details-ansible.html:109
 msgid "Id"
 msgstr ""
@@ -503,15 +508,11 @@ msgstr ""
 msgid "If you do not save, any changes will be lost."
 msgstr ""
 
-#: ./client/app/core/authentication-api.factory.js:24
-msgid "Incorrect username or password."
-msgstr ""
-
-#: ./client/app/states/catalogs/details/details.state.js:145
+#: ./client/app/states/catalogs/details/details.state.js:179
 msgid "Item added to shopping cart"
 msgstr ""
 
-#: ./client/app/states/catalogs/details/details.state.js:143
+#: ./client/app/states/catalogs/details/details.state.js:177
 msgid "Item added to shopping cart, but it's a duplicate of an existing item"
 msgstr ""
 
@@ -519,27 +520,31 @@ msgstr ""
 msgid "Language"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:259
+#: ./client/app/services/resource-details/resource-details.html:99
+msgid "Last 7 days"
+msgstr ""
+
+#: ./client/app/services/service-details/service-details.html:242
 msgid "Last Boot"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:229
+#: ./client/app/services/service-details/service-details.html:212
 msgid "Latest"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:261
+#: ./client/app/services/service-details/service-details.html:244
 msgid "Latest Boot Time"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:232
+#: ./client/app/services/service-details/service-details.html:215
 msgid "Latest Snapshot Name"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:240
+#: ./client/app/services/service-details/service-details.html:223
 msgid "Latest Snapshot Timestamp"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:249
+#: ./client/app/services/service-details/service-details.html:232
 msgid "Latest Snapshot: Unknown"
 msgstr ""
 
@@ -547,9 +552,10 @@ msgstr ""
 msgid "Launched By"
 msgstr ""
 
+#: ./client/app/services/services-state.service.js:136
 #: ./client/app/services/services-state.service.js:141
-#: ./client/app/services/services-state.service.js:146
-#: ./client/app/services/vm-details/vm-details.html:92
+#: ./client/app/services/vms.service.js:273
+#: ./client/app/services/vms.service.js:278
 msgid "Lifecycle"
 msgstr ""
 
@@ -557,11 +563,15 @@ msgstr ""
 msgid "Live Ansible Play"
 msgstr ""
 
+#: ./client/app/shared/loading.component.js:8
+msgid "Loading"
+msgstr ""
+
 #: ./client/app/states/login/login.html:39
 msgid "Log In"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:119
+#: ./client/app/core/navigation/navigation-controller.js:124
 msgid "Log into the full administrative UI"
 msgstr ""
 
@@ -569,20 +579,17 @@ msgstr ""
 msgid "Login"
 msgstr ""
 
+#: ./client/app/states/login/login.state.js:82
+msgid "Login failed, possibly invalid credentials."
+msgstr ""
+
 #: ./client/app/layouts/application.html:104
 #: ./client/app/states/logout/logout.state.js:12
 msgid "Logout"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:28
-#: ./client/app/services/usage-graphs/usage-graphs.html:12
-#: ./client/app/services/usage-graphs/usage-graphs.service.spec.js:9
-#: ./client/app/services/vm-details/vm-details.component.js:27
+#: ./client/app/services/usage-graphs/usage-graphs.service.spec.js:10
 msgid "MHz"
-msgstr ""
-
-#: ./client/app/services/usage-graphs/usage-graphs.html:11
-msgid "MHz Available"
 msgstr ""
 
 #: ./client/app/states/error/error.html:3
@@ -594,7 +601,7 @@ msgid "Mark All Read"
 msgstr ""
 
 #: ./client/app/services/process-snapshots-modal/process-snapshots-modal.html:12
-#: ./client/app/services/usage-graphs/usage-graphs.html:30
+#: ./client/app/services/usage-graphs/usage-graphs.html:23
 msgid "Memory"
 msgstr ""
 
@@ -602,18 +609,18 @@ msgstr ""
 msgid "Monthly Charges - This Month To Date"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:95
+#: ./client/app/services/service-details/service-details.html:80
 msgid "Monthly Cost"
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:22
+#: ./client/app/core/navigation.service.js:39
 msgid "My Orders"
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:13
+#: ./client/app/core/navigation.service.js:23
+#: ./client/app/services/resource-details/resource-details.html:5
 #: ./client/app/services/service-details/service-details.html:5
 #: ./client/app/services/service-explorer/service-explorer.html:4
-#: ./client/app/services/vm-details/vm-details.html:5
 #: ./client/app/services/vms/snapshots.html:5
 #: ./client/app/states/services/reconfigure/reconfigure.html:3
 msgid "My Services"
@@ -622,19 +629,19 @@ msgstr ""
 #: ./client/app/catalogs/catalog-explorer.component.js:56
 #: ./client/app/catalogs/catalog-explorer.component.js:75
 #: ./client/app/catalogs/catalogs-state.service.js:7
-#: ./client/app/requests/order-explorer/order-explorer.component.js:100
-#: ./client/app/requests/order-explorer/order-explorer.component.js:108
-#: ./client/app/requests/orders-state.service.spec.js:27
+#: ./client/app/orders/order-explorer/order-explorer.component.js:102
+#: ./client/app/orders/order-explorer/order-explorer.component.js:110
+#: ./client/app/orders/orders-state.service.spec.js:29
 #: ./client/app/services/edit-service-modal/edit-service-modal.html:9
 #: ./client/app/services/service-details/service-details-ansible.html:101
 #: ./client/app/services/service-details/service-details-ansible.html:151
-#: ./client/app/services/service-details/service-details.html:60
-#: ./client/app/services/service-explorer/service-explorer.component.js:322
-#: ./client/app/services/service-explorer/service-explorer.component.js:335
+#: ./client/app/services/service-details/service-details.html:45
+#: ./client/app/services/service-explorer/service-explorer.component.js:329
+#: ./client/app/services/service-explorer/service-explorer.component.js:380
 #: ./client/app/services/services-state.service.js:8
 #: ./client/app/services/vms.service.js:8
-#: ./client/app/services/vms/snapshots.component.js:104
-#: ./client/app/services/vms/snapshots.component.js:92
+#: ./client/app/services/vms/snapshots.component.js:106
+#: ./client/app/services/vms/snapshots.component.js:94
 msgid "Name"
 msgstr ""
 
@@ -642,12 +649,8 @@ msgstr ""
 msgid "Name *"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:39
+#: ./client/app/services/resource-details/resource-details.component.js:47
 msgid "Never"
-msgstr ""
-
-#: ./client/app/services/vm-details/vm-details.component.js:113
-msgid "Never Verified"
 msgstr ""
 
 #: ./client/app/components/notifications/heading.html:2
@@ -655,26 +658,20 @@ msgstr ""
 msgid "New"
 msgstr ""
 
-#: ./client/app/shared/dialog-content/dialog-content.html:3
-msgid "No Provisioning Dialog Available."
+#: ./client/app/services/usage-graphs/usage-graphs.component.js:27
+msgid "No Information Available"
 msgstr ""
 
 #: ./client/app/services/vms/snapshots.html:9
 msgid "No Service"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:37
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:36
 msgid "No Warning"
 msgstr ""
 
 #: ./client/app/services/service-details/service-details-ansible.html:92
 msgid "No credentials available."
-msgstr ""
-
-#: ./client/app/services/usage-graphs/usage-graphs.html:21
-#: ./client/app/services/usage-graphs/usage-graphs.html:45
-#: ./client/app/services/usage-graphs/usage-graphs.html:69
-msgid "No data available"
 msgstr ""
 
 #: ./client/app/services/service-details/service-details-ansible.html:212
@@ -685,12 +682,16 @@ msgstr ""
 msgid "No plays available."
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:40
+#: ./client/app/services/resource-details/resource-details.component.js:48
 msgid "None"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:42
+#: ./client/app/services/resource-details/resource-details.component.js:50
 msgid "Not Available"
+msgstr ""
+
+#: ./client/app/states/dashboard/dashboard.state.js:215
+msgid "Not Retired"
 msgstr ""
 
 #: ./client/app/services/retire-service-modal/retire-service-modal.html:10
@@ -699,6 +700,10 @@ msgstr ""
 
 #: ./client/app/layouts/application.html:10
 msgid "Notifications"
+msgstr ""
+
+#: ./client/app/states/dashboard/dashboard.state.js:199
+msgid "Now"
 msgstr ""
 
 #: ./client/app/shared/action-button-group/action-button-group.html:20
@@ -710,13 +715,13 @@ msgstr ""
 msgid "Order"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.html:33
+#: ./client/app/orders/order-explorer/order-explorer.html:33
 msgid "Order #"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:102
-#: ./client/app/requests/order-explorer/order-explorer.component.js:110
-#: ./client/app/requests/orders-state.service.js:12
+#: ./client/app/orders/order-explorer/order-explorer.component.js:104
+#: ./client/app/orders/order-explorer/order-explorer.component.js:112
+#: ./client/app/orders/orders-state.service.js:12
 msgid "Order Date"
 msgstr ""
 
@@ -724,30 +729,30 @@ msgstr ""
 msgid "Order Details"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:101
-#: ./client/app/requests/order-explorer/order-explorer.component.js:109
+#: ./client/app/orders/order-explorer/order-explorer.component.js:103
+#: ./client/app/orders/order-explorer/order-explorer.component.js:111
 msgid "Order ID"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.html:47
+#: ./client/app/orders/order-explorer/order-explorer.html:48
 msgid "Ordered"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.html:4
+#: ./client/app/orders/order-explorer/order-explorer.html:4
 #: ./client/app/states/orders/details/details.html:5
 #: ./client/app/states/orders/explorer/explorer.state.js:11
 msgid "Orders"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:89
+#: ./client/app/services/service-details/service-details.html:74
 msgid "Owner"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:392
+#: ./client/app/services/service-details/service-details.html:388
 msgid "Parent Catalog Item"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:383
+#: ./client/app/services/service-details/service-details.html:379
 msgid "Parent Service"
 msgstr ""
 
@@ -767,7 +772,7 @@ msgstr ""
 msgid "Playbook"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.html:73
+#: ./client/app/services/service-explorer/service-explorer.html:74
 msgid "Playbook: [[playbook]]"
 msgstr ""
 
@@ -775,89 +780,79 @@ msgstr ""
 msgid "Plays"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:227
+#: ./client/app/services/vms/snapshots.component.js:237
 msgid "Please confirm, this action will delete all snapshots of vm %s"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:223
+#: ./client/app/services/vms/snapshots.component.js:233
 msgid "Please confirm, this action will delete snapshot %s"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:197
-#: ./client/app/services/services-state.service.js:200
+#: ./client/app/services/services-state.service.js:192
+#: ./client/app/services/services-state.service.js:195
 msgid "Policy"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:163
+#: ./client/app/services/resource-details/resource-details.component.js:384
 msgid "Power"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:170
-msgid "Power Management"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.component.js:140
-#: ./client/app/services/service-details/service-details.component.js:145
-#: ./client/app/services/vm-details/vm-details.component.js:162
+#: ./client/app/services/resource-details/resource-details.component.js:383
+#: ./client/app/services/service-details/service-details.component.js:160
+#: ./client/app/services/service-details/service-details.component.js:165
 msgid "Power Operations"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:184
-#: ./client/app/services/service-explorer/service-explorer.component.js:422
+#: ./client/app/services/service-details/service-details.html:169
+#: ./client/app/services/service-explorer/service-explorer.component.js:440
 msgid "Power State: Off"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:189
-#: ./client/app/services/service-explorer/service-explorer.component.js:421
+#: ./client/app/services/service-details/service-details.html:174
+#: ./client/app/services/service-explorer/service-explorer.component.js:439
 msgid "Power State: On"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:195
-#: ./client/app/services/service-explorer/service-explorer.component.js:423
+#: ./client/app/services/service-details/service-details.html:180
+#: ./client/app/services/service-explorer/service-explorer.component.js:441
 msgid "Power State: Unknown"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:101
+#: ./client/app/core/navigation/navigation-controller.js:105
 msgid "Product logo"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:52
-#: ./client/app/services/vm-details/vm-details.html:54
+#: ./client/app/services/service-details/service-details.html:37
 msgid "Properties"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:195
+#: ./client/app/services/service-details/service-details.component.js:214
 #: ./client/app/states/services/reconfigure/reconfigure.html:8
 msgid "Reconfigure"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:197
+#: ./client/app/services/service-details/service-details.component.js:216
 msgid "Reconfigure the Service"
 msgstr ""
 
-#: ./client/app/states/services/reconfigure/reconfigure.state.js:125
+#: ./client/app/states/services/reconfigure/reconfigure.state.js:84
 msgid "Reconfigure this service has been cancelled"
 msgstr ""
 
-#: ./client/app/shared/dialog-content/dialog-content.html:151
-msgid "Refresh"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.html:377
-#: ./client/app/services/vm-details/vm-details.html:108
+#: ./client/app/services/service-details/service-details.html:373
 msgid "Relationships"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.html:106
+#: ./client/app/services/service-explorer/service-explorer.html:107
 msgid "Relative current cost"
 msgstr ""
 
 #: ./client/app/core/shopping-cart/shopping-cart.html:16
 #: ./client/app/core/shopping-cart/shopping-cart.html:21
-#: ./client/app/requests/order-explorer/order-explorer.component.js:129
-#: ./client/app/services/service-explorer/service-explorer.component.js:256
-#: ./client/app/services/services-state.service.js:243
-#: ./client/app/services/services-state.service.js:245
+#: ./client/app/orders/order-explorer/order-explorer.component.js:122
+#: ./client/app/services/service-explorer/service-explorer.component.js:254
+#: ./client/app/services/services-state.service.js:238
+#: ./client/app/services/services-state.service.js:240
 msgid "Remove"
 msgstr ""
 
@@ -865,13 +860,13 @@ msgstr ""
 msgid "Remove Item"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:131
-#: ./client/app/requests/process-order-modal/process-order-modal.html:5
+#: ./client/app/orders/order-explorer/order-explorer.component.js:124
+#: ./client/app/orders/process-order-modal/process-order-modal.html:5
 msgid "Remove Order"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:258
-#: ./client/app/services/services-state.service.js:250
+#: ./client/app/services/service-explorer/service-explorer.component.js:256
+#: ./client/app/services/services-state.service.js:245
 msgid "Remove Service"
 msgstr ""
 
@@ -879,23 +874,28 @@ msgstr ""
 msgid "Remove Services"
 msgstr ""
 
+#: ./client/app/orders/order-explorer/order-explorer.html:103
+msgid "Reorder"
+msgstr ""
+
 #: ./client/app/services/service-details/service-details-ansible.html:60
 msgid "Repo Name"
 msgstr ""
 
-#: ./client/app/requests/requests-state.service.js:13
-msgid "Request Date"
-msgstr ""
-
-#: ./client/app/requests/order-explorer/order-explorer.html:81
+#: ./client/app/orders/order-explorer/order-explorer.html:82
 msgid "Request ID"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.html:96
+#: ./client/app/orders/order-explorer/order-explorer.html:97
 msgid "Request State"
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.html:39
+#: ./client/app/orders/request-list/requests-list.html:26
+msgid "Requested"
+msgstr ""
+
+#: ./client/app/orders/order-explorer/order-explorer.html:39
+#: ./client/app/orders/request-list/requests-list.html:21
 msgid "Requester"
 msgstr ""
 
@@ -904,7 +904,11 @@ msgstr ""
 msgid "Reset"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:152
+#: ./client/app/states/services/resource-details/details.state.js:12
+msgid "Resource Details"
+msgstr ""
+
+#: ./client/app/services/service-details/service-details.html:137
 msgid "Resources"
 msgstr ""
 
@@ -912,24 +916,28 @@ msgstr ""
 msgid "Results"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:343
-#: ./client/app/services/service-details/service-details.html:350
-#: ./client/app/services/service-explorer/service-explorer.component.js:240
-#: ./client/app/services/services-state.service.js:159
-#: ./client/app/services/services-state.service.js:160
-#: ./client/app/services/vm-details/vm-details.component.js:196
+#: ./client/app/services/resource-details/resource-details.component.js:417
+#: ./client/app/services/service-details/service-details.html:330
+#: ./client/app/services/service-details/service-details.html:337
+#: ./client/app/services/service-explorer/service-explorer.component.js:238
+#: ./client/app/services/services-state.service.js:154
+#: ./client/app/services/services-state.service.js:155
+#: ./client/app/services/vms.service.js:283
+#: ./client/app/services/vms.service.js:284
+#: ./client/app/services/vms.service.js:290
+#: ./client/app/services/vms.service.js:292
 msgid "Retire"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:341
+#: ./client/app/services/service-details/service-details.html:328
 msgid "Retire Resource"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:242
+#: ./client/app/services/service-explorer/service-explorer.component.js:240
 msgid "Retire Service"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:166
+#: ./client/app/services/services-state.service.js:161
 msgid "Retire Service Now"
 msgstr ""
 
@@ -937,13 +945,15 @@ msgstr ""
 msgid "Retire Services"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:198
+#: ./client/app/states/dashboard/dashboard.state.js:137
+msgid "Retire Status"
+msgstr ""
+
+#: ./client/app/services/resource-details/resource-details.component.js:419
 msgid "Retire the Service"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:57
-#: ./client/app/states/dashboard/dashboard.state.js:184
-#: ./client/app/states/dashboard/dashboard.state.js:192
+#: ./client/app/states/dashboard/dashboard.state.js:189
 msgid "Retired"
 msgstr ""
 
@@ -951,17 +961,16 @@ msgstr ""
 msgid "Retired Services"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:178
+#: ./client/app/services/service-details/service-details.html:163
 msgid "Retired resource"
 msgstr ""
 
 #: ./client/app/services/retire-service-modal/retire-service-modal.html:13
-#: ./client/app/services/service-explorer/service-explorer.component.js:336
-#: ./client/app/states/dashboard/dashboard.state.js:180
+#: ./client/app/services/service-explorer/service-explorer.component.js:381
 msgid "Retirement Date"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:113
+#: ./client/app/services/service-details/service-details.html:98
 msgid "Retirement State"
 msgstr ""
 
@@ -969,37 +978,45 @@ msgstr ""
 msgid "Retirement Warning"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.html:173
-#: ./client/app/services/service-explorer/service-explorer.html:97
+#: ./client/app/services/service-explorer/service-explorer.html:174
+#: ./client/app/services/service-explorer/service-explorer.html:98
 msgid "Retires"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:120
+#: ./client/app/services/service-details/service-details.html:105
 msgid "Retires On"
+msgstr ""
+
+#: ./client/app/states/dashboard/dashboard.state.js:198
+msgid "Retires between"
 msgstr ""
 
 #: ./client/app/states/dashboard/dashboard.html:33
 msgid "Retiring Soon"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:66
+#: ./client/app/services/vms/snapshots.component.js:68
 msgid "Revert"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:68
+#: ./client/app/services/vms/snapshots.component.js:70
 msgid "Revert Snapshot"
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:236
+#: ./client/app/services/vms/snapshots.component.js:246
 msgid "Reverting snapshot."
 msgstr ""
 
-#: ./client/app/core/event-notifications.service.js:42
+#: ./client/app/core/event-notifications.service.js:43
 msgid "Review the notification tray for results of this batch operation"
 msgstr ""
 
+#: ./client/app/core/navigation/navigation-controller.js:110
+msgid "SUI Version:"
+msgstr ""
+
 #: ./client/app/core/save-modal-dialog/save-modal-dialog.html:16
-#: ./client/app/shared/action-button-group/action-button-group.html:13
+#: ./client/app/shared/action-button-group/action-button-group.component.js:30
 msgid "Save"
 msgstr ""
 
@@ -1011,12 +1028,8 @@ msgstr ""
 msgid "Schedule Service Retirement"
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:75
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:74
 msgid "Scheduling retirement."
-msgstr ""
-
-#: ./client/app/services/vm-details/vm-details.html:183
-msgid "Security"
 msgstr ""
 
 #: ./client/app/services/ownership-service-modal/ownership-service-modal.html:20
@@ -1031,7 +1044,7 @@ msgstr ""
 msgid "Select an Owner"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:106
+#: ./client/app/core/navigation/navigation-controller.js:111
 msgid "Server Name:"
 msgstr ""
 
@@ -1040,7 +1053,7 @@ msgid "Service"
 msgstr ""
 
 #: ./client/app/catalogs/catalog-explorer.html:4
-#: ./client/app/core/navigation.config.js:31
+#: ./client/app/core/navigation.service.js:56
 msgid "Service Catalog"
 msgstr ""
 
@@ -1049,18 +1062,14 @@ msgstr ""
 msgid "Service Catalogs"
 msgstr ""
 
-#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:16
-msgid "Service Custom Button Details"
-msgstr ""
-
-#: ./client/app/services/service-details/service-details.component.js:33
+#: ./client/app/services/service-details/service-details.component.js:30
 #: ./client/app/states/services/details/details.state.js:12
-#: ./client/app/states/services/reconfigure/reconfigure.state.js:17
-#: ./client/app/states/services/reconfigure/reconfigure.state.js:39
+#: ./client/app/states/services/reconfigure/reconfigure.state.js:16
+#: ./client/app/states/services/reconfigure/reconfigure.state.js:38
 msgid "Service Details"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:82
+#: ./client/app/services/service-details/service-details.html:67
 msgid "Service Id"
 msgstr ""
 
@@ -1084,20 +1093,20 @@ msgstr ""
 msgid "Services Retired"
 msgstr ""
 
+#: ./client/app/services/service-explorer/service-explorer.component.js:230
 #: ./client/app/services/service-explorer/service-explorer.component.js:232
-#: ./client/app/services/service-explorer/service-explorer.component.js:234
-#: ./client/app/services/services-state.service.js:259
-#: ./client/app/services/services-state.service.js:261
+#: ./client/app/services/services-state.service.js:254
+#: ./client/app/services/services-state.service.js:256
 msgid "Set Ownership"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:248
-#: ./client/app/services/services-state.service.js:153
+#: ./client/app/services/service-explorer/service-explorer.component.js:246
+#: ./client/app/services/services-state.service.js:148
 msgid "Set Retirement"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:250
-#: ./client/app/services/services-state.service.js:151
+#: ./client/app/services/service-explorer/service-explorer.component.js:248
+#: ./client/app/services/services-state.service.js:146
 msgid "Set Retirement Dates"
 msgstr ""
 
@@ -1105,7 +1114,7 @@ msgstr ""
 msgid "Set Service Ownership"
 msgstr ""
 
-#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:67
+#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:73
 msgid "Setting ownership."
 msgstr ""
 
@@ -1125,10 +1134,13 @@ msgstr ""
 msgid "Shopping cart successfully ordered"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.html:154
-msgid "Show parent and child VMs"
+#: ./client/app/services/resource-details/resource-details.html:116
+msgid "Smart State Analysis"
 msgstr ""
 
+#: ./client/app/services/resource-details/resource-details.component.js:307
+#: ./client/app/services/resource-details/resource-details.component.js:308
+#: ./client/app/services/service-details/service-details.html:266
 #: ./client/app/services/vms/snapshots.component.js:23
 #: ./client/app/services/vms/snapshots.html:14
 #: ./client/app/services/vms/snapshots.html:42
@@ -1139,21 +1151,21 @@ msgstr ""
 msgid "Standard Out"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:150
-#: ./client/app/services/service-details/service-details.html:325
-#: ./client/app/services/service-explorer/service-explorer.component.js:269
-#: ./client/app/services/service-explorer/service-explorer.html:188
-#: ./client/app/services/vm-details/vm-details.component.js:172
+#: ./client/app/services/resource-details/resource-details.component.js:393
+#: ./client/app/services/service-details/service-details.component.js:169
+#: ./client/app/services/service-details/service-details.html:312
+#: ./client/app/services/service-explorer/service-explorer.component.js:267
+#: ./client/app/services/service-explorer/service-explorer.html:191
 msgid "Start"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:152
-#: ./client/app/services/vm-details/vm-details.component.js:174
+#: ./client/app/services/resource-details/resource-details.component.js:395
+#: ./client/app/services/service-details/service-details.component.js:171
 msgid "Start the Service"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:271
-#: ./client/app/services/service-explorer/service-explorer.html:188
+#: ./client/app/services/service-explorer/service-explorer.component.js:269
+#: ./client/app/services/service-explorer/service-explorer.html:191
 msgid "Start this service"
 msgstr ""
 
@@ -1171,25 +1183,25 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:157
-#: ./client/app/services/service-details/service-details.html:330
-#: ./client/app/services/service-explorer/service-explorer.component.js:277
-#: ./client/app/services/service-explorer/service-explorer.html:191
-#: ./client/app/services/vm-details/vm-details.component.js:180
+#: ./client/app/services/resource-details/resource-details.component.js:401
+#: ./client/app/services/service-details/service-details.component.js:176
+#: ./client/app/services/service-details/service-details.html:317
+#: ./client/app/services/service-explorer/service-explorer.component.js:275
+#: ./client/app/services/service-explorer/service-explorer.html:196
 msgid "Stop"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:159
-#: ./client/app/services/vm-details/vm-details.component.js:182
+#: ./client/app/services/resource-details/resource-details.component.js:403
+#: ./client/app/services/service-details/service-details.component.js:178
 msgid "Stop the Service"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:279
-#: ./client/app/services/service-explorer/service-explorer.html:191
+#: ./client/app/services/service-explorer/service-explorer.component.js:277
+#: ./client/app/services/service-explorer/service-explorer.html:196
 msgid "Stop this service"
 msgstr ""
 
-#: ./client/app/services/usage-graphs/usage-graphs.html:54
+#: ./client/app/services/usage-graphs/usage-graphs.html:39
 msgid "Storage"
 msgstr ""
 
@@ -1198,20 +1210,20 @@ msgstr ""
 msgid "Submit Request"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:164
-#: ./client/app/services/service-details/service-details.html:335
-#: ./client/app/services/service-explorer/service-explorer.component.js:285
-#: ./client/app/services/service-explorer/service-explorer.html:194
-#: ./client/app/services/vm-details/vm-details.component.js:188
+#: ./client/app/services/resource-details/resource-details.component.js:409
+#: ./client/app/services/service-details/service-details.component.js:183
+#: ./client/app/services/service-details/service-details.html:322
+#: ./client/app/services/service-explorer/service-explorer.component.js:283
+#: ./client/app/services/service-explorer/service-explorer.html:201
 msgid "Suspend"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:166
-#: ./client/app/services/vm-details/vm-details.component.js:190
+#: ./client/app/services/resource-details/resource-details.component.js:411
+#: ./client/app/services/service-details/service-details.component.js:185
 msgid "Suspend the Service"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:287
+#: ./client/app/services/service-explorer/service-explorer.component.js:285
 msgid "Suspend this service"
 msgstr ""
 
@@ -1224,7 +1236,8 @@ msgid "Tagging successful."
 msgstr ""
 
 #: ./client/app/core/tag-editor-modal/tag-editor-modal.html:11
-#: ./client/app/services/service-details/service-details.html:133
+#: ./client/app/services/resource-details/resource-details.html:131
+#: ./client/app/services/service-details/service-details.html:118
 msgid "Tags"
 msgstr ""
 
@@ -1232,8 +1245,10 @@ msgstr ""
 msgid "Tenant"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:59
-msgid "The contents of this page is a function of the current users's group."
+#: ./client/app/orders/request-list/requests-list.html:32
+#: ./client/app/orders/request-list/requests-list.html:35
+#: ./client/app/orders/request-list/requests-list.html:38
+msgid "The current approval status of the request"
 msgstr ""
 
 #: ./client/app/states/dashboard/dashboard.html:53
@@ -1256,7 +1271,7 @@ msgstr ""
 msgid "The page you requested cannot be found."
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:35
+#: ./client/app/core/navigation.service.js:67
 msgid "The total number of available catalogs"
 msgstr ""
 
@@ -1264,7 +1279,7 @@ msgstr ""
 msgid "There already is an identical item in the cart. Do you want to add it anyway?"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:337
+#: ./client/app/services/service-details/service-details.component.js:366
 msgid "There are no Compute Resources for this service."
 msgstr ""
 
@@ -1276,7 +1291,7 @@ msgstr ""
 msgid "There was a problem loading the page."
 msgstr ""
 
-#: ./client/app/states/catalogs/details/details.state.js:152
+#: ./client/app/states/catalogs/details/details.state.js:186
 msgid "There was an error adding to shopping cart:"
 msgstr ""
 
@@ -1284,41 +1299,35 @@ msgstr ""
 msgid "There was an error creating the snapshot."
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:300
-msgid "There was an error duplicating %s."
-msgstr ""
-
 #: ./client/app/services/edit-service-modal/edit-service-modal.component.js:32
 msgid "There was an error editing this service."
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:120
+#: ./client/app/services/service-details/service-details.component.js:91
 msgid "There was an error fetching this service."
 msgstr ""
 
-#: ./client/app/catalogs/catalog-explorer.component.js:114
+#: ./client/app/catalogs/catalog-explorer.component.js:104
 msgid "There was an error loading catalogs."
 msgstr ""
 
-#: ./client/app/requests/order-explorer/order-explorer.component.js:268
-#: ./client/app/requests/order-explorer/order-explorer.component.js:282
+#: ./client/app/orders/order-explorer/order-explorer.component.js:259
 msgid "There was an error loading orders."
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:193
+#: ./client/app/services/vms/snapshots.component.js:203
 msgid "There was an error loading snapshots."
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.component.js:356
-#: ./client/app/services/service-explorer/service-explorer.component.js:431
+#: ./client/app/services/service-explorer/service-explorer.component.js:449
 msgid "There was an error loading the services."
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:131
+#: ./client/app/services/resource-details/resource-details.component.js:293
 msgid "There was an error loading the vm details."
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:205
+#: ./client/app/services/vms/snapshots.component.js:215
 msgid "There was an error loading the vm."
 msgstr ""
 
@@ -1330,11 +1339,11 @@ msgstr ""
 msgid "There was an error removing one or more services."
 msgstr ""
 
-#: ./client/app/requests/process-order-modal/process-order-modal.component.js:42
+#: ./client/app/orders/process-order-modal/process-order-modal.component.js:42
 msgid "There was an error removing order"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:269
+#: ./client/app/services/service-details/service-details.component.js:288
 msgid "There was an error removing this service."
 msgstr ""
 
@@ -1342,12 +1351,12 @@ msgstr ""
 msgid "There was an error retiring this %s."
 msgstr ""
 
-#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:80
-#: ./client/app/services/service-details/service-details.component.js:328
+#: ./client/app/services/retire-service-modal/retire-service-modal.component.js:79
+#: ./client/app/services/service-details/service-details.component.js:357
 msgid "There was an error retiring this service."
 msgstr ""
 
-#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:72
+#: ./client/app/services/ownership-service-modal/ownership-service-modal.component.js:78
 msgid "There was an error saving ownership."
 msgstr ""
 
@@ -1360,8 +1369,8 @@ msgid "There was an error stopping this %s."
 msgstr ""
 
 #: ./client/app/core/shopping-cart/shopping-cart.component.js:46
-#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:89
-#: ./client/app/states/services/reconfigure/reconfigure.state.js:120
+#: ./client/app/states/services/custom_button_details/custom_button_details.state.js:104
+#: ./client/app/states/services/reconfigure/reconfigure.state.js:79
 msgid "There was an error submitting this request:"
 msgstr ""
 
@@ -1373,6 +1382,10 @@ msgstr ""
 msgid "There was an error tagging this service."
 msgstr ""
 
+#: ./client/app/services/resource-details/resource-details.html:98
+msgid "Timeline - Power Events"
+msgstr ""
+
 #: ./client/app/states/dashboard/dashboard.html:20
 msgid "Total Requests"
 msgstr ""
@@ -1381,15 +1394,15 @@ msgstr ""
 msgid "Total Services"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:217
+#: ./client/app/services/service-details/service-details.html:201
 msgid "Total Snapshots"
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:26
+#: ./client/app/core/navigation.service.js:50
 msgid "Total orders submitted"
 msgstr ""
 
-#: ./client/app/core/navigation.config.js:17
+#: ./client/app/core/navigation.service.js:33
 msgid "Total services ordered, both active and retired"
 msgstr ""
 
@@ -1397,15 +1410,11 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: ./client/app/services/vm-details/vm-details.component.js:115
-msgid "Unknown"
-msgstr ""
-
 #: ./client/app/services/consoles.service.js:66
 msgid "Unsupported console protocol returned."
 msgstr ""
 
-#: ./client/app/services/vms/snapshots.component.js:106
+#: ./client/app/services/vms/snapshots.component.js:108
 msgid "Updated"
 msgstr ""
 
@@ -1417,15 +1426,15 @@ msgstr ""
 msgid "User Default"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:107
+#: ./client/app/core/navigation/navigation-controller.js:112
 msgid "User Name:"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:108
+#: ./client/app/core/navigation/navigation-controller.js:113
 msgid "User Role:"
 msgstr ""
 
-#: ./client/app/states/login/login.state.js:47
+#: ./client/app/states/login/login.state.js:48
 msgid "User does not have privileges to login."
 msgstr ""
 
@@ -1437,12 +1446,8 @@ msgstr ""
 msgid "Utilization"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:306
+#: ./client/app/services/service-details/service-details.html:293
 msgid "VM Console"
-msgstr ""
-
-#: ./client/app/states/vms/details/details.state.js:12
-msgid "VM Details"
 msgstr ""
 
 #: ./client/app/states/vms/snapshots/snapshots.state.js:13
@@ -1453,24 +1458,23 @@ msgstr ""
 msgid "Verbosity"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:105
+#: ./client/app/core/navigation/navigation-controller.js:109
 msgid "Version:"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:287
+#: ./client/app/services/resource-details/resource-details.component.js:316
+#: ./client/app/services/service-details/service-details.html:272
 msgid "View"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:354
+#: ./client/app/services/service-details/service-details.html:341
 msgid ""
 "View\n"
-"                            Details"
+"                                                    Details"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:358
-msgid ""
-"View\n"
-"                            Graphs"
+#: ./client/app/services/resource-details/resource-details.component.js:318
+msgid "View snapshots"
 msgstr ""
 
 #: ./client/app/services/consoles.service.js:24
@@ -1494,19 +1498,19 @@ msgstr ""
 msgid "We apologize for the inconvenience."
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.html:311
+#: ./client/app/services/service-details/service-details.html:298
 msgid "Web Console"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:252
+#: ./client/app/services/services-state.service.js:247
 msgid "Yes, Remove Service"
 msgstr ""
 
-#: ./client/app/services/services-state.service.js:168
+#: ./client/app/services/services-state.service.js:163
 msgid "Yes, Retire Service Now"
 msgstr ""
 
-#: ./client/app/states/login/login.state.js:74
+#: ./client/app/states/login/login.state.js:73
 msgid "You do not have permission to view the Service UI. Contact your administrator to update your group permissions."
 msgstr ""
 
@@ -1522,55 +1526,56 @@ msgstr ""
 msgid "[[number]] VMs"
 msgstr ""
 
-#: ./client/app/requests/process-order-modal/process-order-modal.html:9
+#: ./client/app/orders/process-order-modal/process-order-modal.html:9
 msgid "and all of its service requests will be permanently removed!"
 msgstr ""
+
+#: ./client/app/orders/order-explorer/order-explorer.html:57
+msgid "item"
+msgid_plural "items"
+msgstr[0] ""
+msgstr[1] ""
 
 #: ./client/app/shared/pagination/pagination.html:12
 #: ./client/app/shared/pagination/pagination.html:5
 msgid "items"
 msgstr ""
 
-#: ./client/app/core/gettext.config.js:25
+#: ./client/app/core/gettext.config.js:24
 msgid "locale_name"
 msgstr ""
 
-#: ./client/app/services/usage-graphs/usage-graphs.html:12
-#: ./client/app/services/usage-graphs/usage-graphs.html:36
-#: ./client/app/services/usage-graphs/usage-graphs.html:60
+#: ./client/app/services/vms.service.js:280
+msgid "now?"
+msgstr ""
+
+#: ./client/app/services/usage-graphs/usage-graphs.html:13
+#: ./client/app/services/usage-graphs/usage-graphs.html:29
+#: ./client/app/services/usage-graphs/usage-graphs.html:45
 #: ./client/app/shared/pagination/pagination.html:29
 #: ./client/app/shared/pagination/pagination.html:32
 msgid "of"
 msgstr ""
 
-#: ./client/app/services/service-explorer/service-explorer.html:194
+#: ./client/app/services/service-explorer/service-explorer.html:201
 msgid "suspend this service"
 msgstr ""
 
-#: ./client/app/core/navigation/navigation-controller.js:212
+#: ./client/app/core/navigation/navigation-controller.js:182
 msgid "unread notifications"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:26
-#: ./client/app/services/service-details/service-details.component.js:27
-#: ./client/app/services/service-details/service-details.component.js:28
-#: ./client/app/services/usage-graphs/usage-graphs.service.spec.js:9
-#: ./client/app/services/vm-details/vm-details.component.js:25
-#: ./client/app/services/vm-details/vm-details.component.js:26
-#: ./client/app/services/vm-details/vm-details.component.js:27
+#: ./client/app/services/resource-details/resource-details.component.js:217
+#: ./client/app/services/resource-details/resource-details.component.js:223
+#: ./client/app/services/resource-details/resource-details.component.js:229
+#: ./client/app/services/usage-graphs/usage-graphs.service.spec.js:10
 msgid "used"
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:264
+#: ./client/app/services/service-details/service-details.component.js:283
 msgid "was removed."
 msgstr ""
 
-#: ./client/app/services/service-details/service-details.component.js:323
+#: ./client/app/services/service-details/service-details.component.js:352
 msgid "was retired."
 msgstr ""
-
-#: ./client/app/requests/order-explorer/order-explorer.html:55
-msgid "{{ $count }} item"
-msgid_plural "{{ $count }} items"
-msgstr[0] ""
-msgstr[1] ""


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1516807

**tl;dr**

* timeline, when empty shows 7 day range, set default timeline option to a 7 day period, this is then updated to better fit the events data 
* compliance icon is now correct, value is capitalized 
* utilization data now grabs the hour behind the latest (where as before it was grabbing the second item in an array), Ends up vm metrics stream sometimes returns two entries per hour, that means we need to find the one from the last hour, hence the .find 
* utilization available number has been truncated to three places  

### with events in timeline (after)
<img width="1504" alt="screen shot 2017-11-28 at 5 39 04 pm" src="https://user-images.githubusercontent.com/6640236/33348346-1ea229f8-d464-11e7-8c52-b30f10afa839.png">

### with events in timeline (before)
<img width="1524" alt="screen shot 2017-11-28 at 5 47 51 pm" src="https://user-images.githubusercontent.com/6640236/33348427-68fe3474-d464-11e7-825b-15321503c9a6.png">

<hr>

### without events in timeline (after)
<img width="1504" alt="screen shot 2017-11-28 at 5 38 48 pm" src="https://user-images.githubusercontent.com/6640236/33348347-1eac151c-d464-11e7-8f15-e4aef133658b.png">

### without events in timeline (before)  (you'll notice we're missing storage because we were grabbing the wrong hour)
<img width="1524" alt="screen shot 2017-11-28 at 5 48 29 pm" src="https://user-images.githubusercontent.com/6640236/33348482-94781ed0-d464-11e7-89de-4906d0f5dab6.png">

