### PR TITLE
build:git-hash: prefer reading from BUILD if available

### DIFF
--- a/config/githash.js
+++ b/config/githash.js
@@ -1,11 +1,15 @@
-const shell = require('shelljs')
-const fs = require('fs')
-const path = require('path')
-const filePath = path.join(__dirname, '../client/version/version.json')
-const gitCommit = shell.exec('git rev-parse HEAD', {silent: true}).stdout
+const { exec } = require('shelljs');
+const { existsSync, readFileSync, writeFileSync } = require('fs');
+const { join } = require('path');
 
-const gitFileContents = `{"gitCommit": "${gitCommit.replace("\n", '')}"}` // eslint-disable-line 
-fs.writeFile(filePath, gitFileContents, (err) => {
-  if (err) throw err
-  console.log(`Successfully wrote Git hash - ${gitCommit}`)
-})
+const input = join(__dirname, '../BUILD');
+const output = join(__dirname, '../client/version/version.json');
+
+let gitCommit = existsSync(input)
+  ? readFileSync(input, { encoding: 'utf-8' })
+  : exec('git rev-parse HEAD', { silent: true }).stdout;
+gitCommit = gitCommit.replace("\n", '');
+
+writeFileSync(output, JSON.stringify({ gitCommit }));
+
+console.log(`Successfully wrote Git hash - ${gitCommit}`);


### PR DESCRIPTION
`yarn run build` runs `build:git-hash` which runs `config/githash.js`, which creates `client/version/version.json` with the current git sha, by running git rev-parse.

For container builds, we don't have git, so the commit is empty.

This updates the task to try reading a `BUILD` file in SUI root, and using its contents as the sha.
(If a `BUILD` file is not present, it falls back to `git rev-parse`, and empty commit if that fails.)

Fixes #1634, cc @simaishi :)