### PR TITLE
Timelines: need to escape strings for the popover.

### DIFF
--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -286,15 +286,16 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       second: 'numeric'
     }
 
-    tooltip.html(
-      `
-        <div class="arrow"></div>
-        <div class="popover-content">
-          <div>Name: ${item.details.event}</div> 
-          <div>Date: ${item.date.toLocaleDateString('en-US', options)}</div>                    
-        </div>
-    `
-    )
+    let eventDetails = lodash.escape(item.details.event)
+
+    tooltip
+    .html(`
+      <div class="arrow"></div>
+      <div class="popover-content">
+        <div>Name: ${eventDetails}</div>
+        <div>Date: ${item.date.toLocaleDateString('en-US', options)}</div>
+      </div>
+    `)
 
     tooltip
     .style('left', `${left}px`)


### PR DESCRIPTION
Unlike Angular's `{{...}}`, javascript new template syntax does not escape HTML for you for free.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1517396

ping @AllenBW 