### PR TITLE
BZ#1653288 Service is getting retired without any confirmation in self service ui

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -349,13 +349,13 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
     const data = {action: 'request_retire'}
     CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure)
 
-    function retireSuccess () {
-      EventNotifications.success(vm.service.name + __(' was retired.'))
+    function retireSuccess (response) {
+      EventNotifications.success(response.message)
       $state.go('services')
     }
 
-    function retireFailure () {
-      EventNotifications.error(__('There was an error retiring this service.'))
+    function retireFailure (response) {
+      EventNotifications.error(response.data.error.message)
     }
   }
 


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653288

A confirmation modal was never present on this command (the retire now menu item). But the response to the action, the hardcoded text was inaccurate, the service isn't retired upon clicking, a retire service request is created, update the response notifications to use the api feedback rather than hardcoded text. 

#### Message on success
<img width="1102" alt="screen shot 2018-11-27 at 3 09 19 pm" src="https://user-images.githubusercontent.com/6640236/49109158-0897a580-f258-11e8-8f27-d64805b251f1.png">


#### Message on error
<img width="1101" alt="screen shot 2018-11-27 at 3 17 33 pm" src="https://user-images.githubusercontent.com/6640236/49109166-0cc3c300-f258-11e8-903f-af45162ea3a9.png">


