### PR TITLE
BZ#1518390-Pass additional information to the API when refreshing a dialog field

### DIFF
--- a/client/app/core/dialog-field-refresh.service.js
+++ b/client/app/core/dialog-field-refresh.service.js
@@ -10,17 +10,20 @@ export function DialogFieldRefreshFactory (CollectionsApi) {
 
   return service
 
-  function refreshDialogField (dialogData, dialogField, url, resourceId) {
+  function refreshDialogField (dialogData, dialogField, url, idList) {
     return new Promise((resolve, reject) => {
       CollectionsApi.post(
         url,
-        resourceId,
+        idList.dialogId,
         {},
         angular.toJson({
           action: 'refresh_dialog_fields',
           resource: {
             dialog_fields: dialogData,
-            fields: dialogField
+            fields: dialogField,
+            resource_action_id: idList.resourceActionId,
+            target_id: idList.targetId,
+            target_type: idList.targetType
           }
         })
       ).then((response) => {

--- a/client/app/core/dialog-field-refresh.service.spec.js
+++ b/client/app/core/dialog-field-refresh.service.spec.js
@@ -5,76 +5,89 @@ describe('DialogFieldRefresh', () => {
     bard.inject('CollectionsApi', 'Notifications', 'DialogFieldRefresh')
   })
 
-  it('allows a dialog field to be refreshed', () => {
-    const successResponse = {
-      result: {
-        dialog1: {
-          data_type: 'string',
-          options: 'options',
-          read_only: false,
-          required: false,
-          values: 'Text'
+  describe('#refreshDialogField', () => {
+    it('allows a dialog field to be refreshed', () => {
+      const successResponse = {
+        result: {
+          dialog1: {
+            data_type: 'string',
+            options: 'options',
+            read_only: false,
+            required: false,
+            values: 'Text'
+          }
         }
       }
-    }
-    const collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
-    const dialogData = {
-      'dialog1': 'value1',
-      'dialog2': 'value2'
-    }
-    DialogFieldRefresh.refreshDialogField(dialogData, ['dialog1'], '/test/1', 1234).then((response) => {
-      expect(collectionsApiSpy).to.have.been.calledWith('/test/1',
-        1234,
-        {},
-        '{"action":"refresh_dialog_fields","resource":{"dialog_fields":{"dialog1":"value1","dialog2":"value2"},"fields":["dialog1"]}}')
+      const collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
+      const dialogData = {
+        'dialog1': 'value1',
+        'dialog2': 'value2'
+      }
+      const idList = {
+        dialogId: 1234,
+        resourceActionId: 4321,
+        targetId: 3241,
+        targetType: 'targetType'
+      }
+      DialogFieldRefresh.refreshDialogField(dialogData, ['dialog1'], '/test/1', idList).then((response) => {
+        expect(collectionsApiSpy).to.have.been.calledWith('/test/1',
+                                                          1234,
+                                                          {},
+                                                          '{"action":"refresh_dialog_fields","resource":{"dialog_fields":{"dialog1":"value1","dialog2":"value2"},"fields":["dialog1"], "resource_action_id": "4321", "target_id": "3241", "target_type": "targetType"}}')
+      })
+    })
+
+    it('reports back when a field fails to refresh', () => {
+      const dialogData = {
+        'dialog1': 'value1',
+        'dialog2': 'value2'
+      }
+      const idList = {
+        dialogId: 1234,
+        resourceActionId: 4321,
+        targetId: 3241,
+        targetType: 'targetType'
+      }
+      const failureResponse = {'status': 'failed'}
+      sinon.stub(CollectionsApi, 'post').returns(Promise.reject(failureResponse))
+      DialogFieldRefresh.refreshDialogField(dialogData, ['dialog1'], '/test/1', idList).then((response) => {
+
+      }).catch((err) => {
+        expect(err).to.eq(failureResponse)
+      })
     })
   })
 
-  it('reports back when a field fails to refresh', () => {
-    const dialogData = {
-      'dialog1': 'value1',
-      'dialog2': 'value2'
-    }
-    const failureResponse = {'status': 'failed'}
-    sinon.stub(CollectionsApi, 'post').returns(Promise.reject(failureResponse))
-    DialogFieldRefresh.refreshDialogField(dialogData, ['dialog1'], '/test/1', 1234).then((response) => {
-
-    }).catch((err) => {
-      expect(err).to.eq(failureResponse)
-    })
-  })
-  it('can override defaults values for a dialog', () => {
-    const testDialog = {
-      dialog_tabs: [
-        {
-          dialog_groups: [
-            {
-              dialog_fields: [
-                {'name': 'test1', 'default_value': 'test1'},
-                {'name': 'test2', 'default_value': 'test2'}
-              ]
-            }
-          ]
-        }
-      ]
-    }
-
-    const testValues = {
-      dialog_test1: 'modifiedTest1',
-      dialog_test2: 'modifiedTest2'
-    }
-
-    const expectedDialog = {
-      'dialog_tabs': [{
-        'dialog_groups': [{
-          'dialog_fields': [{
-            'name': 'test1',
-            'default_value': 'modifiedTest1'
-          }, {'name': 'test2', 'default_value': 'modifiedTest2'}]
+  describe('#setFieldValueDefaults', () => {
+    it('can override defaults values for a dialog', () => {
+      const testDialog = {
+        dialog_tabs: [{
+          dialog_groups: [{
+            dialog_fields: [
+              {'name': 'test1', 'default_value': 'test1'},
+              {'name': 'test2', 'default_value': 'test2'}
+            ]
+          }]
         }]
-      }]
-    }
-    const modifiedDialog = DialogFieldRefresh.setFieldValueDefaults(testDialog, testValues)
-    expect(modifiedDialog).to.deep.eq(expectedDialog)
+      }
+
+      const testValues = {
+        dialog_test1: 'modifiedTest1',
+        dialog_test2: 'modifiedTest2'
+      }
+
+      const expectedDialog = {
+        'dialog_tabs': [{
+          'dialog_groups': [{
+            'dialog_fields': [{
+              'name': 'test1',
+              'default_value': 'modifiedTest1'
+            }, {'name': 'test2', 'default_value': 'modifiedTest2'}]
+          }]
+        }]
+      }
+      const modifiedDialog = DialogFieldRefresh.setFieldValueDefaults(testDialog, testValues)
+      expect(modifiedDialog).to.deep.eq(expectedDialog)
+    })
   })
 })

--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -32,12 +32,13 @@ function getStates () {
 function StateController ($state, $stateParams, CollectionsApi, EventNotifications, DialogFieldRefresh) {
   var vm = this
   vm.title = __('Custom button action')
-  vm.dialogId = ''
+  vm.dialogId = $stateParams.dialogId || ''
   vm.dialogs = {}
   vm.service = {}
   vm.serviceId = $stateParams.serviceId
   vm.vmId = $stateParams.vmId || null
   vm.button = $stateParams.button
+  vm.resourceAction = vm.button.resource_action
   vm.submitCustomButton = submitCustomButton
   vm.submitButtonEnabled = false
   vm.dialogUrl = 'service_dialogs/'
@@ -48,7 +49,7 @@ function StateController ($state, $stateParams, CollectionsApi, EventNotificatio
 
   function init () {
     const options = {expand: 'resources', attributes: 'content'}
-    const dialogId = vm.button.resource_action.dialog_id
+    const dialogId = vm.resourceAction.dialog_id
     const resolveDialogs = CollectionsApi.query('service_dialogs/' + dialogId, options)
     const resolveService = CollectionsApi.get('services', $stateParams.serviceId, {attributes: ['picture', 'picture.image_href']})
 
@@ -63,7 +64,21 @@ function StateController ($state, $stateParams, CollectionsApi, EventNotificatio
   }
   init()
   function refreshField (field) {
-    return DialogFieldRefresh.refreshDialogField(vm.dialogData, [field.name], vm.dialogUrl, vm.dialogId)
+    let targetType = 'service'
+    let targetId = vm.serviceId
+    if (vm.vmId) {
+      targetType = 'vm'
+      targetId = vm.vmId
+    }
+
+    let idList = {
+      dialogId: vm.dialogId,
+      resourceActionId: vm.resourceAction.id,
+      targetId: targetId,
+      targetType: targetType
+    }
+
+    return DialogFieldRefresh.refreshDialogField(vm.dialogData, [field.name], vm.dialogUrl, idList)
   }
 
   function setDialogData (data) {


### PR DESCRIPTION
Very similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/2885, except for refreshing dialogs in the service UI.

The resource action id, target id, and target type need to be passed to the API in order to establish the context for dialog fields when they are refreshed via the /service_dialogs endpoint, otherwise certain automate methods can fail.

@miq-bot add_label gaprindashvili/yes, bug

There is no current BZ that deals with this since https://bugzilla.redhat.com/show_bug.cgi?id=1518390 is talking about the classic UI, but it's the closest relative. I just wanted to put this PR out there to get ahead of a potential BZ popping up with the same issue but for the service UI.

@chalettu Please review!