### PR TITLE
Fix webmks console js/css paths

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -192,7 +192,6 @@ module.exports = {
     }),
 
     new HtmlWebpackPlugin({
-      base: '/',
       filename: 'console/webmks.html',
       template: '../client/console/common.ejs',
       chunks: ['console_webmks']


### PR DESCRIPTION
Fixes #1688

With `base: '/'`, the generated file (`../manageiq/public/ui/service/console/webmks.html`) contains...

    <base href="/">
    <link href="../styles/console_webmks-HASH.css" rel="stylesheet">
    ...
    <script src="../js/console_webmks-HASH.js">

that breaks on appliances where Service UI always runs as `/ui/service`.

The base causes all the relative links to be interporeted as `/styles/...` and `/js/...`,
instead of the proper relative paths (relative to `/ui/service/console/`), leading to 404s.

(The relative path in development is `/console`, so the base isn't needed for development either.)

Cc @skateman , comes from https://github.com/ManageIQ/manageiq-ui-service/pull/1554