### PR TITLE
Fix for refresh of dialog fields not being called in some circumstances

### DIFF
--- a/client/app/states/catalogs/details/details.state.js
+++ b/client/app/states/catalogs/details/details.state.js
@@ -125,10 +125,7 @@ function Controller ($stateParams, CollectionsApi, EventNotifications, ShoppingC
  */
   function refreshField (field) {
     const resourceActions = vm.serviceTemplate.resource_actions
-    let resourceActionId = ''
-    if (resourceActions.length > 0 && resourceActions[0].action === 'Provision') {
-      resourceActionId = resourceActions[0].id
-    }
+    let resourceActionId = lodash.find(resourceActions, ['action', 'Provision']).id
 
     let idList = {
       dialogId: vm.parsedDialogs[0].id,


### PR DESCRIPTION
The root cause is that we were defaulting to use the first `resourceAction` as long as the `action` was `'Provision'`. However, in this case, `serviceTemplate.resourceActions` returned two, and the `action` property for the first one was `'Retirement'` and the second was `'Provision'`. However, since we were only checking the `action` for the first in the list, the id was ending up as an empty string and thus the API call was simply failing in the backend.

So, this piece of code now finds the correct provision `resourceAction`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1598475

@miq-bot add_label gaprindashvili/yes, bug, blocker
/cc @tinaafitz , @d-m-u 

@d-m-u Can you review?

@dclarizio Not sure who this should be assigned to, haven't done service-ui work in a while, please advise!