### PR TITLE
RBAC - use sui_dashboard_show instead of the sui_dashboard folder for VIEW dashboard permission

### DIFF
--- a/client/app/core/product-features.constants.json
+++ b/client/app/core/product-features.constants.json
@@ -6,7 +6,7 @@
       "NOTIFICATIONS": "sui_notifications"
     },
     "DASHBOARD": {
-      "VIEW": "sui_dashboard",
+      "VIEW": "sui_dashboard_show",
       "MONTHLY_CHARGES": "sui_dashboard_monthly_charge_view"
     },
     "SERVICES": {

--- a/tests/mock/rbac/allPermissions.json
+++ b/tests/mock/rbac/allPermissions.json
@@ -6905,12 +6905,17 @@
         "name": "Dashboard",
         "description": "Dashboard features",
         "children": [
-            "sui_dashboard_monthly_charge_view"
+            "sui_dashboard_monthly_charge_view",
+            "sui_dashboard_show"
         ]
     },
     "sui_dashboard_monthly_charge_view": {
         "name": "Monthly Charge view",
         "description": "Display monthly charges"
+    },
+    "sui_dashboard_show": {
+        "name": "View Dashboard",
+        "description": "Display any dashboards"
     },
     "sui_orders": {
         "name": "My Orders",


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/19657

This way, when the new "View Dashboard" feature is not set, there will be no Dashboard

https://bugzilla.redhat.com/show_bug.cgi?id=1783356

---

both "view dashboard" and "monthly charge view" on:

![sui_both](https://user-images.githubusercontent.com/289743/71103084-64a9d080-21b1-11ea-9734-43daa13167e9.png)

only "view dashboard":

![sui_show](https://user-images.githubusercontent.com/289743/71103100-6a9fb180-21b1-11ea-8a3b-b51f65f45120.png)

no "view dashboard" (regardless of "monthly charge view")

![sui_noshow](https://user-images.githubusercontent.com/289743/71103133-7c815480-21b1-11ea-92ef-f7ae10e583f5.png)
