### PR TITLE
Timeline - remove onResize handler when destroying timeline

### DIFF
--- a/client/app/shared/timeline/timeline.component.js
+++ b/client/app/shared/timeline/timeline.component.js
@@ -14,9 +14,15 @@ function TimelineController ($element, $window) {
   const vm = this
   const d3 = $window.d3
 
-  angular.element($window).on('resize', function () {
+  const resizeHandler = function () {
     renderTimeline()
-  })
+  }
+
+  angular.element($window).on('resize', resizeHandler)
+
+  vm.$onDestroy = function () {
+    angular.element($window).off('resize', resizeHandler)
+  }
 
   vm.$onChanges = (changes) => {
     vm.options = changes.options.currentValue || vm.options


### PR DESCRIPTION
Fixes #1337

The timeline component listens for the resize event on window, and triggers a repaint of the timeline

But, it never removes that listener, even after moving to a screen without timeline,
causing a console error when opening the notification area (which generates a resize event).

    Error: <rect> attribute width: A negative value is not valid. ("-250")
    Error: <pattern> attribute width: A negative value is not valid. ("-250")
    Error: <rect> attribute width: A negative value is not valid. ("-250")
    Error: <rect> attribute width: A negative value is not valid. ("-250")

This fixes that, by removing the listener when the component is destroyed.


Cc @AllenBW , no more 1337 issues, w00t :)