### PR TITLE
Service Orders: only show ServiceOrderCart instances

### DIFF
--- a/client/app/core/navigation.service.js
+++ b/client/app/core/navigation.service.js
@@ -58,7 +58,7 @@ export function NavigationFactory (RBAC, Polling, POLLING_INTERVAL, $ngRedux, Co
         iconClass: 'fa fa-file-o',
         badgeQuery: {
           'field': 'service_orders',
-          'filter': 'state=ordered'
+          'filter': ['state=ordered', 'type=ServiceOrderCart'],
         },
         badges: [
           {
@@ -121,7 +121,7 @@ export function NavigationFactory (RBAC, Polling, POLLING_INTERVAL, $ngRedux, Co
     const options = {
       hide: 'resources',
       auto_refresh: true,
-      filter: [filter],
+      filter: Array.isArray(filter) ? filter : [filter],
     };
 
     return CollectionsApi.query(field, options).then((data) => data.subquery_count);

--- a/client/app/orders/orders-state.service.js
+++ b/client/app/orders/orders-state.service.js
@@ -45,7 +45,7 @@ export function OrdersStateFactory (ListConfiguration, CollectionsApi, RBAC) {
   // Private
 
   function getQueryFilters (filters) {
-    const queryFilters = ['state=ordered']
+    const queryFilters = ['state=ordered', 'type=ServiceOrderCart'];
 
     angular.forEach(filters, function (nextFilter) {
       if (nextFilter.id === 'name') {


### PR DESCRIPTION
by filtering for ServiceOrderCart, we're excluding ServiceOrderV2V

(the filter *should* be for kind_of instead of the exact type, but the API doesn't support it and there are no ServiceOrderCart subclasses)

Fixes #1463

Related PRs (merged):

* https://github.com/ManageIQ/manageiq-schema/pull/452
* https://github.com/ManageIQ/manageiq/pull/19795
* https://github.com/ManageIQ/manageiq-api/pull/773