### PR TITLE
BZ#1630119 - Hide revert snapshot button for openstack vm's

### DIFF
--- a/client/app/services/vms/snapshots.component.js
+++ b/client/app/services/vms/snapshots.component.js
@@ -36,12 +36,14 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
       resolveVm: resolveVm,
       // Config
       listConfig: getListConfig(),
-      menuActions: getMenuActions(),
+      menuActions: [],
       listActions: getListActions(),
       toolbarConfig: getToolbarConfig()
     })
     resolveSnapshots()
-    resolveVm()
+    resolveVm().then(() => {
+      vm.menuActions = getMenuActions()
+    })
   }
 
   function getToolbarConfig () {
@@ -63,12 +65,13 @@ function ComponentController (VmsService, sprintf, EventNotifications, ListView,
   }
 
   function getMenuActions () {
+    const revertUnsupported = (['openstack'].includes(vm.vm.vendor))
     const menuActions = [{
       name: __('Revert'),
       actionName: 'revert',
       title: __('Revert Snapshot'),
       actionFn: revertSnapshot,
-      permissions: vm.permissions.revert
+      permissions: vm.permissions.revert && !revertUnsupported
     }, {
       name: __('Delete'),
       actionName: 'delete',


### PR DESCRIPTION
Fixes BZ 1630119. 
@miq-bot add_label bug
@miq-bot add_label gaprindashvili/yes
