### PR TITLE
Notifications should gated on sui_notification product feature

### DIFF
--- a/client/app/core/event-notifications.service.spec.js
+++ b/client/app/core/event-notifications.service.spec.js
@@ -1,10 +1,13 @@
-/* global EventNotifications, CollectionsApi */
+/* global readJSON, RBAC, EventNotifications, CollectionsApi */
 /* eslint-disable no-unused-expressions */
 describe('Event Notifications Service', () => {
+  const permissions = readJSON('tests/mock/rbac/allPermissions.json')
+
   beforeEach(() => {
     module('app.core')
-    bard.inject('CollectionsApi', 'EventNotifications')
+    bard.inject('CollectionsApi', 'EventNotifications', 'RBAC')
     EventNotifications.setToastDisplay(true)
+    RBAC.set(permissions)
   })
   const successResponse = {}
   it('should allow a batch of notifications to be added', () => {


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=1518279

~~### this needs to be merged first https://github.com/ManageIQ/manageiq/pull/16817~~

Ok I could see how this bz might cause a much heartbreak though... a bunch of existing roles that have sui_product features, **do not** have the product feature `sui_core` or `sui_notifications`

for instance, `EvmRole-vm_user` has 
  - sui_vm_details_view
  - sui_vm_console
  - sui_vm_web_console
  - sui_vm_tags
  - sui_vm_retire
  - sui_vm_start
  - sui_vm_stop
  - sui_vm_suspend
  - sui_orders_show
  - sui_orders_operations

and is missing core or notifications... so this user would NOT see notifications

SOOO @Loicavenel @chriskacerguis maybe we should revisit  `miq_user_roles.yml` and add more product features (specifically everything under `sui_core`) to each role that has any sui product features?