### PR TITLE
Remove window.patternflyVersion

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -13,7 +13,6 @@ window.moment = require('moment')
 window.sprintf = require('sprintf-js').sprintf
 window.c3 = require('c3/c3')
 window.d3 = require('d3/d3')
-window.patternflyVersion = 4
 window.numeral = numeral
 
 // Libraries: core


### PR DESCRIPTION
Introduced in https://github.com/ManageIQ/manageiq-ui-service/pull/1379 to support https://github.com/ManageIQ/ui-components/pull/249 - `pf-select` means a different thing in angular-patternfly 4.

Later, in https://github.com/ManageIQ/ui-components/pull/295, that conditon was replaced by `miqSelect`, so this global goes unused.

(Also, ui-classic is moving to the same version, so the difference will be gone anyway.)

(Also also, https://github.com/ManageIQ/ui-components/pull/344 :).)