### PR TITLE
Removes whitespace that breaks translation

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -367,7 +367,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
           filterMultiselect: true,
           filterValues: filterValues,
           filterDelimiter: '/',
-          filterCategoriesPlaceholder: __('Filter by Tag Value  '),
+          filterCategoriesPlaceholder: __('Filter by Tag Value'),
           filterCategories: filterCategories
         }
       )


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1525880

### Proooooof!  Look now its totally fixed <3
<img width="1019" alt="screen shot 2018-05-29 at 9 20 12 am" src="https://user-images.githubusercontent.com/6640236/40661706-729e0016-6322-11e8-8586-dd6983f79641.png">


Needs to be backported, translated string is present in g, but this space, that breaks the translation is also present 😭