### PR TITLE
Add support for the VMRC remote consoles for VMware VMs

### DIFF
--- a/client/app/core/product-features.constants.json
+++ b/client/app/core/product-features.constants.json
@@ -31,6 +31,7 @@
         "DELETE": "sui_vm_snapshot_delete"
       },
       "HTML5_CONSOLE": "sui_vm_html5_console",
+      "VMRC_CONSOLE": "sui_vm_vmrc_console",
       "WEB_CONSOLE": "sui_vm_web_console",
       "TAGS": "sui_vm_tags",
       "RETIRE": "sui_vm_retire",

--- a/client/app/services/consoles.service.js
+++ b/client/app/services/consoles.service.js
@@ -6,10 +6,10 @@ export function ConsolesFactory ($window, CollectionsApi, $timeout, $location, E
 
   return service
 
-  function openConsole (vmId) {
+  function openConsole (vmId, protocol) {
     return CollectionsApi.post('vms', vmId, {}, {
       action: 'request_console',
-      resource: {protocol: 'html5'}
+      resource: {protocol: protocol}
     })
       .then(consoleResponse)
       .catch(consoleError)

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -385,9 +385,9 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
     vm.genericObjectsTypeViewState[object.id] = object.isExpanded
   }
 
-  function openConsole (item) {
-    if (item.supported_consoles.html5.visible && item.supported_consoles.html5.enabled) {
-      Consoles.open(item.id)
+  function openConsole (item, protocol) {
+    if (item.supported_consoles.html5.visible && item.supported_consoles.html5.enabled || item.supported_consoles.vmrc.visible && item.supported_consoles.vmrc.enabled) {
+      Consoles.open(item.id, protocol)
     }
   }
 

--- a/client/app/services/service-details/service-details.component.js
+++ b/client/app/services/service-details/service-details.component.js
@@ -386,7 +386,7 @@ function ComponentController ($stateParams, $state, $window, CollectionsApi, Eve
   }
 
   function openConsole (item, protocol) {
-    if (item.supported_consoles.html5.visible && item.supported_consoles.html5.enabled || item.supported_consoles.vmrc.visible && item.supported_consoles.vmrc.enabled) {
+    if ((item.supported_consoles.html5.visible && item.supported_consoles.html5.enabled) || (item.supported_consoles.vmrc.visible && item.supported_consoles.vmrc.enabled)) {
       Consoles.open(item.id, protocol)
     }
   }

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -304,6 +304,15 @@
                                                 ng-click="$ctrl.customScope.openConsole(item, 'html5')">
                                                 <a href="#" translate>VM HTML5 Console</a>
                                             </li>
+                                            <li ng-if="item.supported_consoles.vmrc.visible || item.supported_consoles.vmrc.message"
+                                                role="menuitem"
+                                                uib-tooltip="{{item.supported_consoles.vmrc.message}}"
+                                                tooltip-placement="bottom"
+                                                ng-class="{'disabled': !item.supported_consoles.vmrc.enabled || !$ctrl.customScope.permissions.vmrc_console}"
+                                                ng-click="$ctrl.customScope.openConsole(item, 'vmrc')">
+                                                <a href="#" translate>VM VMRC Console</a>
+                                            </li>
+
                                             <li ng-if="item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message"
                                                 role="menuitem"
                                                 uib-tooltip="{{item.supported_consoles.cockpit.message}}"

--- a/client/app/services/service-details/service-details.html
+++ b/client/app/services/service-details/service-details.html
@@ -301,7 +301,7 @@
                                                 uib-tooltip="{{item.supported_consoles.html5.message}}"
                                                 tooltip-placement="bottom"
                                                 ng-class="{'disabled': !item.supported_consoles.html5.enabled || !$ctrl.customScope.permissions.html5_console}"
-                                                ng-click="$ctrl.customScope.openConsole(item)">
+                                                ng-click="$ctrl.customScope.openConsole(item, 'html5')">
                                                 <a href="#" translate>VM HTML5 Console</a>
                                             </li>
                                             <li ng-if="item.supported_consoles.cockpit.visible || item.supported_consoles.cockpit.message"

--- a/client/app/services/service-explorer/service-explorer.component.spec.js
+++ b/client/app/services/service-explorer/service-explorer.component.spec.js
@@ -32,6 +32,7 @@ describe('Component: serviceExplorer', () => {
       serviceSuspend: false,
       cockpit: false,
       html5_console: false,
+      vmrc_console: false,
       viewSnapshots: false,
       vm_snapshot_show_list: false,
       vm_snapshot_add: false,

--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -148,6 +148,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
       instanceRetire: RBAC.hasAny([RBAC.FEATURES.SERVICES.RETIRE.RETIRE_NOW, RBAC.FEATURES.SERVICES.RETIRE.SET_DATE]),
       cockpit: RBAC.has(RBAC.FEATURES.VMS.WEB_CONSOLE),
       html5_console: RBAC.has(RBAC.FEATURES.VMS.HTML5_CONSOLE),
+      vmrc_console: RBAC.has(RBAC.FEATURES.VMS.VMRC_CONSOLE),
       viewSnapshots: RBAC.has(RBAC.FEATURES.VMS.SNAPSHOTS.VIEW),
 
       vm_snapshot_show_list: RBAC.has(RBAC.FEATURES.VMS.SNAPSHOTS.VIEW), // Display Lists of VM Snapshots

--- a/client/app/services/services-state.service.spec.js
+++ b/client/app/services/services-state.service.spec.js
@@ -85,6 +85,7 @@ describe('Service: ServicesStateFactory', () => {
         'instanceRetire': false,
         'cockpit': false,
         'html5_console': false,
+        'vmrc_console': false,
         'viewSnapshots': false,
         'vm_snapshot_add': false,
         'vm_snapshot_show_list': false,


### PR DESCRIPTION
Resolving https://github.com/ManageIQ/manageiq/issues/18718 by exposing the protocol as a param when asking the API for a remote console.

Depends on:
https://github.com/ManageIQ/manageiq/pull/19097
https://github.com/ManageIQ/manageiq-api/pull/642
https://github.com/ManageIQ/manageiq-providers-vmware/pull/429

@miq-bot add_label pending core, hammer/no, changelog/yes
@miq-bot assign @himdel 
@miq-bot add_reviewer @AllenBW 