### PR TITLE
Login - show error message on any failure, not just 401

### DIFF
--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -78,13 +78,23 @@ function StateController ($window, $state, Text, RBAC, API_LOGIN, API_PASSWORD, 
       }
     })
     .catch((response) => {
+      let message = __('Login failed.');
+      let error = response.data && response.data.error && response.data.error.message;
+
       if (response.status === 401) {
-        vm.credentials.login = ''
-        vm.credentials.password = ''
-        const message = response.data.error.message
-        Notifications.message('danger', '', __('Login failed, possibly invalid credentials. ') + `(${message})`, false)
+        vm.credentials.login = '';
+        vm.credentials.password = '';
+
+        message = __('Login failed, possibly invalid credentials.');
       }
-      Session.destroy()
+
+      if (!error && response.status >= 300) {
+        error = `${response.status} ${response.statusText}`;
+      }
+
+      Notifications.message('danger', '', error ? `${message} (${error})` : message, false);
+
+      Session.destroy();
     })
     .then(() => {
       vm.spinner = false

--- a/client/app/states/login/login.state.js
+++ b/client/app/states/login/login.state.js
@@ -52,7 +52,6 @@ function StateController ($window, $state, Text, RBAC, API_LOGIN, API_PASSWORD, 
   }
 
   function onSubmit () {
-    Session.timeoutNotified = false
     Session.privilegesError = false
     vm.spinner = true
 

--- a/client/app/states/login/login.state.spec.js
+++ b/client/app/states/login/login.state.spec.js
@@ -22,9 +22,8 @@ describe('State: login', () => {
         expect(ctrl.text.brand).to.equal('<strong>ManageIQ</strong> Service UI')
       })
 
-      it('sets session timeoutNotified and privilegesError', () => {
+      it('sets session privilegesError', () => {
         ctrl.onSubmit()
-        expect(Session.timeoutNotified).to.be.false
         expect(Session.privilegesError).to.be.false
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -4454,7 +4454,7 @@ glob@^6.0.4:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.3:
+glob@^7.0.5, glob@^7.1.3:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-service/issues/1626

before https://github.com/ManageIQ/manageiq-ui-service/pull/1142:
always show 'Login failed, possibly invalid credentials.'

before now
on 401, show 'Login failed, possibly invalid credentials. (Authentication failed)'
else no error

now
on 401, show 'Login failed, possibly invalid credentials. (Authentication failed)'
on 504, show 'Login failed. (504 Gateway Timeout)', etc.
on code error in api: 'Login failed. (wrong number of arguments (given 8, expected 2..4))'
else, show 'Login failed.'

Prefer to read the error message from the API response, but replace with the status code if nothing is there.

![nope](https://user-images.githubusercontent.com/289743/73656293-bc2fcd00-4687-11ea-99fc-85980754c068.png)
![504](https://user-images.githubusercontent.com/289743/73656296-bdf99080-4687-11ea-93cf-758e85cac037.png)
![xxx](https://user-images.githubusercontent.com/289743/73656299-bf2abd80-4687-11ea-831a-1989337fccf4.png)
