### PR TITLE
Add a bin/setup script for cross-repo to setup yarn

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+set -vx
+yarn


### PR DESCRIPTION
For cross-repo to run tests for this repo we have to give it a way to do initial setup then run the tests.  We can override the script_cmd with `yarn run test` but we need to have it run `yarn` before that.