### PR TITLE
Explicitly add the HTML for WebMKS into the webpack production config

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -25,6 +25,14 @@ config.plugins.push(
     chunks: ['app']
   }),
 
+  // Build the HTML required for the WebMKS console
+  new HtmlWebpackPlugin({
+    base: '/',
+    filename: 'console/webmks.html',
+    template: '../client/console/common.ejs',
+    chunks: ['console_webmks']
+  }),
+
   new OptimizeCssAssetsWebpackPlugin()
 )
 


### PR DESCRIPTION
To be honest, I have no idea how to test this, but @himdel says this is *The Right Way&trade;* to fix this. The file was present in development, but not in production. Even though we're including the development file in production :rofl: 

@miq-bot add_label bug, ivanchuk/yes, hammer/no, changelog/no
@miq-bot assign @himdel 

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1732730