### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,0 @@
-# Each line is a file pattern followed by one or more owners.
-# Order is important; the last matching pattern takes the most
-# precedence.
-
-# BU and UX staff
-client/* @ManageIQ/core-business @ManageIQ/core-ux 
-
-# Primary owners
-* @chriskacerguis @allenbw @himdel 


### PR DESCRIPTION
Cc @AllenBW , @chalettu , @ohadlevy , WDYT?

As far as I know, the list of codeowners is pretty much identical to the list of mergers in the repo. Which IMO means we don't actually need the whole CODEOWNERS thing at all.

(And that BU and UX staff line doesn't seem to be doing anything, as pretty much every single PR touches `client/*`.)

Any objections? :)

---

Where this is coming from:

with codeowners enabled, I get an email for every opened SUI PR.
I don't want to be subscribed to every PR by default.
With codeowners, I see no other way to achieve that.
Without codeowners, you can still watch the repository to be notified of new PRs.
