### PR TITLE
[WIP]Prevent duplicate notification creation to to notification queue

### DIFF
--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -154,26 +154,30 @@ export function EventNotificationsFactory ($timeout, lodash, CollectionsApi, Ses
     removeToast(notification)
     service.markRead(notification)
   }
+
   function setToastDisplay (enabled) {
     state.toastsEnabled = enabled
   }
+
   // Private
   function add (notificationType, type, message, notificationData, id) {
     const group = lodash.find(state.groups, {notificationType: notificationType})
-    const newNotification = {
-      id: id,
-      notificationType: notificationType,
-      unread: angular.isDefined(notificationData) ? notificationData.unread : true,
-      type: type,
-      message: message,
-      data: notificationData || {},
-      href: id ? '/api/notifications/' + id : undefined,
-      timeStamp: (new Date()).getTime()
-    }
+    if (!lodash.find(group.notifications, {message: message})) {
+      const newNotification = {
+        id: id,
+        notificationType: notificationType,
+        unread: angular.isDefined(notificationData) ? notificationData.unread : true,
+        type: type,
+        message: message,
+        data: notificationData || {},
+        href: id ? '/api/notifications/' + id : undefined,
+        timeStamp: (new Date()).getTime()
+      }
 
-    group.notifications.unshift(newNotification)
-    updateUnreadCount(group)
-    showToast(newNotification)
+      group.notifications.unshift(newNotification)
+      updateUnreadCount(group)
+      showToast(newNotification)
+    }
   }
 
   function asyncInit () {

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -278,7 +278,9 @@
                                         </ul>
                                     </div>
                                     <div class="btn-group dropdown-kebab-pf" uib-dropdown dropdown-append-to-body
-                                         ng-if="$ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.console">
+                                         ng-if="($ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.console)
+                                            && (item.supported_consoles.vnc.visible || item.supported_consoles.vnc.message
+                                            || item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message)">
                                         <button type="button" class="btn btn-default" uib-dropdown-toggle
                                                 type="button">
                                             <i class="fa fa-window-maximize "></i>

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -278,9 +278,7 @@
                                         </ul>
                                     </div>
                                     <div class="btn-group dropdown-kebab-pf" uib-dropdown dropdown-append-to-body
-                                         ng-if="($ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.console)
-                                            && (item.supported_consoles.vnc.visible || item.supported_consoles.vnc.message
-                                            || item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message)">
+                                         ng-if="$ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.console">
                                         <button type="button" class="btn btn-default" uib-dropdown-toggle
                                                 type="button">
                                             <i class="fa fa-window-maximize "></i>


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1516668
https://github.com/ManageIQ/manageiq-ui-service/pull/751 lives again!

When a new notification is identical (by message) to an existing one, the new one is not added to the notification queue, this prevents death by notifications 

### Death by notifications on the right, this in place on the left
<img width="1920" alt="screen shot 2017-12-07 at 4 35 24 pm" src="https://user-images.githubusercontent.com/6640236/33739861-a8fe0d1a-db6c-11e7-910a-08b89b3ccc81.png">
