### PR TITLE
Adds on-close to pf-notification-drawer component

### DIFF
--- a/client/app/core/navigation/navigation-controller.js
+++ b/client/app/core/navigation/navigation-controller.js
@@ -74,7 +74,7 @@ export function NavigationController (Text, Navigation, Session, API_BASE, Shopp
       notificationHTML: 'app/components/notifications/notification-body.html',
       notificationFooterHTML: 'app/components/notifications/notification-footer.html',
       handleItemClick: handleItemClick,
-      toggleNotificationsList: toggleNotificationsList,
+      toggleNotificationsList: () => { vm.notificationsDrawerShown = !vm.notificationsDrawerShown },
       updateViewingToast: updateViewingToast,
       handleDismissToast: handleDismissToast,
       getNotficationStatusIconClass: getNotficationStatusIconClass,
@@ -168,10 +168,6 @@ export function NavigationController (Text, Navigation, Session, API_BASE, Shopp
 
   function handleItemClick (item) {
     $state.transitionTo(item.state)
-  }
-
-  function toggleNotificationsList () {
-    vm.notificationsDrawerShown = !vm.notificationsDrawerShown
   }
 
   function getNotficationStatusIconClass (notification) {

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -5,12 +5,17 @@
     <pf-toast-notification-list notifications="vm.toastNotifications" show-close="true"
          close-callback="vm.handleDismissToast" update-viewing="vm.updateViewingToast"></pf-toast-notification-list>
 
-    <pf-notification-drawer drawer-hidden="!vm.notificationsDrawerShown" notification-groups="vm.notificationGroups"
-         allow-expand="true"
-         drawer-title="{{'Notifications' | translate}}" heading-include="{{vm.headingHTML}}"
-         subheading-include="{{vm.subHeadingHTML}}"
-         notification-body-include="{{vm.notificationHTML}}" notification-footer-include="{{vm.notificationFooterHTML}}"
-         custom-scope="vm" />
+    <pf-notification-drawer
+            drawer-hidden="!vm.notificationsDrawerShown"
+            notification-groups="vm.notificationGroups"
+            allow-expand="true"
+            on-close="vm.toggleNotificationsList"
+            drawer-title="{{'Notifications' | translate}}"
+            heading-include="{{vm.headingHTML}}"
+            subheading-include="{{vm.subHeadingHTML}}"
+            notification-body-include="{{vm.notificationHTML}}"
+            notification-footer-include="{{vm.notificationFooterHTML}}"
+            custom-scope="vm" >
     </pf-notification-drawer>
 
     <pf-about-modal additional-info="vm.about.additionalInfo" is-open="vm.about.isOpen"


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=1554809

does not modify default behavior of clicking the bell to open and close tray

### So we have this real narrow edge case of 20-30 pixels where yah can end up with this view:
<img width="774" alt="screen shot 2018-04-02 at 4 12 04 pm" src="https://user-images.githubusercontent.com/6640236/38213908-eb643326-3690-11e8-8250-99cad33b6ea2.png">


### In efforts to avoid this purgatory, unable to close notifications, proposing we do this, add a notification list close button (what this pr does): 
<img width="789" alt="screen shot 2018-04-02 at 4 09 34 pm" src="https://user-images.githubusercontent.com/6640236/38213931-fe628ff4-3690-11e8-9547-b91d0b32965b.png">


