### PR TITLE
Service retirement should use make retire as a request

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -346,7 +346,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   }
 
   function retireService () {
-    const data = {action: 'retire'}
+    const data = {action: 'request_retire'}
     CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure)
 
     function retireSuccess () {

--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -567,7 +567,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
           return services
         },
         modalType: function () {
-          return 'retire'
+          return 'request_retire'
         }
       }
     }

--- a/tests/mock/poweroperations/service.json
+++ b/tests/mock/poweroperations/service.json
@@ -577,6 +577,11 @@
             "href": "http://localhost:3001/api/services/10000000000619"
         },
         {
+            "name": "request_retire",
+            "method": "post",
+            "href": "http://localhost:3001/api/services/10000000000619"
+        },
+        {
             "name": "set_ownership",
             "method": "post",
             "href": "http://localhost:3001/api/services/10000000000619"

--- a/tests/mock/services/service1.json
+++ b/tests/mock/services/service1.json
@@ -495,6 +495,11 @@
       "href": "http://localhost:3001/api/services/10000000000542"
     },
     {
+      "name": "request_retire",
+      "method": "post",
+      "href": "http://localhost:3001/api/services/10000000000542"
+    },
+    {
       "name": "set_ownership",
       "method": "post",
       "href": "http://localhost:3001/api/services/10000000000542"


### PR DESCRIPTION
Since the API call for service retirement changed in https://github.com/ManageIQ/manageiq-api/pull/380 for the new retire as a request, the SUI ought to use the new call.

For https://bugzilla.redhat.com/show_bug.cgi?id=1599299