### PR TITLE
BZ#1637512-Restore action cable subscription, ensure enablement flag is available

### DIFF
--- a/client/app/core/appliance-info.service.js
+++ b/client/app/core/appliance-info.service.js
@@ -23,7 +23,8 @@ export function ApplianceInfo ($sessionStorage) {
       role: data.identity.role,
       suiVersion: gitHash.gitCommit,
       miqVersion: data.server_info.version + '.' + data.server_info.build,
-      server: data.server_info.appliance
+      server: data.server_info.appliance,
+      asyncNotify: data.settings.asynchronous_notifications || true
     }
     $sessionStorage.applianceInfo = applianceInfo
   }

--- a/client/app/core/appliance-info.service.spec.js
+++ b/client/app/core/appliance-info.service.spec.js
@@ -40,7 +40,8 @@ describe('Appliance Info Service', () => {
       'role': 'EvmRole-super_administrator',
       'miqVersion': 'master.20170510164252_9e5df30',
       'suiVersion': '',
-      'server': 'EVM'
+      'server': 'EVM',
+      'asyncNotify': 'true'
     }
     ApplianceInfo.set(applianceInfoData)
     const currentApplianceInfo = ApplianceInfo.get()

--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -91,10 +91,6 @@ export function authInit ($rootScope, $state, $log, Session, $sessionStorage, La
     }
     syncSession()
     .then(rbacReloadOrLogin(toState, toParams))
-    .then(() => {
-      const cable = ActionCable.createConsumer('/ws/notifications')
-      cable.subscriptions.create('NotificationChannel', {})
-    })
     .catch(badUser)
   }
 

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -74,10 +74,6 @@ function StateController ($window, $state, Text, RBAC, API_LOGIN, API_PASSWORD, 
         Session.destroy()
       }
     })
-    .then(() => {
-      const cable = ActionCable.createConsumer('/ws/notifications')
-      cable.subscriptions.create('NotificationChannel', {})
-    })
     .catch((response) => {
       if (response.status === 401) {
         vm.credentials.login = ''


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1637512

Pretty much reimplements #1314, but now its working without errors

### what it looks like, but yah really should jump in for yerself
![test](https://user-images.githubusercontent.com/6640236/46691326-a5cc4b00-cbd2-11e8-8c72-0412dd363cc6.gif)

and if you jump in... @skateman provided this wonderfully useful commands... (to be run from rails console)
```
Notification.create(:type => :generic_task_fail, :subject => Vm.first, :options => {:message => "nil"}, :user_id => User.first.id)
```
or
``` 
Notification.last.send(:emit_message)
```
