### PR TITLE
Removes unnecessary header x-miq-group

### DIFF
--- a/client/app/core/authentication-api.factory.js
+++ b/client/app/core/authentication-api.factory.js
@@ -11,8 +11,7 @@ export function AuthenticationApiFactory ($http, $base64, API_BASE, Session, Not
       $http.get(API_BASE + '/api/auth?requester_type=ui', {
         headers: {
           'Authorization': 'Basic ' + $base64.encode([userLogin, password].join(':')),
-          'X-Auth-Token': undefined,
-          'X-Miq-Group': undefined
+          'X-Auth-Token': undefined
         }
       }).then(loginSuccess, loginFailure)
 

--- a/client/app/core/authentication-api.factory.spec.js
+++ b/client/app/core/authentication-api.factory.spec.js
@@ -19,8 +19,7 @@ describe('Authentication API', () => {
         'http://localhost:9876/api/auth?requester_type=ui', {
           'headers': {
             'Authorization': 'Basic dGVzdDp0ZXN0',
-            'X-Auth-Token': undefined,
-            'X-Miq-Group': undefined
+            'X-Auth-Token': undefined
           }
         })
     })

--- a/client/app/core/session.service.js
+++ b/client/app/core/session.service.js
@@ -31,15 +31,12 @@ export function SessionFactory ($http, $sessionStorage, $cookies, RBAC, Polling)
   }
 
   function setGroup (group) {
-    $http.defaults.headers.common['Accept'] = 'application/json;charset=UTF-8'
     if (typeof group === 'object') {
-      $http.defaults.headers.common['X-Miq-Group'] = group.description
       model.user.group = group.description
       model.user.group_href = group.href
       $sessionStorage.miqGroup = group.description
       $sessionStorage.selectedMiqGroup = group.description
     } else {
-      $http.defaults.headers.common['X-Miq-Group'] = group
       $sessionStorage.miqGroup = group
       $sessionStorage.selectedMiqGroup = group
       model.user.group = group
@@ -56,7 +53,6 @@ export function SessionFactory ($http, $sessionStorage, $cookies, RBAC, Polling)
     model.token = null
     model.user = {}
     destroyWsToken()
-    delete $http.defaults.headers.common['X-Miq-Group']
     delete $http.defaults.headers.common['X-Auth-Token']
     delete $sessionStorage.miqGroup
     delete $sessionStorage.selectedMiqGroup


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1531626

The sister has been slain, no longer a blocker, this pr is the winner ⚔️ 
~~This pr has a sister, https://github.com/ManageIQ/manageiq-api/pull/287 , another way to solve the above bz~~

 
In the past, was used for group switching: http://manageiq.org/docs/reference/latest/api/overview/authorization

This is now done through the api, this code is no longer needed and in fact creates the issue (bz above), tl;dr - special characters in headers are bad and not to spec

PS: Totally tested group switching and logging in with invalid groups, everything behaves identical to master