### PR TITLE
My Orders list: fix TypeError

### DIFF
--- a/client/app/shared/pagination/pagination.component.js
+++ b/client/app/shared/pagination/pagination.component.js
@@ -60,7 +60,7 @@ function ComponentController () {
   }
 
   function initCheckAll () {
-    vm.checkAllState = vm.checkAll.checked || false
+    vm.checkAllState = vm.checkAll && vm.checkAll.checked || false
     vm.lastCheckAllState = vm.checkAllState
   }
 


### PR DESCRIPTION
Pagination check all support from https://github.com/ManageIQ/manageiq-ui-service/pull/1533 fails when not passing a `checkAll` object to pagination from the start.

    angular.js:15635 TypeError: [ManageIQ] Cannot read property 'checked' of undefined
        at initCheckAll (app-6c33a85c672b91a2d834.js:327476)
        at ComponentController.vm.$onChanges (app-6c33a85c672b91a2d834.js:327459)

Make sure we default to false in such case.