### PR TITLE
BZ#1517101-Adds empty state to service details relationship section

### DIFF
--- a/client/app/services/resource-details/resource-details.component.js
+++ b/client/app/services/resource-details/resource-details.component.js
@@ -55,10 +55,10 @@ function ComponentController ($state, $stateParams, VmsService, lodash, EventNot
         }
       },
       genInfo: {
-        'info': 'No Information Available'
+        'info': __('No data available')
       },
       provInfo: {
-        'info': ['No Information Available']
+        'info': [__('No data available')]
       },
       compliance: {
         'title': 'Compliance',
@@ -90,7 +90,7 @@ function ComponentController ($state, $stateParams, VmsService, lodash, EventNot
           }
         ]
       },
-      emptyState: {icon: 'pficon pficon-help', title: 'No Information Available'}
+      emptyState: {icon: 'pficon pficon-help', title: __('No data available')}
     })
     vm.today = new Date()
     vm.presentDate = new Date()

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -32,7 +32,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
       availableTags: [],
       credential: {},
       listActions: [],
-      emptyState: {icon: 'pficon pficon-help', title: 'No Information Available'},
+      emptyState: {icon: 'pficon pficon-help', title: __('No data available')},
       // Functions
       hasCustomButtons: hasCustomButtons,
       disableStopButton: disableStopButton,

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -32,6 +32,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
       availableTags: [],
       credential: {},
       listActions: [],
+      emptyState: {icon: 'pficon pficon-help', title: 'No Information Available'},
       // Functions
       hasCustomButtons: hasCustomButtons,
       disableStopButton: disableStopButton,

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -371,7 +371,9 @@
         <div class="panel-body">
             <section>
                 <h2 translate>Relationships</h2>
-                <div class="container-fluid">
+                <pf-empty-state ng-if="!vm.service.parent_service || !vm.service.service_template" config="vm.emptyState"></pf-empty-state>
+
+                <div class="container-fluid" ng-if="vm.service.parent_service || vm.service.service_template" >
                     <div class="row" ng-if="vm.service.parent_service">
                         <div class="col-sm-4">
                             <a href="#" ng-click="vm.gotoService(vm.service.parent_service)">{{vm.service.parent_service.name}}</a>

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -371,7 +371,7 @@
         <div class="panel-body">
             <section>
                 <h2 translate>Relationships</h2>
-                <pf-empty-state ng-if="!vm.service.parent_service || !vm.service.service_template" config="vm.emptyState"></pf-empty-state>
+                <pf-empty-state ng-if="!vm.service.parent_service && !vm.service.service_template" config="vm.emptyState"></pf-empty-state>
 
                 <div class="container-fluid" ng-if="vm.service.parent_service || vm.service.service_template" >
                     <div class="row" ng-if="vm.service.parent_service">
@@ -383,7 +383,7 @@
                             <span>{{vm.service.parent_service.description}}</span>
                         </div>
                     </div>
-                    <div class="row">
+                    <div class="row" ng-if="vm.service.service_template">
                         <div class="col-sm-4">
                             <a href="#" ng-click="vm.gotoCatalogItem()">{{vm.service.service_template.name}}</a>
                         </div>

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -30,7 +30,7 @@
     </actions>
 </pf-toolbar>
 <loading status="vm.loading"></loading>
-<div ng-if="!vm.loading" class="ss-details-wrapper">
+<div ng-if="!vm.loading" class="ss-details-wrapper ss-details-wrapper-with-toolbar">
     <div class="panel panel-default ss-details-panel">
         <div class="panel-body">
             <section>

--- a/client/app/services/usage-graphs/usage-graphs.component.js
+++ b/client/app/services/usage-graphs/usage-graphs.component.js
@@ -24,7 +24,7 @@ function ComponentController () {
       cpuDataExists: false,
       memoryDataExists: false,
       storageDataExists: false,
-      emptyState: {icon: 'pficon pficon-help', title: __('No Information Available')}
+      emptyState: {icon: 'pficon pficon-help', title: __('No data available')}
     })
 
     if (vm.cpuChart.data.total > 0) {


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1517101

When no relationship information was available, we were showing the title with an empty body (made it look like a bug).  This fix adds the pf-empty state to the body that clearly indicates no information is available 

### After (two examples, cuz its nice to see different types)
<img width="1826" alt="screen shot 2017-11-30 at 10 13 38 am" src="https://user-images.githubusercontent.com/6640236/33437945-73cce270-d5b7-11e7-8ce4-b5035b8e170f.png">
<img width="1826" alt="screen shot 2017-11-30 at 10 13 38 am" src="https://user-images.githubusercontent.com/6640236/33438132-f1d43c18-d5b7-11e7-8473-9f6a8d00cc08.png">



### Before (two examples, cuz its nice to see different types)
<img width="1828" alt="screen shot 2017-11-30 at 10 14 13 am" src="https://user-images.githubusercontent.com/6640236/33437948-7821e7f8-d5b7-11e7-9002-249cb690109b.png">
<img width="1281" alt="screen shot 2017-11-30 at 10 19 32 am" src="https://user-images.githubusercontent.com/6640236/33438161-ff423c6a-d5b7-11e7-8482-e3d8690491ec.png">

