### PR TITLE
drop adhoc metrics references

### DIFF
--- a/tests/mock/rbac/allPermissions.json
+++ b/tests/mock/rbac/allPermissions.json
@@ -3028,16 +3028,11 @@
         "name": "View",
         "description": "View Containers Providers",
         "children": [
-            "ems_container_ad_hoc_metrics",
             "ems_container_show_list",
             "ems_container_show",
             "ems_container_timeline",
             "ems_container_perf"
         ]
-    },
-    "ems_container_ad_hoc_metrics": {
-        "name": "Ad hoc Metrics",
-        "description": "Show Ad hoc Metrics of Providers"
     },
     "ems_container_show_list": {
         "name": "List",

--- a/tests/mock/session/user.json
+++ b/tests/mock/session/user.json
@@ -3010,16 +3010,11 @@
                 "name": "View",
                 "description": "View Containers Providers",
                 "children": [
-                    "ems_container_ad_hoc_metrics",
                     "ems_container_show_list",
                     "ems_container_show",
                     "ems_container_timeline",
                     "ems_container_perf"
                 ]
-            },
-            "ems_container_ad_hoc_metrics": {
-                "name": "Ad hoc Metrics",
-                "description": "Show Ad hoc Metrics of Providers"
             },
             "ems_container_show_list": {
                 "name": "List",


### PR DESCRIPTION
These have been removed from our product, so removing them from tests

part of https://github.com/ManageIQ/manageiq-ui-classic/pull/8357