### PR TITLE
pf-login - override patternfly login screen background image

### DIFF
--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -2,6 +2,7 @@
 
 .login-pf
   background-color: $app-color-deep-blue
+  background-image: none
   height: calc(100vh)
   margin-bottom: -38px
   margin-top: -60px


### PR DESCRIPTION
With the upgrade from patternfly 3.45 to 3.46, the login screen background changed.
That's because patternfly made using a background image the default, but we don't have one so the default one from patternfly gets used.

Overriding background-image for the login screen to achieve the original result.

Details in https://github.com/patternfly/patternfly/issues/1057

---

Before:

![bad](https://user-images.githubusercontent.com/289743/40242077-26fe7e0c-5aac-11e8-8895-45f90c6b937f.png)

After:

![good](https://user-images.githubusercontent.com/289743/40242068-223042fc-5aac-11e8-8241-d41e13b5a0b9.png)