### PR TITLE
Session - use localStorage instead of sessionStorage

### DIFF
--- a/client/app/core/authorization.config.js
+++ b/client/app/core/authorization.config.js
@@ -44,13 +44,15 @@ export function authConfig ($httpProvider) {
 }
 
 /** @ngInject */
-export function authInit ($rootScope, $state, $log, Session, $sessionStorage, Language, $window, RBAC, ActionCable) {
+export function authInit ($rootScope, $state, $log, Session, $localStorage, Language, $window, RBAC, ActionCable) {
   $rootScope.$on('$stateChangeStart', changeStart)
   $rootScope.$on('$stateChangeError', changeError)
   $rootScope.$on('$stateChangeSuccess', changeSuccess)
 
-  $sessionStorage.$sync()  // needed when called right on reload
-  if ($sessionStorage.token) {
+  // needed when called right on reload
+  $localStorage.$sync();
+
+  if ($localStorage.token) {
     syncSession()
   }
 
@@ -82,8 +84,11 @@ export function authInit ($rootScope, $state, $log, Session, $sessionStorage, La
 
     // user is required and session not active - not going anywhere right away
     event.preventDefault()
-    $sessionStorage.$sync()  // needed when called right on reload
-    if (!$sessionStorage.token) {
+
+    // needed when called right on reload
+    $localStorage.$sync();
+
+    if (! $localStorage.token) {
       // no saved token, go directly to login
       $state.transitionTo('login')
       return
@@ -96,8 +101,8 @@ export function authInit ($rootScope, $state, $log, Session, $sessionStorage, La
 
   function syncSession () {
     // trying saved token..
-    Session.setAuthToken($sessionStorage.token)
-    Session.setGroup($sessionStorage.miqGroup)
+    Session.setAuthToken($localStorage.token)
+    Session.setGroup($localStorage.miqGroup)
 
     return Session.loadUser()
     .then(function (response) {

--- a/client/app/core/language.service.js
+++ b/client/app/core/language.service.js
@@ -1,7 +1,7 @@
 /* eslint camelcase: "off" */
 import languageFile from '../../gettext/json/available_languages.json'
 /** @ngInject */
-export function LanguageFactory ($http, $q, $log, $sessionStorage, Session, $window, gettextCatalog, lodash) {
+export function LanguageFactory ($http, $q, $log, $localStorage, Session, $window, gettextCatalog, lodash) {
   var availableAvailable = $q.defer()
   var service = {
     available: {
@@ -78,9 +78,9 @@ export function LanguageFactory ($http, $q, $log, $sessionStorage, Session, $win
   function onLogin (data) {
     setUser(data)
     var code = 'en'
-    if ($sessionStorage.loginLanguage) {
-      code = $sessionStorage.loginLanguage
-      delete $sessionStorage.loginLanguage
+    if ($localStorage.loginLanguage) {
+      code = $localStorage.loginLanguage
+      delete $localStorage.loginLanguage
       save(code)
       Session.updateUserSession({ settings: { locale: code } })
     } else {
@@ -162,7 +162,7 @@ export function LanguageFactory ($http, $q, $log, $sessionStorage, Session, $win
 
   function setLoginLanguage (code) {
     const languageCode = service.match(service.available, code)
-    $sessionStorage.loginLanguage = languageCode
+    $localStorage.loginLanguage = languageCode
     service.setLocale(code)
   }
 

--- a/client/app/core/polling.service.js
+++ b/client/app/core/polling.service.js
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function PollingFactory ($interval, $sessionStorage, lodash) {
+export function PollingFactory ($interval, $localStorage, lodash) {
   var service = {
     start: start,
     stop: stop,
@@ -17,8 +17,8 @@ export function PollingFactory ($interval, $sessionStorage, lodash) {
 
   function start (key, func, interval, limit) {
     var poll
-    if (angular.isDefined($sessionStorage.pause)) {
-      interval = $sessionStorage.pause
+    if (angular.isDefined($localStorage.pause)) {
+      interval = $localStorage.pause
     }
     if (!polls[key]) {
       poll = $interval(func, interval, limit)

--- a/client/app/core/session.service.spec.js
+++ b/client/app/core/session.service.spec.js
@@ -1,4 +1,4 @@
-/* global $sessionStorage, Session, readJSON, inject, $http, $cookies */
+/* global $localStorage, Session, readJSON, inject, $http, $cookies */
 /* eslint-disable no-unused-expressions */
 describe('Session', () => {
   let reloadOk
@@ -36,16 +36,16 @@ describe('Session', () => {
       })
     })
 
-    bard.inject('Session', 'RBAC', '$window', '$sessionStorage', '$httpBackend', 'gettextCatalog', '$state')
+    bard.inject('Session', 'RBAC', '$window', '$localStorage', '$httpBackend', 'gettextCatalog', '$state')
   })
 
   describe('switchGroup', () => {
     it('should persist and not reload the window', () => {
-      $sessionStorage.miqGroup = 'bad'
+      $localStorage.miqGroup = 'bad'
 
       Session.setGroup('good')
 
-      expect($sessionStorage.miqGroup).to.eq('good')
+      expect($localStorage.miqGroup).to.eq('good')
       expect(reloadOk).to.eq(false)
     })
 
@@ -61,9 +61,9 @@ describe('Session', () => {
     })
 
     it('updates user session storage', () => {
-      $sessionStorage.user = JSON.stringify(readJSON('tests/mock/session/user.json'))
+      $localStorage.user = JSON.stringify(readJSON('tests/mock/session/user.json'))
       Session.updateUserSession({settings: {ui_service: {display: {locale: 'fr'}}}})
-      let user = JSON.parse($sessionStorage.user)
+      let user = JSON.parse($localStorage.user)
       expect(user.settings.ui_service.display.locale).to.eq('fr')
     })
   })
@@ -134,18 +134,18 @@ describe('Session', () => {
     it('allows a user to be retrieved from session', () => {
       const user = readJSON('tests/mock/session/user.json')
       const expectedUserProps = ['userid', 'name', 'user_href', 'group', 'group_href', 'role', 'role_href', 'tenant', 'groups']
-      $sessionStorage.user = user
+      $localStorage.user = user
       Session.loadUser()
       const userInfo = Session.currentUser()
       expect(userInfo).to.have.all.keys(expectedUserProps)
     })
     it('allows miq user group to be set from session', () => {
       const user = readJSON('tests/mock/session/user.json')
-      $sessionStorage.selectedMiqGroup = 'EvmGroup-super_administrator'
-      $sessionStorage.user = user
+      $localStorage.selectedMiqGroup = 'EvmGroup-super_administrator'
+      $localStorage.user = user
       Session.loadUser()
 
-      expect($sessionStorage.miqGroup).to.eq('EvmGroup-super_administrator')
+      expect($localStorage.miqGroup).to.eq('EvmGroup-super_administrator')
     })
     it('allow a ws token to be set', (done) => {
       bard.inject('$http', '$cookies')

--- a/client/app/states/login/login.e2e.js
+++ b/client/app/states/login/login.e2e.js
@@ -1,7 +1,7 @@
 describe('pages with login', function () {
   it('should log in with a non-Angular page', function () {
     console.log('Executing login Test')
-    browser.driver.executeScript('return window.sessionStorage.getItem("ngStorage-token");').then(function (retValue) {
+    browser.driver.executeScript('return window.localStorage.getItem("ngStorage-token");').then(function (retValue) {
       console.log('Token value =>' + retValue)
       expect(retValue).not.toBe(null)
     })


### PR DESCRIPTION
sessionStorage is not shared between tabs (unless one gets opened from the other),
and disappears when closing the tab.

Thus, opening a link in a new tab just doesn't work and redirects to `/login`.
Changing to use localStorage instead - the same change was needed in ui-classic: https://github.com/ManageIQ/manageiq-ui-classic/pull/3065

The one place that's still using sessionStorage after this is the ApplianceInfo service, for caching. That looks more like ephemeral cache which doesn't have to be shared.

Fixes https://github.com/ManageIQ/manageiq-ui-service/issues/1527