### PR TITLE
tolowercase of a null does not end well - breaks service explorer

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -97,7 +97,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
   function isAnsibleService (service) {
     var compareValue = angular.isDefined(service.type) ? service.type : service.name
 
-    return compareValue.toLowerCase().indexOf('ansible') !== -1
+    return compareValue ? compareValue.toLowerCase().includes('ansible') : false
   }
 
   function getListActions () {


### PR DESCRIPTION
Not sure how this went unnoticed, only an issue on master