### PR TITLE
BZ#1653193 - Custom buttons - only show button name when the "Display on Button" option is set

### DIFF
--- a/client/app/services/custom-button/custom-button.html
+++ b/client/app/services/custom-button/custom-button.html
@@ -6,7 +6,9 @@
             ng-disabled="!button.enabled"
             ng-click="vm.invokeCustomAction(button)">
       <i ng-class="button.options.button_icon" ng-style="{color: button.options.button_color }"></i>
-      {{ button.name }}
+      <span ng-if="button.options.display">
+        {{ button.name }}
+      </span>
     </button>
   </span>
 </span>
@@ -32,7 +34,9 @@
            uib-tooltip="{{ button.enabled ? button.description : button.disabled_text }}"
            tooltip-placement="left">
           <i ng-class="button.options.button_icon" ng-style="{color: button.options.button_color }"></i>
-          {{ button.name }}
+          <span ng-if="button.options.display">
+            {{ button.name }}
+          </span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
Only show custom button names when the "Display on Button" option is set.

![fix](https://user-images.githubusercontent.com/289743/49221784-05282980-f3d2-11e8-827e-4c9ab487afcb.png)

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653193