### PR TITLE
settings.help_menu.documentation - Fix missing href "Cannot read property 'match' of undefined"

### DIFF
--- a/client/app/core/navigation/navigation-controller.js
+++ b/client/app/core/navigation/navigation-controller.js
@@ -92,12 +92,16 @@ export function NavigationController (Text, Navigation, Session, API_BASE, Shopp
     })
 
     CollectionsApi.query('settings/help_menu/documentation').then((data) => {
-      const documentation = data.help_menu.documentation
-      const matches = documentation.href.match(/http.*(http.*)/)
-      if (matches[1]) {
-        vm.documentation = matches[1]
+      const href = data.help_menu && data.help_menu.documentation && data.help_menu.documentation.href;
+      if (! href) {
+        return;
       }
-    })
+
+      // fixes "http://localhost:3000/api/http://www.google.com"
+      const matches = href.match(/http.*(http.*)/);
+      vm.documentation = matches[1] || href;
+    });
+
     vm.items = Navigation.init()
     refresh()
     if (ShoppingCart.allowed()) {


### PR DESCRIPTION
The code assumes `settings.help_menu.documentation` contains a href, and fails without it.

But the href is there only if we want to override the link, fixing.

Also, the original code expects the href to always be http://api_location/api/http://the_href.com ,
now it will parse that if present, but fall back to just using the href if not.

(I do not see any ui-classic references to the setting.)