### PR TITLE
Support the act tool for testing GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,13 @@ jobs:
         - 12
     steps:
     - uses: actions/checkout@v2
+    - name: Set up system
+      run: bin/before_install
     - name: Set up Node
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-        cache: yarn
+        cache: ${{ !env.ACT && 'yarn' || '' }}
         registry-url: https://npm.manageiq.org/
     - name: Prepare tests
       run: bin/setup

--- a/bin/before_install
+++ b/bin/before_install
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -n "$ACT" ]; then
+  curl -o- -L https://yarnpkg.com/install.sh | bash
+  echo "$HOME/.yarn/bin" >> $GITHUB_PATH
+  echo "$HOME/.config/yarn/global/node_modules/.bin" >> $GITHUB_PATH
+fi


### PR DESCRIPTION
https://github.com/nektos/act is a tool for running github actions locally...there's a lot that is missing, but it works mostly.  I can recreate master failures with it and with these changes.