### PR TITLE
BZ#1624573 - Fix issue where error message is not displayed for consoles

### DIFF
--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -47,8 +47,15 @@ export function ConsolesFactory ($window, CollectionsApi, $timeout, $location, E
     }
   }
 
-  function consoleError (error) {
-    EventNotifications.error(__('There was an error opening the console. ' + error.message))
+  function consoleError (response) {
+    let message = __('undefined')
+    if (response.data) {
+      message = response.data.error.message
+    } else if (response.message) {
+      message = response.message
+    }
+
+    EventNotifications.error(__(`There was an error opening the console. ${message}`))
   }
 
   function consoleOpen (results) {


### PR DESCRIPTION
Fix for https://bugzilla.redhat.com/show_bug.cgi?id=1624573.   Error messages not being displayed properly for console launch errors. 
@miq-bot add_label gaprindashvili/yes
@miq-bot add_label bug
