### PR TITLE
AuthenticationApi - remove Promise wrapping

### DIFF
--- a/client/app/core/authentication-api.factory.spec.js
+++ b/client/app/core/authentication-api.factory.spec.js
@@ -33,6 +33,7 @@ describe('Authentication API', () => {
       })
     })
   })
+
   describe('failure case', () => {
     let mockDir = 'tests/mock/authentication-api/'
     const errorResponse = readJSON(mockDir + 'failure.json')
@@ -40,13 +41,10 @@ describe('Authentication API', () => {
     it('should fail Login', () => {
       Session.destroy()
       sinon.stub($http, 'get').returns(Promise.reject(errorResponse))
-      return AuthenticationApi.login('test', 'test').then(function (data) {
-        expect(Session.active()).to.eq(false)
-      }).catch((err) => {
-        if (err) {
-          expect(Session.active()).to.eq(false)
-        }
-      })
+
+      return AuthenticationApi.login('test', 'test')
+        .then(() => expect(false).to.eq(true)) // login didn't fail if the promise succeeds
+        .catch(() => expect(Session.active()).to.eq(false));
     })
   })
 })


### PR DESCRIPTION
by wrapping $http promises in Promise, we're no longer running the code within the angular digest cycle,
so any login error will fail to display a flash message until the user causes a digest cycle by clicking the submit button again, or changing the inputs.

Undoing that wrap :).

Caused by https://github.com/ManageIQ/manageiq-ui-service/pull/1142
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1793532