### PR TITLE
Drop unused ui-select dependency

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -38,7 +38,6 @@ require('bootstrap-datepicker')
 require('angular-bootstrap-switch')
 require('angular-ui-sortable')
 require('bootstrap-combobox')
-require('ui-select')
 require('@manageiq/ui-components/dist/js/ui-components')
 
 // Libraries: angular-patternfly
@@ -61,7 +60,6 @@ require('./app/app.module.js')
 require('angular-patternfly/dist/styles/angular-patternfly.css')
 require('@manageiq/ui-components/dist/css/ui-components.css')
 require('ngprogress/ngProgress.css')
-require('ui-select/dist/select.css')
 require('patternfly-timeline/dist/timeline.css')
 
 // Application styles

--- a/client/app/shared/shared.module.js
+++ b/client/app/shared/shared.module.js
@@ -19,8 +19,7 @@ export const SharedModule = angular
     'app.core',
     'ui.bootstrap',
     'patternfly',
-    'patternfly.charts',
-    'ui.select'
+    'patternfly.charts'
   ])
   .component('actionButtonGroup', ActionButtonGroupComponent)
   .component('customDropdown', CustomDropdownComponent)

--- a/package.json
+++ b/package.json
@@ -104,7 +104,6 @@
     "text-encoder-lite": "coolaj86/TextEncoderLite#e1e031b",
     "ts-loader": "3.5.0",
     "typescript": "2.9.2",
-    "ui-select": "0.19.8",
     "url-loader": "0.6.2",
     "webpack": "3.11.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9464,10 +9464,6 @@ uglifyjs-webpack-plugin@^0.4.6:
     uglify-js "^2.8.29"
     webpack-sources "^1.0.1"
 
-ui-select@0.19.8:
-  version "0.19.8"
-  resolved "https://registry.yarnpkg.com/ui-select/-/ui-select-0.19.8.tgz#74860848a7fd8bc494d9856d2f62776ea98637c1"
-
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"


### PR DESCRIPTION
this used to be needed for the dialog-user component,
but was later replaced by pf-select and later miq-select.

Unused since https://github.com/ManageIQ/ui-components/pull/249

(The dependency is also being removed from the other repos in https://github.com/ManageIQ/ui-components/pull/390 and https://github.com/ManageIQ/manageiq-ui-classic/pull/5607.)