### PR TITLE
[EmbeddedAnsible] Fix stdout sanitization

### DIFF
--- a/client/app/services/service-details/service-details-ansible.component.js
+++ b/client/app/services/service-details/service-details-ansible.component.js
@@ -11,7 +11,7 @@ export const ServiceDetailsAnsibleComponent = {
 }
 
 /** @ngInject */
-function ComponentController (ModalService, ServicesState, lodash) {
+function ComponentController (ModalService, ServicesState, lodash, $sce) {
   const vm = this
   vm.$onInit = activate
   vm.$onChanges = changes
@@ -71,7 +71,7 @@ function ComponentController (ModalService, ServicesState, lodash) {
           vm.orcStacks[resourceName].jobs = []
           vm.orcStacks[resourceName].output = {}
           ServicesState.getServiceJobsStdout(vm.service.id, vm.orcStacks[resourceName].stack.id).then((response) => {
-            vm.orcStacks[resourceName].stdout = response.stdout || 'No standard out avaliable.'
+            vm.orcStacks[resourceName].stdout = $sce.trustAsHtml(response.stdout) || 'No standard out avaliable.'
             vm.orcStacks[resourceName].jobs = response.job_plays
             vm.orcStacks[resourceName].jobs.forEach((item) => {
               item.elapsed = vm.elapsed(item.finish_time, item.start_time)


### PR DESCRIPTION
Second half of this PR https://github.com/ManageIQ/manageiq/pull/19320

Since the API is now passing the full html source (for the moment), don't sanitize the HTML passed back from the API to retain it's formatting.

Fixes:  https://bugzilla.redhat.com/show_bug.cgi?id=1753721


Before
------

<img width="1173" alt="Screen Shot 2019-09-20 at 2 51 17 PM" src="https://user-images.githubusercontent.com/314014/65364850-19941780-dbda-11e9-8b4b-6baccecdf246.png">


After
-----

<img width="1180" alt="Screen Shot 2019-09-20 at 7 07 49 PM" src="https://user-images.githubusercontent.com/314014/65364853-2284e900-dbda-11e9-8322-1f44304f67b1.png">

