### PR TITLE
[WIP] Update ui-components to 1.5

### DIFF
--- a/client/app/core/core.module.js
+++ b/client/app/core/core.module.js
@@ -43,7 +43,7 @@ import { SiteSwitcher } from './site-switcher/site-switcher.component.js'
 export const CoreModule = angular
   .module('app.core', [
     'gettext',
-    'miqStaticAssets.dialogUser', // also implies miqStaticAssets.miqSelect
+    'miqStaticAssets.dialogUser', // also implies miqStaticAssets.treeView, miqStaticAssets.treeSelector, miqStaticAssets.miqSelect
     'ngAnimate',
     'ngCookies',
     'ngMessages',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@manageiq/font-fabulous": "~1.0.5",
-    "@manageiq/ui-components": "1.4.4",
+    "@manageiq/ui-components": "~1.5.0",
     "@pf3/select": "~1.12.6",
     "@uirouter/angularjs": "~1.0.28",
     "actioncable": "~5.2.4-4",


### PR DESCRIPTION
Part of ManageIQ/manageiq-ui-classic#6716

Once ManageIQ/ui-components#455 is released as 1.5.0,
this should make ui-classic use that version and work.

---

TODO verify peerDependencies