### PR TITLE
VM custom button dialog - use the VM instead of the parent service

### DIFF
--- a/client/app/states/services/custom_button_details/custom_button_details.state.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.js
@@ -55,6 +55,10 @@ function StateController ($state, $stateParams, CollectionsApi, EventNotificatio
       target_id: vm.serviceId,
       target_type: 'service'
     }
+    if (vm.vmId) {
+      options.target_type = 'vm'
+      options.target_id = vm.vmId
+    }
 
     const dialogId = vm.resourceAction.dialog_id
     const resolveDialogs = CollectionsApi.query(`service_dialogs/${dialogId}`, options)

--- a/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
+++ b/client/app/states/services/custom_button_details/custom_button_details.state.spec.js
@@ -1,7 +1,10 @@
 /* global $state, $controller, CollectionsApi, Notifications, DialogFieldRefresh */
 /* eslint-disable no-unused-expressions */
 describe('State: services.custom_button_details', () => {
-  let dialog, dialogData, dialogFields, button
+  const dialogId = 213
+  const serviceId = 123
+
+  let dialog, dialogData, dialogFields, button, dialogResponse
 
   beforeEach(() => {
     module('app.states')
@@ -41,92 +44,126 @@ describe('State: services.custom_button_details', () => {
         'dialogField2': 2
       }
     }
+
+    dialogResponse = {
+      content: [dialog],
+      id: dialogId
+    }
   })
 
-  describe('controller', () => {
-    let collectionsApiSpy, controller, notificationsErrorSpy, notificationsSuccessSpy
+  describe('for a service', () => {
+    it('sends target_type=service service dialog query on init', (done) => {
+      bard.inject('$controller', '$state', '$stateParams', 'CollectionsApi')
+      const spy = sinon.stub(CollectionsApi, 'query').returns(Promise.resolve(dialogResponse))
+      const resourceActionId = button.resource_action.id
 
-    beforeEach(() => {
-      bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications', 'DialogFieldRefresh')
-
-      sinon.stub(DialogFieldRefresh, 'refreshDialogField')
-
-      const apiQueries = sinon.stub(CollectionsApi, 'get')
-      apiQueries.onFirstCall().returns(Promise.resolve(dialog))
-      apiQueries.onSecondCall().returns(Promise.resolve({}))
-      controller = $controller($state.get('services.custom_button_details').controller, {
+      $controller($state.get('services.custom_button_details').controller, {
         $stateParams: {
-          dialogId: 213,
-          button: button,
-          serviceId: 123,
+          dialogId,
+          button,
+          serviceId,
           serviceTemplateCatalogId: 321
         }
       })
-      controller.setDialogData(dialogData)
+
+      done()
+
+      expect(spy).to.have.been.calledWith(`service_dialogs/${dialogId}`, {
+        expand: 'resources',
+        attributes: 'content',
+        resource_action_id: resourceActionId,
+        target_type: 'service',
+        target_id: serviceId
+      })
     })
 
-    describe('controller initialization', () => {
-      it('is created successfully', () => {
-        expect(controller).to.be.defined
-      })
-    })
-    describe('dialog values are updated', () => {
-      it('has values updated', () => {
-        const dialogValues = {
-          'dialogField1': 1,
-          'dialogField2': 2
-        }
-        expect(controller.dialogData).to.eql(dialogValues)
-      })
-    })
-    describe('controller#submitCustomButton', () => {
-      describe('when the API call is successful', () => {
-        beforeEach(() => {
-          const successResponse = {
-            message: 'Great Success!'
+    describe('after init', () => {
+      let collectionsApiSpy, controller, notificationsErrorSpy, notificationsSuccessSpy
+
+      beforeEach(() => {
+        bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications', 'DialogFieldRefresh')
+
+        sinon.stub(DialogFieldRefresh, 'refreshDialogField')
+
+        const apiQueries = sinon.stub(CollectionsApi, 'get')
+        apiQueries.onFirstCall().returns(Promise.resolve(dialog))
+        apiQueries.onSecondCall().returns(Promise.resolve({}))
+        controller = $controller($state.get('services.custom_button_details').controller, {
+          $stateParams: {
+            dialogId,
+            button,
+            serviceId,
+            serviceTemplateCatalogId: 321
           }
-
-          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
-          notificationsSuccessSpy = sinon.spy(Notifications, 'success')
         })
+        controller.setDialogData(dialogData)
+      })
 
-        it('POSTs to the services API', () => {
-          controller.submitCustomButton()
-          expect(collectionsApiSpy).to.have.been.calledWith(
-            'services',
-            123,
-            {},
-            '{"action":"buttonName","resource":{"dialogField1":1,"dialogField2":2}}'
-          )
-        })
-
-        it('makes a notification success call', (done) => {
-          controller.submitCustomButton()
-          done()
-          expect(notificationsSuccessSpy).to.have.been.calledWith('Great Success!')
-        })
-
-        it('goes to the service details', (done) => {
-          controller.submitCustomButton()
-          done()
-          expect($state.is('services.details')).to.be.true
+      describe('controller initialization', () => {
+        it('is created successfully', () => {
+          expect(controller).to.be.defined
         })
       })
 
-      describe('when the API call fails', () => {
-        beforeEach(() => {
-          const errorResponse = 'oopsies'
+      describe('dialog values are updated', () => {
+        it('has values updated', () => {
+          const dialogValues = {
+            'dialogField1': 1,
+            'dialogField2': 2
+          }
+          expect(controller.dialogData).to.eql(dialogValues)
+        })
+      })
 
-          collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.reject(errorResponse))
-          notificationsErrorSpy = sinon.spy(Notifications, 'error')
+      describe('controller#submitCustomButton', () => {
+        describe('when the API call is successful', () => {
+          beforeEach(() => {
+            const successResponse = {
+              message: 'Great Success!'
+            }
+
+            collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
+            notificationsSuccessSpy = sinon.spy(Notifications, 'success')
+          })
+
+          it('POSTs to the services API', () => {
+            controller.submitCustomButton()
+            expect(collectionsApiSpy).to.have.been.calledWith(
+              'services',
+              serviceId,
+              {},
+              '{"action":"buttonName","resource":{"dialogField1":1,"dialogField2":2}}'
+            )
+          })
+
+          it('makes a notification success call', (done) => {
+            controller.submitCustomButton()
+            done()
+            expect(notificationsSuccessSpy).to.have.been.calledWith('Great Success!')
+          })
+
+          it('goes to the service details', (done) => {
+            controller.submitCustomButton()
+            done()
+            expect($state.is('services.details')).to.be.true
+          })
         })
 
-        it('makes a notification error call', (done) => {
-          controller.submitCustomButton()
-          done()
-          expect(notificationsErrorSpy).to.have.been.calledWith(
-            'There was an error submitting this request: oopsies'
-          )
+        describe('when the API call fails', () => {
+          beforeEach(() => {
+            const errorResponse = 'oopsies'
+
+            collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.reject(errorResponse))
+            notificationsErrorSpy = sinon.spy(Notifications, 'error')
+          })
+
+          it('makes a notification error call', (done) => {
+            controller.submitCustomButton()
+            done()
+            expect(notificationsErrorSpy).to.have.been.calledWith(
+              'There was an error submitting this request: oopsies'
+            )
+          })
         })
       })
     })
@@ -135,20 +172,6 @@ describe('State: services.custom_button_details', () => {
   describe('Custom button actions for a VM', () => {
     let collectionsApiSpy, controller
 
-    const dialogFields = [{
-      name: 'dialogField1',
-      default_value: '1'
-    }, {
-      name: 'dialogField2',
-      default_value: '2'
-    }]
-    const dialog = {
-      dialog_tabs: [{
-        dialog_groups: [{
-          dialog_fields: dialogFields
-        }]
-      }]
-    }
     const button = {
       name: 'buttonName',
       applies_to_id: 456,
@@ -159,48 +182,78 @@ describe('State: services.custom_button_details', () => {
       }
     }
 
-    beforeEach(() => {
-      bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications', 'DialogFieldRefresh')
-      sinon.stub(DialogFieldRefresh, 'refreshDialogField')
-      const dialogResponse = {content: [dialog], id: 213}
-      const apiQueries = sinon.stub(CollectionsApi, 'get')
-      apiQueries.onFirstCall().returns(Promise.resolve(dialogResponse))
-      apiQueries.onSecondCall().returns(Promise.resolve({}))
+    it('sends target_type=vm service dialog query on init', (done) => {
+      bard.inject('$controller', '$state', '$stateParams', 'CollectionsApi')
+      const spy = sinon.stub(CollectionsApi, 'query').returns(Promise.resolve(dialogResponse))
+      const vmId = 456
+      const resourceActionId = button.resource_action.id
 
-      controller = $controller($state.get('services.custom_button_details').controller, {
+      $controller($state.get('services.custom_button_details').controller, {
         $stateParams: {
-          dialogId: 213,
+          dialogId,
           button: button,
-          serviceId: 123,
-          vmId: 456,
+          serviceId,
+          vmId,
           serviceTemplateCatalogId: 321
         }
       })
 
-      controller.setDialogData(dialogData)
-    })
-    it('POSTs to the vms API', (done) => {
-      const successResponse = {
-        message: 'Great Success!'
-      }
-
-      collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
-      sinon.spy(Notifications, 'success')
-
-      controller.submitCustomButton()
       done()
 
-      expect(collectionsApiSpy).to.have.been.calledWith(
-        'vms',
-        456,
-        {},
-        '{"action":"buttonName","resource":{"dialogField1":1,"dialogField2":2}}'
-      )
+      expect(spy).to.have.been.calledWith(`service_dialogs/${dialogId}`, {
+        expand: 'resources',
+        attributes: 'content',
+        resource_action_id: resourceActionId,
+        target_type: 'vm',
+        target_id: vmId
+      })
     })
-    it('goes to the resource details', (done) => {
-      controller.submitCustomButton()
-      done()
-      expect($state.is('services.resource-details')).to.be.true
+
+    describe('after init', () => {
+      beforeEach(() => {
+        bard.inject('$controller', '$log', '$state', '$stateParams', '$rootScope', 'CollectionsApi', 'Notifications', 'DialogFieldRefresh')
+        sinon.stub(DialogFieldRefresh, 'refreshDialogField')
+        const apiQueries = sinon.stub(CollectionsApi, 'get')
+        apiQueries.onFirstCall().returns(Promise.resolve(dialogResponse))
+        apiQueries.onSecondCall().returns(Promise.resolve({}))
+
+        controller = $controller($state.get('services.custom_button_details').controller, {
+          $stateParams: {
+            dialogId,
+            button: button,
+            serviceId,
+            vmId: 456,
+            serviceTemplateCatalogId: 321
+          }
+        })
+
+        controller.setDialogData(dialogData)
+      })
+
+      it('POSTs to the vms API', (done) => {
+        const successResponse = {
+          message: 'Great Success!'
+        }
+
+        collectionsApiSpy = sinon.stub(CollectionsApi, 'post').returns(Promise.resolve(successResponse))
+        sinon.spy(Notifications, 'success')
+
+        controller.submitCustomButton()
+        done()
+
+        expect(collectionsApiSpy).to.have.been.calledWith(
+          'vms',
+          456,
+          {},
+          '{"action":"buttonName","resource":{"dialogField1":1,"dialogField2":2}}'
+        )
+      })
+
+      it('goes to the resource details', (done) => {
+        controller.submitCustomButton()
+        done()
+        expect($state.is('services.resource-details')).to.be.true
+      })
     })
   })
 
@@ -213,12 +266,12 @@ describe('State: services.custom_button_details', () => {
         sinon.stub(DialogFieldRefresh, 'refreshDialogField')
 
         controller = $controller($state.get('services.custom_button_details').controller, {
-          dialog: {content: [dialog], id: 213},
+          dialog: dialogResponse,
           service: {},
           $stateParams: {
-            dialogId: 213,
+            dialogId,
             button: button,
-            serviceId: 123,
+            serviceId,
             serviceTemplateCatalogId: 321
           }
         })
@@ -232,7 +285,7 @@ describe('State: services.custom_button_details', () => {
           dialogData.data,
           ['fieldName'],
           'service_dialogs',
-          {dialogId: 213, resourceActionId: 789, targetId: 123, targetType: 'service'}
+          {dialogId, resourceActionId: 789, targetId: serviceId, targetType: 'service'}
         )
       })
     })
@@ -243,12 +296,12 @@ describe('State: services.custom_button_details', () => {
         sinon.stub(DialogFieldRefresh, 'refreshDialogField')
 
         controller = $controller($state.get('services.custom_button_details').controller, {
-          dialog: {content: [dialog], id: 213},
+          dialog: dialogResponse,
           service: {},
           $stateParams: {
-            dialogId: 213,
+            dialogId,
             button: button,
-            serviceId: 123,
+            serviceId,
             vmId: 456,
             serviceTemplateCatalogId: 321
           }
@@ -263,7 +316,7 @@ describe('State: services.custom_button_details', () => {
           dialogData.data,
           ['fieldName'],
           'service_dialogs',
-          {dialogId: 213, resourceActionId: 789, targetId: 456, targetType: 'vm'}
+          {dialogId, resourceActionId: 789, targetId: 456, targetType: 'vm'}
         )
       })
     })


### PR DESCRIPTION
Triggering a VM-based custom button on a Service's VM Resource causes the right dialog to appear..

But the inital data assumes the associated resource is the service, not the VM.
Subsequent field refresh requests and submit already use the VM, but the initial load was missed in https://github.com/ManageIQ/manageiq-ui-service/pull/1022.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1687061