### PR TITLE
[WIP] Power state - support Suspended, show actual state for Unknown

### DIFF
--- a/client/app/services/poweroperations.service.js
+++ b/client/app/services/poweroperations.service.js
@@ -64,6 +64,8 @@ export function PowerOperationsFactory (CollectionsApi, EventNotifications, spri
         powerState = 'on'
       } else if (powerStatesMatch(item.power_states, 'off')) {
         powerState = 'off'
+      } else if (powerStatesMatch(item.power_states, 'suspended')) {
+        powerState = 'suspended'
       } else if (powerStatesMatch(item.power_states, 'timeout')) {
         powerState = 'timeout'
       }

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -175,19 +175,24 @@
                                              tooltip-popup-delay="1000"
                                              tooltip-placement="bottom"></i>
                                           <span ng-if="!item.retired">
-                                          <i class="pficon fa fa-power-off" ng-if="item.power_state === 'off'"
+                                          <i class="pficon pficon-off" ng-if="item.power_state === 'off'"
                                              uib-tooltip="{{'Power State: Off'|translate}}"
                                              tooltip-append-to-body="true"
                                              tooltip-popup-delay="1000"
                                              tooltip-placement="bottom"></i>
-                                          <i class="pficon pficon-ok" ng-if="item.power_state === 'on'"
+                                          <i class="pficon pficon-on" ng-if="item.power_state === 'on'"
                                              uib-tooltip="{{'Power State: On'|translate}}"
                                              tooltip-append-to-body="true"
                                              tooltip-popup-delay="1000"
                                              tooltip-placement="bottom"></i>
-                                          <i class="pficon fa fa-question-circle"
-                                             ng-if="item.power_state !== 'on' && item.power_state !== 'off'"
-                                             uib-tooltip="{{'Power State: Unknown'|translate}}"
+                                          <i class="pficon pficon-asleep" ng-if="item.power_state === 'suspended'"
+                                             uib-tooltip="{{'Power State: Suspended'|translate}}"
+                                             tooltip-append-to-body="true"
+                                             tooltip-popup-delay="1000"
+                                             tooltip-placement="bottom"></i>
+                                          <i class="pficon pficon-unknown"
+                                             ng-if="! ['on', 'off', 'suspended'].includes(item.power_state)"
+                                             uib-tooltip="{{'Power State: Unknown'|translate}} ({{item.power_state}})"
                                              tooltip-append-to-body="true"
                                              tooltip-popup-delay="1000"
                                              tooltip-placement="bottom"></i>

--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -450,12 +450,13 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
 
     function getPowerInfo (powerState) {
       const powerStates = {
-        'on': {icon: 'pficon-ok', tooltip: __('Power State: On')},
-        'off': {icon: 'fa-power-off', tooltip: __('Power State: Off')},
-        'unknown': {icon: 'fa-question-circle', tooltip: __('Power State: Unknown')}
+        'on': {icon: 'pficon-on', tooltip: __('Power State: On')},
+        'off': {icon: 'pficon-off', tooltip: __('Power State: Off')},
+        'suspended': {icon: 'pficon-asleep', tooltip: __('Power State: Suspended')},
+        'unknown': {icon: 'pficon-unknown', tooltip: __('Power State: Unknown') + ` (${powerState})`},
       }
 
-      return (powerState !== 'on' && powerState !== 'off' ? powerStates.unknown : powerStates[powerState])
+      return powerStates[powerState] || powerStates.unknown
     }
 
     function queryFailure (response) {


### PR DESCRIPTION
SUI is hardcoded to understand only 2 values of power_state: `on`, `off`
Everything else is "Unknown".

Adding an extra power_state: `suspended` ("Suspended")
Changing "Unknown" to "Unknown (actual value)"
Changing the icons for `on`, `off`, `unknown` and `suspended` to match [QuadiconHelper](https://github.com/ManageIQ/manageiq-decorators/blob/master/app/helpers/quadicon_helper.rb#L9)

~~Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704226~~ (the BZ was closed WONTFIX)

---

Icons + "Unknown" tooltip - before:

![before](https://user-images.githubusercontent.com/289743/58816252-a9f12100-8618-11e9-8453-9b11d6305aae.png)

After:

![now](https://user-images.githubusercontent.com/289743/58816287-ba090080-8618-11e9-9d93-9826a0f8bc0b.png)

(TODO add suspened icon too)