### PR TITLE
BZ#1653288 - Duplicates retire modal from service explorer in service details view

### DIFF
--- a/client/app/services/retire-remove-service-modal/retire-remove-service-modal.component.js
+++ b/client/app/services/retire-remove-service-modal/retire-remove-service-modal.component.js
@@ -40,7 +40,7 @@ function ComponentController ($state, CollectionsApi, EventNotifications) {
       vm.close()
       switch (vm.resolve.modalType) {
         case 'retire':
-          EventNotifications.success(__('Services Retired'))
+          EventNotifications.success(__('Service Retire - Request Created'))
           break
         case 'remove':
           EventNotifications.batch(response.results, __('Service deleting.'), __('Error deleting service.'))

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -346,17 +346,18 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   }
 
   function retireService () {
-    const data = {action: 'request_retire'}
-    CollectionsApi.post('services', vm.service.id, {}, data).then(retireSuccess, retireFailure)
-
-    function retireSuccess (response) {
-      EventNotifications.success(response.message)
-      $state.go('services')
+    var modalOptions = {
+      component: 'retireRemoveServiceModal',
+      resolve: {
+        services: function () {
+          return [vm.service]
+        },
+        modalType: function () {
+          return 'retire'
+        }
+      }
     }
-
-    function retireFailure (response) {
-      EventNotifications.error(response.data.error.message)
-    }
+    ModalService.open(modalOptions)
   }
 
   function createResourceGroups (service) {


### PR DESCRIPTION
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1653288

Looks like this is a side effect of https://github.com/ManageIQ/manageiq-ui-service/pull/1462, it killed the confirmation modal used by this view, opting to go with the same close modal in both views (explorer and details) updated the modal text to be inline with actual action, a retirement request

### What's it look like? 
<img width="1059" alt="screen shot 2018-12-13 at 7 39 21 am" src="https://user-images.githubusercontent.com/6640236/49939435-d8344600-feaa-11e8-846a-def86a3699df.png">
<img width="1053" alt="screen shot 2018-12-13 at 7 39 26 am" src="https://user-images.githubusercontent.com/6640236/49939437-d8344600-feaa-11e8-836d-ab3dd3bec8ee.png">
