### PR TITLE
Service detail screen - don't run automate methods

### DIFF
--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -1,4 +1,4 @@
-/* eslint camelcase: "off" */
+/* eslint camelcase: "off", comma-dangle: 0 */
 import './_service-details.sass'
 import templateUrl from './service-details.html'
 
@@ -63,16 +63,20 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
         checkDisabled: isResourceDisabled
       }
     })
-    fetchResources(vm.serviceId)
+    fetchResources(vm.serviceId, {
+      isAutoRefresh: false,
+    })
     Polling.start('servicesPolling', startPollingService, LONG_POLLING_INTERVAL)
   }
 
   function startPollingService () {
-    fetchResources(vm.serviceId, true)
+    fetchResources(vm.serviceId, {
+      isAutoRefresh: true,
+    })
   }
 
-  function fetchResources (id, refresh) {
-    ServicesState.getService(id, refresh).then(handleSuccess, handleFailure)
+  function fetchResources (id, options) {
+    ServicesState.getService(id, options).then(handleSuccess, handleFailure)
 
     function handleSuccess (response) {
       vm.service = response

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -65,6 +65,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
     })
     fetchResources(vm.serviceId, {
       isAutoRefresh: false,
+      runAutomate: false,
     })
     Polling.start('servicesPolling', startPollingService, LONG_POLLING_INTERVAL)
   }
@@ -72,6 +73,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   function startPollingService () {
     fetchResources(vm.serviceId, {
       isAutoRefresh: true,
+      runAutomate: false,
     })
   }
 

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -1,4 +1,4 @@
-/* eslint camelcase: "off" */
+/* eslint camelcase: "off", comma-dangle: 0 */
 
 /** @ngInject */
 export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
@@ -24,18 +24,54 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
   function getService (id, refresh) {
     const options = {
       attributes: [
-        'name', 'guid', 'created_at', 'type', 'description', 'picture', 'picture.image_href', 'evm_owner.name', 'evm_owner.userid',
-        'miq_group.description', 'aggregate_all_vm_memory', 'aggregate_all_vm_disk_count',
-        'aggregate_all_vm_disk_space_allocated', 'aggregate_all_vm_disk_space_used', 'aggregate_all_vm_memory_on_disk', 'retired',
-        'retirement_state', 'retirement_warn', 'retires_on', 'actions', 'custom_actions', 'provision_dialog', 'service_resources',
-        'chargeback_report', 'service_template', 'parent_service', 'power_state', 'power_status', 'options', 'vms.ipaddresses',
-        'vms.snapshots', 'vms.v_total_snapshots', 'vms.v_snapshot_newest_name', 'vms.v_snapshot_newest_timestamp',
-        'vms.max_mem_usage_absolute_average_avg_over_time_period', 'vms.hardware',
-        'vms.hardware.aggregate_cpu_speed', 'vms.cpu_usagemhz_rate_average_avg_over_time_period', 'generic_objects.picture',
-        'generic_objects.generic_object_definition', 'vms.supported_consoles'
+        'actions',
+        'aggregate_all_vm_disk_count',
+        'aggregate_all_vm_disk_space_allocated',
+        'aggregate_all_vm_disk_space_used',
+        'aggregate_all_vm_memory',
+        'aggregate_all_vm_memory_on_disk',
+        'chargeback_report',
+        'created_at',
+        'custom_actions',
+        'description',
+        'evm_owner.name',
+        'evm_owner.userid',
+        'generic_objects.generic_object_definition',
+        'generic_objects.picture',
+        'guid',
+        'miq_group.description',
+        'name',
+        'options',
+        'parent_service',
+        'picture',
+        'picture.image_href',
+        'power_state',
+        'power_status',
+        'provision_dialog',
+        'retired',
+        'retirement_state',
+        'retirement_warn',
+        'retires_on',
+        'service_resources',
+        'service_template',
+        'type',
+        'vms.cpu_usagemhz_rate_average_avg_over_time_period',
+        'vms.hardware',
+        'vms.hardware.aggregate_cpu_speed',
+        'vms.ipaddresses',
+        'vms.max_mem_usage_absolute_average_avg_over_time_period',
+        'vms.snapshots',
+        'vms.supported_consoles',
+        'vms.v_snapshot_newest_name',
+        'vms.v_snapshot_newest_timestamp',
+        'vms.v_total_snapshots',
       ],
-      expand: ['vms', 'orchestration_stacks', 'generic_objects'],
-      auto_refresh: refresh
+      expand: [
+        'generic_objects',
+        'orchestration_stacks',
+        'vms',
+      ],
+      auto_refresh: refresh,
     }
 
     return CollectionsApi.get('services', id, options)

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -21,7 +21,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
     getConfigurationCustomDropdown: getConfigurationCustomDropdown
   }
 
-  function getService (id, refresh) {
+  function getService (id, { isAutoRefresh = false } = {}) {
     const options = {
       attributes: [
         'actions',
@@ -71,7 +71,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
         'orchestration_stacks',
         'vms',
       ],
-      auto_refresh: refresh,
+      auto_refresh: isAutoRefresh,
     }
 
     return CollectionsApi.get('services', id, options)

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -21,7 +21,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
     getConfigurationCustomDropdown: getConfigurationCustomDropdown
   }
 
-  function getService (id, { isAutoRefresh = false } = {}) {
+  function getService (id, { isAutoRefresh = false, runAutomate = true } = {}) {
     const options = {
       attributes: [
         'actions',
@@ -47,7 +47,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
         'picture.image_href',
         'power_state',
         'power_status',
-        'provision_dialog',
+        runAutomate ? 'provision_dialog' : null,
         'retired',
         'retirement_state',
         'retirement_warn',
@@ -65,7 +65,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
         'vms.v_snapshot_newest_name',
         'vms.v_snapshot_newest_timestamp',
         'vms.v_total_snapshots',
-      ],
+      ].filter((truthy) => truthy),
       expand: [
         'generic_objects',
         'orchestration_stacks',

--- a/client/app/services/services-state.service.spec.js
+++ b/client/app/services/services-state.service.spec.js
@@ -13,7 +13,7 @@ describe('Service: ServicesStateFactory', () => {
     it('should allow a service to be retrieved', (done) => {
       const serviceId = '12345'
       const collectionsApiSpy = sinon.stub(CollectionsApi, 'get').returns(Promise.resolve(successResponse))
-      ServicesState.getService(serviceId, { isAutoRefresh: false })
+      ServicesState.getService(serviceId, { isAutoRefresh: false, runAutomate: true })
       const expectedOptions = {
         attributes: [
           'name', 'guid', 'created_at', 'type', 'description', 'picture', 'picture.image_href', 'evm_owner.name', 'evm_owner.userid',

--- a/client/app/services/services-state.service.spec.js
+++ b/client/app/services/services-state.service.spec.js
@@ -13,7 +13,7 @@ describe('Service: ServicesStateFactory', () => {
     it('should allow a service to be retrieved', (done) => {
       const serviceId = '12345'
       const collectionsApiSpy = sinon.stub(CollectionsApi, 'get').returns(Promise.resolve(successResponse))
-      ServicesState.getService(serviceId, false)
+      ServicesState.getService(serviceId, { isAutoRefresh: false })
       const expectedOptions = {
         attributes: [
           'name', 'guid', 'created_at', 'type', 'description', 'picture', 'picture.image_href', 'evm_owner.name', 'evm_owner.userid',

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -175,7 +175,7 @@ Component services make available all resources needed by components, crud opera
       getConfigurationCustomDropdown: getConfigurationCustomDropdown,
     };
 
-    function getService(id, { isAutoRefresh }) {
+    function getService(id, { isAutoRefresh, runAutomate }) {
         ...
     }
   }

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -175,7 +175,7 @@ Component services make available all resources needed by components, crud opera
       getConfigurationCustomDropdown: getConfigurationCustomDropdown,
     };
 
-    function getService(id, refresh) {
+    function getService(id, { isAutoRefresh }) {
         ...
     }
   }


### PR DESCRIPTION
When displaying the service detail screen (`/services/:id`), we're doing an API request for the details, including `provision_dialog`.

But, computing `provision_dialog` evaluates all the automate methods,
which is not useful when we don't display the dialog afterwards.

=> Added a `runAutomate` option to `getService`, and set it to false when on the screen.

(Ops-side, this was solved in https://github.com/ManageIQ/manageiq-ui-classic/pull/5126, by reimplementing a readonly part of dialog-user to display the fields with values from `options`. SUI-side, I'm not seeing the dialog being displayed, so no need for that.)

Cc @eclarizio 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1695804