### PR TITLE
[GAPRINDASHVILI] NavigationController - regenerate menu when language changed

### DIFF
--- a/client/app/core/navigation/navigation-controller.js
+++ b/client/app/core/navigation/navigation-controller.js
@@ -1,11 +1,18 @@
 /** @ngInject */
 export function NavigationController (Text, Navigation, Session, API_BASE, ShoppingCart, $scope, $uibModal, $state,
-                                      EventNotifications, ApplianceInfo, CollectionsApi, RBAC, lodash) {
+                                      EventNotifications, ApplianceInfo, CollectionsApi, RBAC, lodash, Language) {
   const vm = this
   const destroy = $scope.$on('shoppingCartUpdated', refresh)
   const destroyCart = $scope.$on('shoppingCartUpdated', refreshCart)
+  let language = null
 
   vm.$doCheck = () => {
+    if (language !== Language.chosen.code) {
+      Navigation.init()
+      vm.items = Navigation.get()
+      language = Language.chosen.code
+    }
+
     if (!lodash.isEqual(vm.items, Navigation.get())) {
       if (!RBAC.suiAuthorized()) {
         Session.privilegesError = true


### PR DESCRIPTION
This is *technically* a backport of https://github.com/ManageIQ/manageiq-ui-service/pull/1375,
except most of the PR had nothing to do with the bug.

---

When the language changes, we need to call `Navigation.init` again, to popule the menu items with the newly translated values.

This would happen on login, but not after reloading the page.
(Because Navigation.init is first called before the language gets set.)

https://bugzilla.redhat.com/show_bug.cgi?id=1501098
https://bugzilla.redhat.com/show_bug.cgi?id=1672324