### PR TITLE
Fix gettext versus template strings

### DIFF
--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -48,14 +48,14 @@ export function ConsolesFactory ($window, CollectionsApi, $timeout, $location, E
   }
 
   function consoleError (response) {
-    let message = __('undefined')
+    let message = ''
     if (response.data) {
       message = response.data.error.message
     } else if (response.message) {
       message = response.message
     }
 
-    EventNotifications.error(__(`There was an error opening the console. ${message}`))
+    EventNotifications.error(__('There was an error opening the console. ') + message)
   }
 
   function consoleOpen (results) {


### PR DESCRIPTION
Gettext needs to translate the original string as it appears in the source,
using template strings with substitution breaks gettext.

Fixing to move the substitution outside the translated string :).

(Noticed during review of #1501 , that "undefined" looked surprising in the catalog.)