### PR TITLE
Refactors dashboard state resolve to return true on failed query

### DIFF
--- a/client/app/states/dashboard/dashboard.state.js
+++ b/client/app/states/dashboard/dashboard.state.js
@@ -31,7 +31,7 @@ function getStates () {
 
 function resolveAllRequests (CollectionsApi, RBAC) {
   if (!RBAC.has('miq_request_view')) {
-    return undefined
+    return true
   }
 
   return [
@@ -94,41 +94,42 @@ function deniedRequestsForServiceReconfigureRequest (CollectionsApi) {
 
 /** @ngInject */
 function resolveExpiringServices (CollectionsApi, RBAC) {
-  if (!RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
-    return undefined
-  }
-  var currentDate = new Date()
-  var date1 = 'retires_on>' + currentDate.toISOString()
-  var days30 = currentDate.setDate(currentDate.getDate() + 30)
-  var date2 = 'retires_on<' + new Date(days30).toISOString()
-  var options = {hide: 'resources', filter: ['retired=false', date1, date2]}
+  if (RBAC.has('service_view') && RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
+    const currentDate = new Date()
+    const date1 = 'retires_on>' + currentDate.toISOString()
+    const days30 = currentDate.setDate(currentDate.getDate() + 30)
+    const date2 = 'retires_on<' + new Date(days30).toISOString()
+    const options = {hide: 'resources', filter: ['retired=false', date1, date2]}
 
-  return CollectionsApi.query('services', options)
+    return CollectionsApi.query('services', options)
+  }
+
+  return true
 }
 
 /** @ngInject */
 function resolveRetiredServices (CollectionsApi, RBAC) {
-  if (!RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
-    return undefined
-  }
-  var options = {hide: 'resources', filter: ['service_id=nil', 'retired=true']}
+  if (RBAC.has('service_view') && RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
+    const options = {hide: 'resources', filter: ['service_id=nil', 'retired=true']}
 
-  return CollectionsApi.query('services', options)
+    return CollectionsApi.query('services', options)
+  }
+  return true
 }
 
 /** @ngInject */
 function resolveServicesWithDefinedServiceIds (CollectionsApi, RBAC) {
-  if (!RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
-    return undefined
+  if (RBAC.has('service_view') && RBAC.has(RBAC.FEATURES.SERVICES.VIEW)) {
+    const options = {
+      expand: 'resources',
+      filter: ['service_id=nil'],
+      attributes: ['chargeback_report']
+    }
+
+    return CollectionsApi.query('services', options)
   }
 
-  var options = {
-    expand: 'resources',
-    filter: ['service_id=nil'],
-    attributes: ['chargeback_report']
-  }
-
-  return CollectionsApi.query('services', options)
+  return true
 }
 
 /** @ngInject */


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1533222

If anything other than a truthy value is returned, ui-router's resolve flips out and throws a state change error.  SUI has state change errors written to then flipout and kick users outta da app.

So when the rbac doesn't match, the query wont be made, the 403 won't ever prevent the state from resolving.

Also, this functionality can't be gated on the `sui_services_view` product features, as this isn't the spice. IT ISN'T!  Meaning, sure, you can have that product feature on your role, but end of the day if you ping `api/services` its gonna 403 you back to 🕳 🔥 😟  (which is no bueno as mentioned above)

This state has gotta be rewritten to exclude `resolve` stat.

# 🌮 💃  🍿 (ie 🎥 😋 )(ie proof its working as desired)
![rbac](https://user-images.githubusercontent.com/6640236/35370539-65ed7180-015c-11e8-9454-2d1b3276aa20.gif)
