### PR TITLE
Ensures service details custom buttons collapse to kebab when > 3

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -147,7 +147,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
     const groups = actions.button_groups || []
     const buttons = [].concat(actions.buttons, ...groups.map((g) => g.buttons))
 
-    return lodash.compact(buttons).length > 0
+    return lodash.compact(buttons).length
   }
 
   function getListActions () {

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -10,24 +10,32 @@
 </div>
 <pf-toolbar class="section-toolbar section-toolbar-right-actions" config="vm.headerConfig"
             ng-if="!vm.loading">
-    <actions>
-        <div class="ss-details-header__actions">
-            <div uib-dropdown class="ss-details-header__actions__inner dropdown-kebab-pf">
-                <custom-button ng-if="vm.hasCustomButtons(vm.service)"
-                               service-id="vm.service.id"
-                               custom-actions="vm.service.custom_actions">
-                </custom-button>
-                <custom-dropdown class="custom-dropdown pull-left"
-                                 config="item"
-                                 items="vm.selectedItemsList"
-                                 items-count="vm.selectedItemsListCount"
-                                 ng-repeat="item in vm.listActions"
-                                 on-update="vm.listActionDisable($config, $changes)"
-                                 menu-right="true">
-                </custom-dropdown>
-            </div>
-        </div>
-    </actions>
+  <actions>
+    <div class="ss-details-header__actions">
+      <div uib-dropdown class="ss-details-header__actions__inner dropdown-kebab-pf">
+        <custom-button
+          ng-if="vm.hasCustomButtons(vm.service) <= 3 && vm.hasCustomButtons(vm.service) > 0"
+          class="custom-dropdown pull-left"
+          service-id="vm.service.id"
+          custom-actions="vm.service.custom_actions">
+        </custom-button>
+        <custom-button-menu
+          service-id="vm.service.id"
+          ng-if="vm.hasCustomButtons(vm.service) > 3"
+          custom-actions="vm.service.custom_actions">
+        </custom-button-menu>
+        <custom-dropdown
+          class="custom-dropdown pull-left"
+          config="item"
+          items="vm.selectedItemsList"
+          items-count="vm.selectedItemsListCount"
+          ng-repeat="item in vm.listActions"
+          on-update="vm.listActionDisable($config, $changes)"
+          menu-right="true">
+        </custom-dropdown>
+      </div>
+    </div>
+  </actions>
 </pf-toolbar>
 <loading status="vm.loading"></loading>
 <div ng-if="!vm.loading" class="ss-details-wrapper ss-details-wrapper-with-toolbar">


### PR DESCRIPTION
continuation of https://bugzilla.redhat.com/show_bug.cgi?id=1524718

We might need a new bz for this... as the above one was to verify for resource details page... 🤔 

## on master, service details page, when with custom buttons looks like this
<img width="1099" alt="screen shot 2018-03-01 at 1 13 17 pm" src="https://user-images.githubusercontent.com/6640236/36862425-c467b798-1d54-11e8-8d5c-586d545fed4a.png">

## this work collapses these buttons when they exceed 3
<img width="1094" alt="screen shot 2018-03-01 at 1 13 39 pm" src="https://user-images.githubusercontent.com/6640236/36862424-c45264ce-1d54-11e8-9b55-a1f4e44467f7.png">

## to match current behavior observed in the resource details page
<img width="1507" alt="screen shot 2018-03-01 at 12 01 57 pm" src="https://user-images.githubusercontent.com/6640236/36862582-4498ae7c-1d55-11e8-903c-a439a53c41a4.png">
