### PR TITLE
Restores listview deafult row click behavior, expanding row content

### DIFF
--- a/client/app/orders/order-explorer/order-explorer.component.js
+++ b/client/app/orders/order-explorer/order-explorer.component.js
@@ -53,7 +53,6 @@ function ComponentController ($filter, $state, lodash, ListView, Language, Order
       showSelectBox: checkApproval(),
       useExpandingRows: true,
       selectionMatchProp: 'id',
-      onClick: expandRow,
       onCheckBoxChange: selectionChange
     }
   }
@@ -129,12 +128,6 @@ function ComponentController ($filter, $state, lodash, ListView, Language, Order
     }
 
     return checkApproval() ? menuActions : null
-  }
-
-  function expandRow (item) {
-    if (!item.disableRowExpansion) {
-      item.isExpanded = !item.isExpanded
-    }
   }
 
   function sortChange (sortId, direction) {


### PR DESCRIPTION
closes https://bugzilla.redhat.com/show_bug.cgi?id=1525546

Aligns order explorer with pfa design, when yah click a row with expanded content, whole row expands: 
http://www.patternfly.org/angular-patternfly/#/api/patternfly.views.component:pfListView

Looks like this
![pfselect](https://user-images.githubusercontent.com/6640236/38250689-7274fc56-371d-11e8-8bdf-ad4ec8fbcd46.gif)

and yah might be thinking.. yeah Allen, nice n all but what about the `disableRowExpansion` thing? 
That sucker is in place to not expand a row if there is nothing to expand, a pf 🐛 of yesteryear, nowahdays, when there's nothing to expand, yah see this, clicking does nada (notice the absence of the 🥕)
<img width="956" alt="screen shot 2018-04-03 at 8 58 18 am" src="https://user-images.githubusercontent.com/6640236/38250656-5c17f44a-371d-11e8-9c3a-5f06c3e52d40.png">
