### PR TITLE
BZ#1515039-Ensure cloud_credential is captured for representation

### DIFF
--- a/client/app/services/service-details/service-details-ansible.component.js
+++ b/client/app/services/service-details/service-details-ansible.component.js
@@ -37,7 +37,7 @@ function ComponentController (ModalService, ServicesState, lodash) {
 
   function fetchResources () {
     vm.loading = true
-    const credentialTypes = ['credential_id', 'network_credential_id', 'machine_credential_id']
+    const credentialTypes = ['credential_id', 'network_credential_id', 'machine_credential_id', 'cloud_credential_id']
 
     if (angular.isDefined(vm.service.options.config_info)) {
       vm.orcStacks = {}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1515039

Looks like we were not observing the cloud_credential_id 😭 🍧 

### After
<img width="1608" alt="screen shot 2017-11-30 at 10 04 27 am" src="https://user-images.githubusercontent.com/6640236/33437707-c46d3a00-d5b6-11e7-8c39-5bd72930758b.png">


### Before
<img width="1607" alt="screen shot 2017-11-30 at 10 05 28 am" src="https://user-images.githubusercontent.com/6640236/33437683-bbfe8ac2-d5b6-11e7-9815-9e782e210864.png">
