### PR TITLE
BZ#1525880-Ensure service tag filters flagged for translation

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -361,13 +361,13 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
       ListView.createGenericField(
         {
           id: 'tags.name',
-          title: 'Tags',
-          placeholder: 'Filter by Tag Category',
+          title: __('Tags'),
+          placeholder: __('Filter by Tag Category'),
           filterType: 'complex-select',
           filterMultiselect: true,
           filterValues: filterValues,
           filterDelimiter: '/',
-          filterCategoriesPlaceholder: 'Filter by Tag Value  ',
+          filterCategoriesPlaceholder: __('Filter by Tag Value  '),
           filterCategories: filterCategories
         }
       )


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=1525880

The "results" and "selected text sadly aren't within our control, provided by ang-pf, looking into possible options for translating...