### PR TITLE
Create global variable for version of Patternfly

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -12,7 +12,7 @@ window.moment = require('moment')
 window.sprintf = require('sprintf-js').sprintf
 window.c3 = require('c3/c3.js')
 window.d3 = require('d3/d3.js')
-
+window.patternflyVersion = 4
 // Vendor libraries, order matters
 require('jquery-ui-bundle')
 require('moment-timezone')

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@angular/platform-browser-dynamic": "5.1.3",
     "@angular/upgrade": "5.1.3",
     "@manageiq/font-fabulous": "1.0.0",
-    "@manageiq/ui-components": "1.0.9",
+    "@manageiq/ui-components": "1.0.10",
     "@uirouter/angularjs": "1.0.12",
     "actioncable": "5.1.4",
     "angular": "1.6.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,9 +110,9 @@
     glob "^7.1.1"
     json-server "^0.9.6"
 
-"@manageiq/ui-components@1.0.8":
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.0.8.tgz#1b29cbb860cfdb665857bbd9fa55a9c90d7d2cec"
+"@manageiq/ui-components@1.0.10":
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.0.10.tgz#3040e96b54eb930ebf6f2292aaf476d90bafd978"
   dependencies:
     angular-bootstrap-switch "^0.5.1"
     angular-dragdrop "^1.0.13"


### PR DESCRIPTION
This was added in support of https://github.com/ManageIQ/ui-components/pull/249 which deals with different elements based on patternfly version in UI-components repo. 
@miq-bot add_label bug
@miq-bot add_label gaprindashvili/yes
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1539862