### PR TITLE
WebMKS: fix mix of common js and import/export

### DIFF
--- a/client/console/common.js
+++ b/client/console/common.js
@@ -1,6 +1,6 @@
 import languageFile from '../gettext/json/manageiq-ui-service.json'
 
-module.exports = () => {
+export default function() {
   const urlParams = new URLSearchParams(window.location.search)
 
   const params = ['path', 'is_vcloud', 'vmx', 'lang'].reduce((map, obj) => {

--- a/client/console/webmks.js
+++ b/client/console/webmks.js
@@ -3,7 +3,7 @@ require('jquery-ui-bundle')
 require('es6-shim')
 require('patternfly/dist/css/patternfly.css')
 require('patternfly/dist/css/patternfly-additions.css')
-let initRemoteConsole = require('./common')
+let initRemoteConsole = require('./common').default;
 
 /* global WMKS */
 


### PR DESCRIPTION
`console/webmks.js` requires `console/common.js`, but common is using modern js `import` but combining it with common js `module.exports` for exports.

This leads  to `TypeError: Cannot assign to read only property 'exports' of object '#'` when opening webmks consoles.

Fixing to use import/export.

Fixes #1697 