### PR TITLE
[JANSA] Update ui components to 1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "@manageiq/font-fabulous": "1.0.3",
-    "@manageiq/ui-components": "1.3.5",
+    "@manageiq/ui-components": "1.3.6",
     "@uirouter/angularjs": "1.0.20",
     "actioncable": "5.2.1",
     "angular": "1.7.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,10 +113,10 @@
   resolved "https://registry.yarnpkg.com/@manageiq/font-fabulous/-/font-fabulous-1.0.3.tgz#3e1fa8391866c82529f19cf2580f6092b6ef1a04"
   integrity sha512-K0YFaADF+3JrKfuHA322YE/mjKRrgOpx82QCCw4b4BrBN6HX6hOuUfpmWpV4FPWObmqSOQp1kD7Mcx1Z8vhhtg==
 
-"@manageiq/ui-components@1.3.5":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.3.5.tgz#6f1c14fd9521dd5f15ef76e9238149f6d35a9f20"
-  integrity sha512-UfNSOjCJhOKoRgbbERrrtVN6+ks26LuwvAsM9OgDGGnak13SacZD/SDviLXPPWHoRBox6CI/GbycQWnAO6xbWg==
+"@manageiq/ui-components@1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@manageiq/ui-components/-/ui-components-1.3.6.tgz#998cc942343fdc9a9028d0ae0bb2adcf51dd1eee"
+  integrity sha512-w+K+kXIkF5UqZpp3g2PL9+ZOybK9rFHAhYJc+WIRIFZbqIbeqF6yVKnirFr06rZEwMvxiOB6qEyLldO9RRAsvQ==
   dependencies:
     angular-bootstrap-switch "^0.5.1"
     angular-dragdrop "^1.0.13"


### PR DESCRIPTION
Includes:

* https://github.com/ManageIQ/ui-components/pull/438
* https://github.com/ManageIQ/ui-components/pull/443
* https://github.com/ManageIQ/ui-components/pull/444
* https://github.com/ManageIQ/ui-components/pull/442