### PR TITLE
yarn run build - create webpack-modules-manifest.json

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -47,7 +47,7 @@ config.plugins.push(
       // find the package.json file for each module
       modules = modules.filter(m => m.includes("node_modules"));
       var packagePaths = modules.map(m => {
-        var match = m.match(/(.*node_modules\/)([^\/]+)(\/[^\/]+)?/);
+        var match = m.match(/(.*node_modules\/)([^/]+)(\/[^/]+)?/);
         var path = [
           `${match[1]}${match[2]}/package.json`,
           `${match[1]}${match[2]}${match[3]}/package.json`,
@@ -65,11 +65,11 @@ config.plugins.push(
       // extract relevant package data from the package.json
       var packages = packagePaths.map(p => {
         var content = fs.readFileSync(p);
-        var package = JSON.parse(content);
+        var pkg = JSON.parse(content);
         return {
-          name: package.name,
-          license: package.license,
-          version: package.version,
+          name: pkg.name,
+          license: pkg.license,
+          version: pkg.version,
           location: p
         }
       });

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -3,6 +3,10 @@ const CleanWebpackPlugin = require('clean-webpack-plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const OptimizeCssAssetsWebpackPlugin = require('optimize-css-assets-webpack-plugin')
 
+const { StatsWriterPlugin } = require('webpack-stats-plugin');
+const fs = require('fs');
+const sortBy = require('lodash/sortBy');
+
 const config = require('./webpack.dev.js')
 
 // Source maps suitable for production use
@@ -25,7 +29,55 @@ config.plugins.push(
     chunks: ['app']
   }),
 
-  new OptimizeCssAssetsWebpackPlugin()
+  new OptimizeCssAssetsWebpackPlugin(),
+
+  // Write out dependencies list for audit purposes
+  new StatsWriterPlugin({
+    filename: "webpack-modules-manifest.json",
+    fields: ["modules"],
+
+    transform(data) {
+      // recursively flatten nested modules
+      const transformModule  = m  => m.modules ? transformModules(m.modules) : m.name.split("!").pop();
+      const transformModules = ms => ms.flatMap(m => transformModule(m));
+
+      var modules = transformModules(data.modules)
+      modules = [...new Set(modules)]; // uniq
+
+      // find the package.json file for each module
+      modules = modules.filter(m => m.includes("node_modules"));
+      var packagePaths = modules.map(m => {
+        var match = m.match(/(.*node_modules\/)([^\/]+)(\/[^\/]+)?/);
+        var path = [
+          `${match[1]}${match[2]}/package.json`,
+          `${match[1]}${match[2]}${match[3]}/package.json`,
+        ].find(p => fs.existsSync(p));
+
+        if (path == null) {
+          console.warn(`[webpack-manifest] WARN: Unable to find a package.json for ${m}`);
+        }
+
+        return path;
+      })
+      packagePaths = packagePaths.filter(p => p != null);
+      packagePaths = [...new Set(packagePaths)]; // uniq
+
+      // extract relevant package data from the package.json
+      var packages = packagePaths.map(p => {
+        var content = fs.readFileSync(p);
+        var package = JSON.parse(content);
+        return {
+          name: package.name,
+          license: package.license,
+          version: package.version,
+          location: p
+        }
+      });
+      packages = sortBy(packages, ['name', 'version']);
+
+      return JSON.stringify(packages, null, 2);
+    }
+  })
 )
 
 module.exports = config

--- a/package.json
+++ b/package.json
@@ -144,7 +144,8 @@
     "style-loader": "0.21.0",
     "url-loader": "0.6.2",
     "webpack": "3.11.0",
-    "webpack-dev-server": "2.11.1"
+    "webpack-dev-server": "2.11.1",
+    "webpack-stats-plugin": "~0.3.2"
   },
   "browserslist": [
     "last 2 versions",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9777,6 +9777,11 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
+webpack-stats-plugin@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.3.2.tgz#c06b185aa5dcc93b3f0c3a7891d24a111f849740"
+  integrity sha512-kxEtPQ6lBBik2qtJlsZkiaDMI6rGXe9w1kLH9ZCdt0wgCGVnbwwPlP60cMqG6tILNFYqXDxNt4+c4OIIuE+Fnw==
+
 webpack@3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.11.0.tgz#77da451b1d7b4b117adaf41a1a93b5742f24d894"


### PR DESCRIPTION
This causes the build to output `manageiq/public/ui/service/webpack-modules-manifest.json`,
in the same format as ui-classic since ManageIQ/manageiq-ui-classic#7180 + ManageIQ/manageiq-ui-classic#7291.
(It's literally the same code.)

Fixes https://github.com/ManageIQ/manageiq-ui-service/issues/1670

Cc @Fryguy , @bhadrim