### PR TITLE
Refactors ansible credentials to be more generic, override with dialog input

### DIFF
--- a/client/app/services/service-details/service-details-ansible.component.js
+++ b/client/app/services/service-details/service-details-ansible.component.js
@@ -37,7 +37,6 @@ function ComponentController (ModalService, ServicesState, lodash) {
 
   function fetchResources () {
     vm.loading = true
-    const credentialTypes = ['credential_id', 'network_credential_id', 'machine_credential_id', 'cloud_credential_id']
 
     if (angular.isDefined(vm.service.options.config_info)) {
       vm.orcStacks = {}
@@ -47,16 +46,23 @@ function ComponentController (ModalService, ServicesState, lodash) {
           vm.orcStacks[resourceName] = {}
           vm.orcStacks[resourceName].stack = lodash.find(vm.service.orchestration_stacks, {'id': resource.resource_id})
           vm.orcStacks[resourceName].resource = resource
-
           vm.orcStacks[resourceName].credentials = []
-          credentialTypes.forEach((credential) => {
-            if (angular.isDefined(vm.service.options.config_info[resourceName][credential])) {
-              ServicesState.getServiceCredential(vm.service.options.config_info[resourceName][credential]).then((response) => {
-                response.type = response.type.substring(response.type.lastIndexOf('::') + 2, response.type.lastIndexOf('Credential'))
-                vm.orcStacks[resourceName].credentials.push(response)
+
+          if (vm.service.options.dialog && resourceName === 'provision') {
+            Object.assign(
+              vm.service.options.config_info[resourceName],
+              ...Object.keys(vm.service.options.dialog)
+              .map(key => ({[normalizeDialogKeys(key)]: vm.service.options.dialog[key]}))
+            )
+          }
+
+          for (const configItem in vm.service.options.config_info[resourceName]) {
+            if (configItem.includes('credential')) {
+              ServicesState.getServiceCredential(vm.service.options.config_info[resourceName][configItem]).then((response) => {
+                vm.orcStacks[resourceName].credentials.push(processCredential(response))
               })
             }
-          })
+          }
 
           ServicesState.getServiceRepository(vm.service.options.config_info[resourceName].repository_id).then((response) => {
             vm.orcStacks[resourceName].repository = response
@@ -105,5 +111,16 @@ function ComponentController (ModalService, ServicesState, lodash) {
 
   function elapsed (finish, start) {
     return Math.abs(new Date(finish) - new Date(start)) / 1000
+  }
+
+  function processCredential (item) {
+    item.type = item.type.substring(item.type.lastIndexOf('::') + 2, item.type.lastIndexOf('Credential'))
+    return item
+  }
+
+  function normalizeDialogKeys (key) {
+    const normalizedKey = key.replace(/dialog_/i, '')
+
+    return normalizedKey === 'credential' ? 'credential_id' : normalizedKey
   }
 }


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1557504
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1540689

Also displays any config_info credential object with 'credential' in the key

This work follows the following assumptions: 
1. dialog objet will always over config info - for provision does not exist in reirement
2. dialog_credientail will always override credential_id
3. from the dialog object, to the config_info -  dialog_cloud_credential -> (normalized) cloud_credential - will override cloud_credential
4. when avaliable, all possible credential types will have "credentail" in the object key, and be contained in config info (if not overridden)

cc @bzwei - yer a flippin 🧙‍♂️ ❤️ 