### PR TITLE
_login: change #brand img height from default to what ui-classic uses

### DIFF
--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -7,8 +7,10 @@
   margin-bottom: -38px
   margin-top: -60px
 
-  #brand img
-    height: 38px !important
+  // override .login-pf #brand img to match ui-classic brand.scss
+  #brand // sass-lint:disable-line no-ids
+    img
+      height: 38px !important // sass-lint:disable-line no-important
 
   .container
     padding-top: 0

--- a/client/app/states/login/_login.sass
+++ b/client/app/states/login/_login.sass
@@ -7,6 +7,9 @@
   margin-bottom: -38px
   margin-top: -60px
 
+  #brand img
+    height: 38px !important
+
   .container
     padding-top: 0
 


### PR DESCRIPTION
Change the login size brand image from height 18 to 38.

ui-classic and ui-service are using the same brand.svg image,
but ui-service defaults to the patternfly 18px height,
while ui-classic overrides the height to 38px.

Updating to do the same.

Before:

![before](https://user-images.githubusercontent.com/289743/79343788-621c7500-7f1e-11ea-9573-aa44d10dd849.png)

After:

![after](https://user-images.githubusercontent.com/289743/79343798-65affc00-7f1e-11ea-9dcc-b792c30c5f8c.png)

ui-classic:

![miq](https://user-images.githubusercontent.com/289743/79343805-69438300-7f1e-11ea-96ef-7a0edc5c8c69.png)


Cc @epwinchell @john-dupuy