### PR TITLE
Snapshots - name & description shown & optional depends on VM type

### DIFF
--- a/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
+++ b/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
@@ -27,6 +27,27 @@ function ComponentController ($controller, $state, EventNotifications, VmsServic
       modalType: vm.resolve.modalType,
       save: save
     })
+
+    vm.nameLabel = __("Name")
+    vm.descriptionLabel = __("Description")
+
+    vm.nameLabelClass = 'col-sm-3'
+    vm.descriptionLabelClass = 'col-sm-3'
+
+    vm.nameShown = true
+    vm.nameRequired = true
+
+    vm.descriptionShown = true
+    vm.descriptionRequired = false
+
+    if (vm.nameRequired) {
+      vm.nameLabel += ' *'
+      vm.nameLabelClass += ' required'
+    }
+    if (vm.descriptionRequired) {
+      vm.descriptionLabel += ' *'
+      vm.descriptionLabelClass += ' required'
+    }
   }
 
   function save () {

--- a/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
+++ b/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
@@ -40,6 +40,23 @@ function ComponentController ($controller, $state, EventNotifications, VmsServic
     vm.descriptionShown = true
     vm.descriptionRequired = false
 
+    // FIXME: @record.snapshot_name_optional?
+    if (['ovirt', 'redhat'].includes(vm.vm.vendor)) {
+      vm.nameShown = false
+      vm.descriptionRequired = true
+    }
+    if (vm.vm.vendor == 'openstack') {
+      vm.nameShown = true
+      vm.descriptionRequired = true
+    }
+
+    if (! vm.nameShown) {
+      vm.nameRequired = false
+    }
+    if (! vm.descriptionShown) {
+      vm.descriptionRequired = false
+    }
+
     if (vm.nameRequired) {
       vm.nameLabel += ' *'
       vm.nameLabelClass += ' required'

--- a/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
+++ b/client/app/services/process-snapshots-modal/process-snapshots-modal.component.js
@@ -28,8 +28,8 @@ function ComponentController ($controller, $state, EventNotifications, VmsServic
       save: save
     })
 
-    vm.nameLabel = __("Name")
-    vm.descriptionLabel = __("Description")
+    vm.nameLabel = __('Name')
+    vm.descriptionLabel = __('Description')
 
     vm.nameLabelClass = 'col-sm-3'
     vm.descriptionLabelClass = 'col-sm-3'
@@ -45,15 +45,15 @@ function ComponentController ($controller, $state, EventNotifications, VmsServic
       vm.nameShown = false
       vm.descriptionRequired = true
     }
-    if (vm.vm.vendor == 'openstack') {
+    if (vm.vm.vendor === 'openstack') {
       vm.nameShown = true
       vm.descriptionRequired = true
     }
 
-    if (! vm.nameShown) {
+    if (!vm.nameShown) {
       vm.nameRequired = false
     }
-    if (! vm.descriptionShown) {
+    if (!vm.descriptionShown) {
       vm.descriptionRequired = false
     }
 

--- a/client/app/services/process-snapshots-modal/process-snapshots-modal.html
+++ b/client/app/services/process-snapshots-modal/process-snapshots-modal.html
@@ -5,17 +5,17 @@
   <h4 class="modal-title" id="myModalLabel" translate>Create Snapshot</h4>
 </div>
 <div class="modal-body">
-  <form  name="createSnapshots" class="form-horizontal">
-    <pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Name *'|translate}}" required>
-      <input id="name" name="name" ng-model="vm.modalData.name" type="text" required/>
+  <form name="createSnapshots" class="form-horizontal">
+    <pf-form-group pf-input-class="col-sm-8" ng-show="vm.nameShown" pf-label-class="{{vm.nameLabelClass}}" pf-label="{{vm.nameLabel}}">
+      <input id="name" name="name" ng-model="vm.modalData.name" type="text" ng-required="vm.nameRequired" />
     </pf-form-group>
-    <pf-form-group pf-input-class="col-sm-8"  ng-show="vm.vm.power_state ==='on'" pf-label-class="col-sm-3" pf-label="{{'Memory'|translate}}">
-      <input id="memory" name="memory" ng-model="vm.modalData.memory" type="checkbox"/>
+    <pf-form-group pf-input-class="col-sm-8" ng-show="vm.vm.power_state ==='on'" pf-label-class="col-sm-3" pf-label="{{'Memory'|translate}}">
+      <input id="memory" name="memory" ng-model="vm.modalData.memory" type="checkbox" />
     </pf-form-group>
-    <pf-form-group pf-input-class="col-sm-8" pf-label-class="col-sm-3" pf-label="{{'Description'|translate}}">
-        <textarea id="description" name="description" ng-model="vm.modalData.description">
-          {{ vm.modalData.description }}
-        </textarea>
+    <pf-form-group pf-input-class="col-sm-8" ng-show="vm.descriptionShown" pf-label-class="{{vm.descriptionLabelClass}}" pf-label="{{vm.descriptionLabel}}">
+      <textarea id="description" name="description" ng-model="vm.modalData.description" ng-required="vm.descriptionRequired">
+        {{ vm.modalData.description }}
+      </textarea>
     </pf-form-group>
   </form>
 </div>


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-service/issues/1567

My Services > (service with VMs) > VM toolbar - Add a new Snapshot

Before:
name is always shown and required
description is never required

But for Ops UI:

* when @record.snapshot_name_optional?
  * name is hidden, not required
  * description is required
* otherwise, when @record.vendor == 'openstack'
  * name is shown & required
  * description is required
* otherwise
  * name is shown & required
  * description is optional

Doing the same thing here, except `snapshot_name_optional?` is not exposed via the API (this should be using the supports mixin instead IMO),
so hardcoding the list of vendors which set it for now.