### PR TITLE
Drop GTL switcher from Service Explorer breadcrumbs bar

### DIFF
--- a/client/app/services/service-explorer/service-explorer.component.js
+++ b/client/app/services/service-explorer/service-explorer.component.js
@@ -37,7 +37,6 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
       limitOptions: [5, 10, 20, 50, 100, 200, 500, 1000],
       // Functions
       resolveServices: resolveServices,
-      viewSelected: viewSelected,
       actionEnabled: actionEnabled,
       updateMenuActionForItemFn: updateMenuActionForItemFn,
       listActionDisable: listActionDisable,
@@ -49,7 +48,6 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
       paginationUpdate: paginationUpdate,
       defaultFilterFields: defaultFilterFields,
       // Config setup
-      viewType: 'listView',
       cardConfig: getCardConfig(),
       listConfig: getListConfig(),
       listActions: getListActions(),
@@ -188,10 +186,6 @@ function ComponentController ($state, ServicesState, Language, ListView, Chargeb
 
   function pollUpdateServicesList () {
     resolveServices(vm.limit, vm.offset, true)
-  }
-
-  function viewSelected (viewId) {
-    vm.viewType = viewId
   }
 
   function serviceFilterConfig () {

--- a/client/app/services/service-explorer/service-explorer.component.spec.js
+++ b/client/app/services/service-explorer/service-explorer.component.spec.js
@@ -121,10 +121,4 @@ describe('Component: serviceExplorer', () => {
     const isNotAnsible = ctrl.isAnsibleService({type: 'vm'})
     expect(isNotAnsible).to.be.false
   })
-
-  it('should change view type', () => {
-    expect(ctrl.viewType).to.equal('listView')
-    ctrl.viewSelected('tableView')
-    expect(ctrl.viewType).to.equal('tableView')
-  })
 })

--- a/client/app/services/service-explorer/service-explorer.html
+++ b/client/app/services/service-explorer/service-explorer.html
@@ -1,38 +1,31 @@
 <div class="breadcrumb-bar">
   <span>
-      <ol class="breadcrumb">
-        <li class="active">{{ 'My Services' | translate }}</li>
-      </ol>
+    <ol class="breadcrumb">
+      <li class="active">{{ 'My Services' | translate }}</li>
+    </ol>
   </span>
-    <div class="view-selector-bar">
-        <div class="form-group toolbar-pf-view-selector">
-            <button class="btn btn-link"
-                    ng-click="vm.viewSelected('listView')"
-                    ng-class="{active: vm.viewType === 'listView'}">
-                <i class="fa fa-th-list"></i>
-            </button>
-        </div>
-    </div>
 </div>
+
 <pf-toolbar class="section-toolbar section-toolbar-right-actions" config="vm.toolbarConfig">
-    <actions>
-        <custom-dropdown class="custom-dropdown pull-left"
-                         config="item"
-                         items="vm.selectedItemsList"
-                         items-count="vm.toolbarConfig.filterConfig.selectedCount"
-                         ng-repeat="item in vm.listActions"
-                         on-update="vm.listActionDisable($config, $changes)"
-                         menu-right="true">
-        </custom-dropdown>
-    </actions>
+  <actions>
+    <custom-dropdown class="custom-dropdown pull-left"
+                     config="item"
+                     items="vm.selectedItemsList"
+                     items-count="vm.toolbarConfig.filterConfig.selectedCount"
+                     ng-repeat="item in vm.listActions"
+                     on-update="vm.listActionDisable($config, $changes)"
+                     menu-right="true">
+    </custom-dropdown>
+  </actions>
 </pf-toolbar>
-<div ng-if="vm.viewType == 'listView'" class="list-view-container section-container explorer-list">
-    <loading status="vm.loading"></loading>
-    <pf-list-view ng-if="!vm.loading" id="serviceList" config="vm.listConfig"
-                  items="vm.servicesList"
-                  menu-actions="vm.menuActions"
-                  update-menu-action-for-item-fn="vm.updateMenuActionForItemFn"
-                  custom-scope="vm">
+
+<div class="list-view-container section-container explorer-list">
+  <loading status="vm.loading"></loading>
+  <pf-list-view ng-if="!vm.loading" id="serviceList" config="vm.listConfig"
+                items="vm.servicesList"
+                menu-actions="vm.menuActions"
+                update-menu-action-for-item-fn="vm.updateMenuActionForItemFn"
+                custom-scope="vm">
         <div class="row service-explorer-row">
             <div class="col-lg-4 col-md-4 col-sm-5 col-xs-8 name-column">
         <span class="no-wrap">
@@ -206,8 +199,9 @@
                 </div>
             </pf-list-view>
         </list-expanded-content>
-    </pf-list-view>
+  </pf-list-view>
 </div>
+
 <explorer-pagination check-all="vm.checkAll"
                      count="vm.toolbarConfig.filterConfig.resultsCount"
                      limit-options="vm.limitOptions"

--- a/client/app/states/services/resource-details/details.state.js
+++ b/client/app/states/services/resource-details/details.state.js
@@ -7,7 +7,6 @@ function getStates (RBAC) {
   return {
     'services.resource-details': {
       url: '/:serviceId/resource=:vmId',
-      params: { viewType: null },
       template: '<resource-details>',
       title: __('Resource Details'),
       data: {

--- a/client/assets/sass/breadcrumbs.sass
+++ b/client/assets/sass/breadcrumbs.sass
@@ -1,25 +1,6 @@
 .breadcrumb-bar
   display: flex
 
-  .view-selector-bar
-    background-color: transparent
-    position: absolute
-    right: 20px
-    top: 5px
-
-    .btn-link
-      color: $app-color-black
-      font-size: 16px
-      line-height: 1
-      padding: 4px 0
-
-      &.active
-        color: $app-color-medium-blue-2
-        cursor: default
-
-      &:hover
-        color: $app-color-medium-blue-2
-
   .breadcrumb-actions
     margin-left: auto
     padding: 5px 15px


### PR DESCRIPTION
it seems like at some point there was a plan for multiple views,
but now, only the list view is supported, removing the switcher and associated logic.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1516722