### PR TITLE
BZ#1601527 - Fixed issue with retire modal coming up blank

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -567,7 +567,7 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
           return services
         },
         modalType: function () {
-          return 'request_retire'
+          return 'retire'
         }
       }
     }


### PR DESCRIPTION
Fixes BZ https://bugzilla.redhat.com/show_bug.cgi?id=1601527

A recent change as part of https://github.com/ManageIQ/manageiq-ui-service/pull/1453 caused the modal to not show up as expected. 
@miq-bot add_label bug