### PR TITLE
BZ#1650693 If tagging is readonly we should not show the edit dropdown

### DIFF
--- a/client/app/shared/tagging/tagging.component.js
+++ b/client/app/shared/tagging/tagging.component.js
@@ -101,7 +101,7 @@ function TaggingController ($scope, $filter, $q, $log, CollectionsApi, TaggingSe
     if (vm.tags.filtered) {
       vm.tags.filtered[0] = placeholderCategorization
       vm.tags.selectedTag = vm.tags.filtered[0]
-      vm.showTagDropdowns = true
+      vm.showTagDropdowns = !vm.readOnly
     }
   }, true)
 


### PR DESCRIPTION
But if tagging is not read only, behavior is nominal

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1650693


### see, no more edit dropdown here (where we shouldn't have one)
<img width="1058" alt="screen shot 2018-11-16 at 4 59 04 pm" src="https://user-images.githubusercontent.com/6640236/48649736-92768180-e9c1-11e8-9a05-0b46612f49b0.png">

### but we can still do tagging where we need to !
<img width="1068" alt="screen shot 2018-11-16 at 4 59 16 pm" src="https://user-images.githubusercontent.com/6640236/48649735-92768180-e9c1-11e8-8934-2b652e2f269a.png">

