### PR TITLE
Fix viewAnsible permissions

### DIFF
--- a/client/app/services/services-state.service.js
+++ b/client/app/services/services-state.service.js
@@ -138,7 +138,7 @@ export function ServicesStateFactory (ListConfiguration, CollectionsApi, RBAC) {
       retire: RBAC.has(RBAC.FEATURES.SERVICES.RETIRE.RETIRE_NOW),
       setRetireDate: RBAC.has(RBAC.FEATURES.SERVICES.RETIRE.SET_DATE),
       editTags: RBAC.has(RBAC.FEATURES.SERVICES.TAGS),
-      viewAnsible: RBAC.hasAny(['configuration_script_view', 'configuration_scripts_accord']),
+      viewAnsible: RBAC.hasAny(['service_view']),
       serviceStart: RBAC.has(RBAC.FEATURES.SERVICES.START),
       serviceStop: RBAC.has(RBAC.FEATURES.SERVICES.STOP),
       serviceSuspend: RBAC.has(RBAC.FEATURES.SERVICES.SUSPEND),


### PR DESCRIPTION
These permissions where changed here: https://github.com/ManageIQ/manageiq/pull/19949

and as such, the Ansible playbook results would not be displayed.

Changing to use "service_view" permission since the manageiq-ui-classic uses "service" (level above), and this is only displaying the view, so this should be the only permission required.

Links
-----

* PR that removed the previous permission in `jansa`/`kasparov/`lasker`: https://github.com/ManageIQ/manageiq/pull/19949
* PR that added the permissions back: https://github.com/ManageIQ/manageiq/pull/21065

QA steps
--------

Directions for reproduction and testing of fix can be found in this gist:

https://gist.github.com/NickLaMuro/98878456f03d499c3d2acba736e8f63a


@miq-bot add-labels jansa/yes?,kasparov/yes?,lasker/yes?