### PR TITLE
VM details - show provider when available

### DIFF
--- a/client/app/services/resource-details/resource-details.component.js
+++ b/client/app/services/resource-details/resource-details.component.js
@@ -257,6 +257,7 @@ function ComponentController ($state, $stateParams, VmsService, lodash, EventNot
           ${response.hostnames.map(item => `<div>${item}</div>`).join('\n')}`
       vm.provInfo.info = [
         `<b>${response.vendor}</b>`,
+        response.ext_management_system ? response.ext_management_system.name : __('(no provider)'),
         `${response.hardware.cpu_total_cores} CPUs (${response.hardware.cpu_sockets} sockets x ${response.hardware.cpu_cores_per_socket} core)`,
         `${response.hardware.memory_mb} MB`
       ]


### PR DESCRIPTION
Service > details > VM details screen,
show the provider name in the second card, second line.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686076

---

Before:

![before](https://user-images.githubusercontent.com/289743/55469964-2e61fc00-55f6-11e9-8b00-e8bf34f80731.png)

Now with a long provider name:

![yes](https://user-images.githubusercontent.com/289743/55469970-34f07380-55f6-11e9-9a91-e436d1d346f9.png)

Now, without an associated provider (archived, orphaned?):

![no](https://user-images.githubusercontent.com/289743/55469983-3b7eeb00-55f6-11e9-8625-71364b13a5a3.png)
