### PR TITLE
custom-button-menu component styling remains consistent

### DIFF
--- a/client/app/services/custom-button-menu/custom-button-menu.html
+++ b/client/app/services/custom-button-menu/custom-button-menu.html
@@ -1,45 +1,45 @@
-<div uib-dropdown 
-     dropdown-append-to-body 
+<div uib-dropdown
+     dropdown-append-to-body
      class="pull-right dropdown-kebab-pf custom-button-menu">
-  <button uib-dropdown-toggle="" 
+  <button uib-dropdown-toggle=""
           class="btn btn-link"
           type="button">
     <span class="fa fa-ellipsis-v"></span>
   </button>
-  <ul uib-dropdown-menu 
-    class="dropdown-menu dropdown-menu-right dropdown-menu-appended-to-body">
+  <ul uib-dropdown-menu
+      class="dropdown-menu dropdown-menu-right dropdown-menu-appended-to-body">
     <li role="menuitem" ng-repeat="button in vm.customActions.buttons">
-        <a class="custom-button-action" 
-            ng-class="{'disabled': !button.enabled}"
-            ng-click="vm.invokeCustomAction(button)"  
-            uib-tooltip="{{ button.enabled ? button.description : button.disabled_text }}"
-            tooltip-placement="left">
-            <i ng-class="button.options.button_icon" 
-                ng-style="{color: button.options.button_color }">
-            </i>
-            {{button.name}}
-        </a>
+      <a class="custom-button-action"
+         ng-class="{'disabled': !button.enabled}"
+         ng-click="vm.invokeCustomAction(button)"
+         uib-tooltip="{{ button.enabled ? button.description : button.disabled_text }}"
+         tooltip-placement="left">
+        <i ng-class="button.options.button_icon"
+           ng-style="{color: button.options.button_color }">
+        </i>
+        {{button.name}}
+      </a>
     </li>
     <li role="menuitem" ng-repeat="buttonGroup in vm.customActions.button_groups" class="dropdown-submenu pull-left">
-        <a href="#">
+      <a href="#">
           <span>
             {{buttonGroup.name}}
           </span>
-        </a>
-        <ul uib-dropdown-menu class="scrollable-menu">
-            <li ng-repeat="button in buttonGroup.buttons">
-                <a class="custom-button-action" 
-                ng-class="{'disabled': !button.enabled}"
-                ng-click="vm.invokeCustomAction(button)"  
-                uib-tooltip="{{ button.enabled ? button.description : button.disabled_text }}"
-                tooltip-placement="left">
-                  <i ng-class="button.options.button_icon" 
-                    ng-style="{color: button.options.button_color }">
-                  </i>
-                {{button.name}}
-                </a>
-            </li>
-        </ul>
+      </a>
+      <ul uib-dropdown-menu class="scrollable-menu">
+        <li ng-repeat="button in buttonGroup.buttons">
+          <a class="custom-button-action"
+             ng-class="{'disabled': !button.enabled}"
+             ng-click="vm.invokeCustomAction(button)"
+             uib-tooltip="{{ button.enabled ? button.description : button.disabled_text }}"
+             tooltip-placement="left">
+            <i ng-class="button.options.button_icon"
+               ng-style="{color: button.options.button_color }">
+            </i>
+            {{button.name}}
+          </a>
+        </li>
+      </ul>
     </li>
   </ul>
 </div>

--- a/client/app/services/custom-button-menu/custom-button-menu.html
+++ b/client/app/services/custom-button-menu/custom-button-menu.html
@@ -26,8 +26,10 @@
             {{buttonGroup.name}}
           </span>
       </a>
-      <ul uib-dropdown-menu class="scrollable-menu">
-        <li ng-repeat="button in buttonGroup.buttons">
+      <ul uib-dropdown-menu class="dropdown-menu scrollable-menu">
+        <li
+          class="menuitem"
+          ng-repeat="button in buttonGroup.buttons">
           <a class="custom-button-action"
              ng-class="{'disabled': !button.enabled}"
              ng-click="vm.invokeCustomAction(button)"


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1552201

Mild continuation of this work, looks like custom-button-menu componet was a lil borked, didn't have the correct classes applied to the ui-bootstrap tool, this fixes both instances of its use, resource/service details pages.

## behavior after this pr
![dropdownmenu](https://user-images.githubusercontent.com/6640236/37040383-b5896c90-2127-11e8-9597-c3c788bee815.gif)

## behavior before this pr (wait for it, you wont be disappointed)
![dropdownmenufail](https://user-images.githubusercontent.com/6640236/37040394-bc87ad22-2127-11e8-8c38-52502121b408.gif)
