### PR TITLE
Make strings in notification drawer translatable

### DIFF
--- a/client/app/components/notifications/heading.html
+++ b/client/app/components/notifications/heading.html
@@ -1,3 +1,3 @@
-<span class="heading-class">{{notificationGroup.heading | translate}}</span>
-<span class="panel-counter sub-heading">{{notificationGroup.unreadCount}} {{'New' | translate}} {{notificationGroup.heading | translate}}</span>
+<span class="heading-class">{{notificationGroup.heading}}</span>
+<span class="panel-counter sub-heading">{{notificationGroup.subHeading}}</span>
 

--- a/client/app/core/event-notifications.service.js
+++ b/client/app/core/event-notifications.service.js
@@ -1,6 +1,6 @@
 /** @ngInject */
 export function EventNotificationsFactory ($log, $timeout, lodash, CollectionsApi, RBAC, ApplianceInfo, ActionCable,
-                                           Session) {
+                                           Session, sprintf) {
   const state = {}
   const toastDelay = 8 * 1000
   const service = {
@@ -191,11 +191,11 @@ export function EventNotificationsFactory ($log, $timeout, lodash, CollectionsAp
   }
 
   function notificationsInit () {
-    const eventTypes = ['info', 'success', 'error', 'warning']
+    const eventTypes = [['info', __('Info')], ['success', __('Success')], ['error', __('Error')], ['warning', __('Warning')]]
 
     function Group (type) {
-      this.notificationType = type
-      this.heading = lodash.capitalize(type)
+      this.notificationType = type[0]
+      this.heading = type[1]
       this.unreadCount = 0
       this.notifications = []
     }
@@ -293,6 +293,7 @@ export function EventNotificationsFactory ($log, $timeout, lodash, CollectionsAp
 
     function update (group) {
       group.unreadCount = group.notifications.filter((notification) => notification.unread).length
+      group.subHeading = sprintf(__('%d new notifications'), group.unreadCount)
       state.unreadNotifications = angular.isDefined(lodash.find(state.groups, function (group) {
         return group.unreadCount > 0
       }))

--- a/client/app/core/navigation/navigation-controller.js
+++ b/client/app/core/navigation/navigation-controller.js
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function NavigationController (Text, Navigation, Session, API_BASE, ShoppingCart, $scope, $uibModal, $state, EventNotifications, ApplianceInfo, CollectionsApi, RBAC, Language, lodash, $rootScope) {
+export function NavigationController (Text, Navigation, Session, API_BASE, ShoppingCart, $scope, $uibModal, $state, EventNotifications, ApplianceInfo, CollectionsApi, RBAC, Language, lodash, $rootScope, sprintf) {
   const vm = this
   vm.language = ''
   const destroy = $scope.$on('shoppingCartUpdated', refresh)
@@ -165,7 +165,7 @@ export function NavigationController (Text, Navigation, Session, API_BASE, Shopp
     angular.forEach(vm.notificationGroups, function (group) {
       vm.unreadNotificationCount += group.unreadCount
     })
-    vm.notificationsIndicatorTooltip = __(vm.unreadNotificationCount + ' unread notifications')
+    vm.notificationsIndicatorTooltip = sprintf(__('%d unread notifications'), vm.unreadNotificationCount)
   }
 
   function refreshToast () {

--- a/client/app/layouts/application.html
+++ b/client/app/layouts/application.html
@@ -11,6 +11,7 @@
             allow-expand="true"
             on-close="vm.toggleNotificationsList"
             drawer-title="{{'Notifications' | translate}}"
+            no-notifications-text="{{'There are no notifications to display.' | translate}}"
             heading-include="{{vm.headingHTML}}"
             subheading-include="{{vm.subHeadingHTML}}"
             notification-body-include="{{vm.notificationHTML}}"


### PR DESCRIPTION
Changes in this PR:
* make notification sub-heading translatable
* make notification event types translatable
* fix `sprintf()` and `gettext` invocation
* add translatable `no-notifications-text`

https://bugzilla.redhat.com/show_bug.cgi?id=1655464
https://bugzilla.redhat.com/show_bug.cgi?id=1655536