### PR TITLE
Update the VM remote console button to the new unified HTML5 console

### DIFF
--- a/client/app/core/product-features.constants.json
+++ b/client/app/core/product-features.constants.json
@@ -30,7 +30,7 @@
         "ADD": "sui_vm_snapshot_create",
         "DELETE": "sui_vm_snapshot_delete"
       },
-      "CONSOLE": "sui_vm_console",
+      "HTML5_CONSOLE": "sui_vm_html5_console",
       "WEB_CONSOLE": "sui_vm_web_console",
       "TAGS": "sui_vm_tags",
       "RETIRE": "sui_vm_retire",

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -380,7 +380,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   }
 
   function openConsole (item) {
-    if (item.supported_consoles.vnc.visible && item.supported_consoles.vnc.enabled) {
+    if (item.supported_consoles.html5.visible && item.supported_consoles.html5.enabled) {
       Consoles.open(item.id)
     }
   }

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -286,8 +286,8 @@
                                         </ul>
                                     </div>
                                     <div class="btn-group" uib-dropdown dropdown-append-to-body
-                                         ng-if="($ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.console)
-                                            && (item.supported_consoles.vnc.visible || item.supported_consoles.vnc.message
+                                         ng-if="($ctrl.customScope.permissions.cockpit || $ctrl.customScope.permissions.html5_console)
+                                            && (item.supported_consoles.html5.visible || item.supported_consoles.html5.message
                                             || item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message)">                                        <button type="button" class="btn btn-default" uib-dropdown-toggle
                                                 type="button">
                                             <i class="fa fa-window-maximize "></i>
@@ -296,13 +296,13 @@
                                         </button>
                                         <ul class="dropdown-menu dropdown-menu-right" uib-dropdown-menu role="menu"
                                             aria-labelledby="btn-append-to-to-body">
-                                            <li ng-if="item.supported_consoles.vnc.visible || item.supported_consoles.vnc.message"
+                                            <li ng-if="item.supported_consoles.html5.visible || item.supported_consoles.html5.message"
                                                 role="menuitem"
-                                                uib-tooltip="{{item.supported_consoles.vnc.message}}"
+                                                uib-tooltip="{{item.supported_consoles.html5.message}}"
                                                 tooltip-placement="bottom"
-                                                ng-class="{'disabled': !item.supported_consoles.vnc.enabled || !$ctrl.customScope.permissions.console}"
+                                                ng-class="{'disabled': !item.supported_consoles.html5.enabled || !$ctrl.customScope.permissions.html5_console}"
                                                 ng-click="$ctrl.customScope.openConsole(item)">
-                                                <a href="#" translate>VM Console</a>
+                                                <a href="#" translate>VM HTML5 Console</a>
                                             </li>
                                             <li ng-if="item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message"
                                                 role="menuitem"

--- a/client/app/services/service-explorer/service-explorer.component.spec.js
+++ b/client/app/services/service-explorer/service-explorer.component.spec.js
@@ -31,7 +31,7 @@ describe('Component: serviceExplorer', () => {
       serviceStop: false,
       serviceSuspend: false,
       cockpit: false,
-      console: false,
+      html5_console: false,
       viewSnapshots: false,
       vm_snapshot_show_list: false,
       vm_snapshot_add: false,

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -111,7 +111,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
       instanceSuspend: RBAC.has(RBAC.FEATURES.VMS.SUSPEND),
       instanceRetire: RBAC.hasAny([RBAC.FEATURES.SERVICES.RETIRE.RETIRE_NOW, RBAC.FEATURES.SERVICES.RETIRE.SET_DATE]),
       cockpit: RBAC.has(RBAC.FEATURES.VMS.WEB_CONSOLE),
-      console: RBAC.has(RBAC.FEATURES.VMS.CONSOLE),
+      html5_console: RBAC.has(RBAC.FEATURES.VMS.HTML5_CONSOLE),
       viewSnapshots: RBAC.has(RBAC.FEATURES.VMS.SNAPSHOTS.VIEW),
 
       vm_snapshot_show_list: RBAC.has(RBAC.FEATURES.VMS.SNAPSHOTS.VIEW), // Display Lists of VM Snapshots

--- a/client/app/services/services-state.service.spec.js
+++ b/client/app/services/services-state.service.spec.js
@@ -84,7 +84,7 @@ describe('Service: ServicesStateFactory', () => {
         'instanceSuspend': false,
         'instanceRetire': false,
         'cockpit': false,
-        'console': false,
+        'html5_console': false,
         'viewSnapshots': false,
         'vm_snapshot_add': false,
         'vm_snapshot_show_list': false,


### PR DESCRIPTION
In order to support [webmks](https://github.com/ManageIQ/manageiq-ui-service/issues/1520) here, there were some [changes](https://github.com/ManageIQ/manageiq/pull/18927) in the backend for the new HTML5 console meta type. This PR adjusts the codebase to these changes. 

Depends on: https://github.com/ManageIQ/manageiq/pull/18927 and https://github.com/ManageIQ/manageiq-api/pull/621

https://bugzilla.redhat.com/show_bug.cgi?id=1532720