### PR TITLE
BZ#1525883-Add missing translation tags to order details view

### DIFF
--- a/client/app/states/orders/details/details.html
+++ b/client/app/states/orders/details/details.html
@@ -22,7 +22,7 @@
               </div>
               <div class="ss-details-header__title">
                 <h2>{{ ::vm.order.name }}</h2>
-                <h4>ordered {{ ::(vm.order.placed_at || vm.order.updated_at) | date }}</h4>
+                <h4> {{'ordered on' | translate}} {{ ::(vm.order.placed_at || vm.order.updated_at) | date }}</h4>
               </div>
             </div>
           </div>


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=1525883

So one might think that the "Order #" text is translatable, but it is in fact provided by the server, ends up ya can add names to orders, but if there is no, the default one shows up: https://github.com/ManageIQ/manageiq/blob/d3544b2c4d4a0c6796a236619349fa46bf57f2e7/app/models/service_order.rb#L35