### PR TITLE
Reorders when service catalog filter is built

### DIFF
--- a/client/app/catalogs/catalog-explorer.component.js
+++ b/client/app/catalogs/catalog-explorer.component.js
@@ -90,13 +90,14 @@ function ComponentController ($state, CatalogsState, ListView, EventNotification
     return CatalogsState.getServiceTemplates(limit, offset).then(success, failure)
 
     function success (response) {
+      const serviceTemplateResultsCount = response.subquery_count
       CatalogsState.getCatalogs(limit, offset).then((response) => {
         vm.catalogsList = response.resources
+        vm.toolbarConfig.filterConfig = getFilterConfig()
+        vm.toolbarConfig.filterConfig.resultsCount = serviceTemplateResultsCount
         vm.loading = false
       })
       vm.serviceTemplateList = response.resources
-      vm.toolbarConfig.filterConfig = getFilterConfig()
-      vm.toolbarConfig.filterConfig.resultsCount = response.subquery_count
     }
 
     function failure (_error) {


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1536385

Async fun!  Looks like we were building the filter before we had what we needed, now we wait.

### oooo it works now!
<img width="744" alt="screen shot 2018-01-19 at 11 26 00 am" src="https://user-images.githubusercontent.com/6640236/35160586-90bef046-fd0b-11e7-9889-7cc409d11e16.png">
