### PR TITLE
Honor 'display' parameter for button groups

### DIFF
--- a/client/app/services/custom-button/custom-button.html
+++ b/client/app/services/custom-button/custom-button.html
@@ -20,7 +20,9 @@
             uib-tooltip="{{buttonGroup.description}}"
             tooltip-placement="top">
       <i ng-class="buttonGroup.set_data.button_icon" ng-style="{color: buttonGroup.set_data.button_color }"></i>
-      {{ buttonGroup.name.split('|')[0] }}
+        <span ng-if="buttonGroup.set_data.display">
+          {{ buttonGroup.name.split('|')[0] }}
+        </span>
       <span class="caret"></span>
     </button>
     <ul uib-dropdown-menu role="menu" aria-labelledby="{{buttonGroup.id}}">


### PR DESCRIPTION
1. In OPS UI, create a button group for Services, make sure it has the `Display on Button` property unchecked
2. In Service UI, navigate to a service summary screen, see whether the display property is being honored.

Without this fix, the property would not get honored in Service UI.

After this fix, with display disabled:
![Screenshot from 2020-08-26 16-56-46](https://user-images.githubusercontent.com/6648365/91320360-b3d2e700-e7bd-11ea-9b41-9abbe72cce60.png)

With display enabled:
![Screenshot from 2020-08-26 16-57-13](https://user-images.githubusercontent.com/6648365/91320375-b9c8c800-e7bd-11ea-8515-764b1259c066.png)


https://bugzilla.redhat.com/show_bug.cgi?id=1745492