### PR TITLE
Speed up service_dialog initialization

### DIFF
--- a/client/app/states/catalogs/details/details.state.js
+++ b/client/app/states/catalogs/details/details.state.js
@@ -75,7 +75,6 @@ function Controller ($stateParams, CollectionsApi, EventNotifications, ShoppingC
       const DIALOGS_RESPONSE = 0
       dialogs = data[DIALOGS_RESPONSE]
       vm.serviceTemplate = data[SERVICE_TEMPLATE_RESPONSE]
-      vm.serviceTemplate.long_description = parseDescription(vm.serviceTemplate)
       setDialogUrl()
 
       if (dialogs.subcount > 0) {


### PR DESCRIPTION
This speeds up dialog initialization with a big number of dynamic fields. 

**How it works:**

1. Gets empty dialog with only static fields initialized (API PR: https://github.com/ManageIQ/manageiq-api/pull/567)
2. Creates hash `dynamicFieldsSummary` with the following keys: 
  `allDynamicFieldsToInit ` - all dynamic fields that should be initialized
  `allFieldResponders` - all dependent fields

3. Sends api requests for each dynamic field in `allDynamicFieldsToInit` apart from dependent fields
4. Updates `dynamicFieldsSummary`: removes all initialized fields from `allDynamicFieldsToInit` and updates dependent fields
5. Repeats 3-4 until `allFieldResponders` is empty (`initDialogFields` is a recursive function)

- - - - - - - 

It works with multiple dialogs and tabs and allows to set fields in any order