### PR TITLE
We were still disabling snapsot revert for all but the current snapshot

### DIFF
--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -33,7 +33,6 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       deleteSnapshot: deleteSnapshot,
       revertSnapshot: revertSnapshot,
       cancelDelete: cancelDelete,
-      updateMenuActionForItemFn: updateMenuActionForItemFn,
       resolveVm: resolveVm,
       // Config
       listConfig: getListConfig(),
@@ -69,7 +68,6 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       actionName: 'revert',
       title: __('Revert Snapshot'),
       actionFn: revertSnapshot,
-      isDisabled: true,
       permissions: vm.permissions.revert
     }, {
       name: __('Delete'),
@@ -80,12 +78,6 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
     }]
 
     return menuActions.filter((item) => item.permissions)
-  }
-
-  function updateMenuActionForItemFn (action, item) {
-    if (action.actionName === 'revert') {
-      action.isDisabled = !item.current
-    }
   }
 
   function getFilterConfig () {

--- a/client/app/services/vms/snapshots.html
+++ b/client/app/services/vms/snapshots.html
@@ -45,8 +45,7 @@
     <pf-list-view
       config="vm.listConfig"
       items="vm.snapshots"
-      menu-actions="vm.menuActions"
-      update-menu-action-for-item-fn="vm.updateMenuActionForItemFn">
+      menu-actions="vm.menuActions">
       <div class="row">
         <div class="col-lg-2 col-md-2 col-sm-2 col-xs-2">
           <span class="no-wrap">


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533817

Now all snapshots can be reverted to and from

because one pr ( #1366 ) isn't enough to solve the problem

### puddin' PROOF
<img width="1255" alt="screen shot 2018-01-19 at 11 59 26 am" src="https://user-images.githubusercontent.com/6640236/35162118-43ae1340-fd10-11e7-8076-0ac0d456b558.png">
