### PR TITLE
webpack - ignore vim swapfiles when watching for changes

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -199,5 +199,9 @@ module.exports = {
   // is not feasible to satisfy the recommendations until we start code splitting
   performance: {
     hints: false
-  }
+  },
+
+  watchOptions: {
+    ignored: ['**/.*.sw[po]'],
+  },
 }


### PR DESCRIPTION
otherwise, using vim with local swapfiles triggers recompilation even when opening a file, not only changing

same as https://github.com/ManageIQ/ui-components/pull/370,
and https://github.com/ManageIQ/manageiq-ui-classic/pull/5275