### PR TITLE
Fix extraction of "Order # 608000000000012 and all of its service requests will be permanently removed!"

### DIFF
--- a/client/app/orders/process-order-modal/process-order-modal.html
+++ b/client/app/orders/process-order-modal/process-order-modal.html
@@ -6,7 +6,7 @@
 </div>
 <div class="modal-body">
   <i class="pf pficon-warning-triangle-o"></i>
-  <span>{{ vm.order.name }}{{ " and all of its service requests will be permanently removed!" | translate }}</span>
+  <span translate>{{ vm.order.name }} and all of its service requests will be permanently removed!</span>
   <hr>
   <h4 translate>Affected Order</h4>
   <icon-list items="[vm.order]"></icon-list>

--- a/language/validate.js
+++ b/language/validate.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 const path = require('path')
 const potFile = path.join(__dirname, '../client/gettext/po/manageiq-ui-service.pot')
 const contents = fs.readFileSync(potFile, 'utf8')
-const re = /<(.|\n)*>|{{(.|\n)*}}/gim // checks for html and also for javascript
+const re = /<(.|\n)*>/gim // checks for html
 const matches = contents.match(re)
 
 if (matches != null) {


### PR DESCRIPTION
When a string starts with leading space, the extractor trims the space, meaning the text will never get translated.

Making sure the whole phrase ends up in the catalog :).

Cc @mzazrivec 
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1752469