### PR TITLE
Upgrading qs:~6.5.2 dependency to use version: 6.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "clean-webpack-plugin": "~3.0.0",
     "copy-webpack-plugin": "~6.3.0",
     "coverage-istanbul-loader": "~3.0.5",
-    "coveralls": "~3.1.0",
+    "coveralls": "~3.1.1",
     "css-loader": "~5.0.1",
     "ejs": "~3.1.7",
     "eslint": "~7.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2288,7 +2288,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"angular-animate@npm:^1.7.7, angular-animate@npm:~1.8.0":
+"angular-animate@npm:^1.7.7":
+  version: 1.8.3
+  resolution: "angular-animate@npm:1.8.3"
+  checksum: 3d26d3765aa4261d6f4dc94089ba1163d53fe7c8324e0a2604ae07246f12f7a0cf044bafce7b33cbb4df86ce10651a6c582afc4ee615d387598e5f4d4c7e245a
+  languageName: node
+  linkType: hard
+
+"angular-animate@npm:~1.8.0":
   version: 1.8.2
   resolution: "angular-animate@npm:1.8.2"
   checksum: 6590940545a05bf678ed8c71cfe19409abe4ca634e73c29f0006bc1ce5bafe645da87bc2f483f09584653881201bac2562c8f39d7aeea2c2aea7f6a1f3a0bbde
@@ -2439,7 +2446,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"angular-sanitize@npm:^1.7.7, angular-sanitize@npm:~1.8.0":
+"angular-sanitize@npm:^1.7.7":
+  version: 1.8.3
+  resolution: "angular-sanitize@npm:1.8.3"
+  checksum: b48d13f6cf3c33e790c7d9ef0694975e29d4cf03535e206ff4227f0ebfe1c5834a19a1a9132b7845f3556291426a1976fb9b9234b60fdb3e6c82f1c8dc35c590
+  languageName: node
+  linkType: hard
+
+"angular-sanitize@npm:~1.8.0":
   version: 1.8.2
   resolution: "angular-sanitize@npm:1.8.2"
   checksum: df06ddee2aa6e2c9daa8eee70d2e2ec701082e1d7285dcd0dd762ec967a1d118f362f1f21c574f9fb1799c5a2bfc0784fdc9ce4a2cceac78179e9a6edc8e02ef
@@ -2487,10 +2501,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"angular@npm:>=1.2.x, angular@npm:>=1.3.0, angular@npm:>=1.4.0, angular@npm:^1.7.7, angular@npm:~1.8.0":
+"angular@npm:>=1.2.x, angular@npm:>=1.4.0, angular@npm:~1.8.0":
   version: 1.8.2
   resolution: "angular@npm:1.8.2"
   checksum: 35ea81a23b8c0231a17c90a8aa69f63856bc8ab767c15131089bcc8b55435ed8c2ad803d60ad86f187a9235708d73cc76e1310abae8cad7c87127c19a3e4f932
+  languageName: node
+  linkType: hard
+
+"angular@npm:>=1.3.0, angular@npm:^1.7.7":
+  version: 1.8.3
+  resolution: "angular@npm:1.8.3"
+  checksum: 1494625fef6252070771bdf622eda43b438841cfc84bc8c47a0e51f7ce7256a8aefaa7f3c605247c09c9558d653751a233443e252d5070e457be3c64b648370d
   languageName: node
   linkType: hard
 
@@ -2748,11 +2769,11 @@ __metadata:
   linkType: hard
 
 "asn1@npm:~0.2.3":
-  version: 0.2.4
-  resolution: "asn1@npm:0.2.4"
+  version: 0.2.6
+  resolution: "asn1@npm:0.2.6"
   dependencies:
     safer-buffer: ~2.1.0
-  checksum: aa5d6f77b1e0597df53824c68cfe82d1d89ce41cb3520148611f025fbb3101b2d25dd6a40ad34e4fac10f6b19ed5e8628cd4b7d212261e80e83f02b39ee5663c
+  checksum: 39f2ae343b03c15ad4f238ba561e626602a3de8d94ae536c46a4a93e69578826305366dc09fbb9b56aec39b4982a463682f259c38e59f6fa380cd72cd61e493d
   languageName: node
   linkType: hard
 
@@ -4188,7 +4209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"coveralls@npm:~3.1.0":
+"coveralls@npm:~3.1.1":
   version: 3.1.1
   resolution: "coveralls@npm:3.1.1"
   dependencies:
@@ -5043,12 +5064,12 @@ __metadata:
   linkType: hard
 
 "datatables.net-dt@npm:^1.10.11":
-  version: 1.11.3
-  resolution: "datatables.net-dt@npm:1.11.3"
+  version: 1.13.1
+  resolution: "datatables.net-dt@npm:1.13.1"
   dependencies:
-    datatables.net: ">=1.10.25"
+    datatables.net: ">=1.12.1"
     jquery: ">=1.7"
-  checksum: 16247a64c9976cd07e179f6b2162f28379e96c5b78f126b99f15181abfa34c793e410d93aa54604ec55ed19cdbf0fbccf911ffeaea96be819ba30a52fbe46eba
+  checksum: 0210ebc0d79ff34a5ab56ed09faf3b23afd6d8b1ab501a78610afd7063ef9c1a11c0e4431c84376a488421ffde3e1abfa97e574304e9d0254c87e39cf1419992
   languageName: node
   linkType: hard
 
@@ -5062,12 +5083,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"datatables.net@npm:>=1.10.25, datatables.net@npm:>=1.10.9, datatables.net@npm:^1.10.11, datatables.net@npm:^1.10.12, datatables.net@npm:^1.10.15":
+"datatables.net@npm:>=1.10.25, datatables.net@npm:>=1.10.9, datatables.net@npm:^1.10.15":
   version: 1.11.3
   resolution: "datatables.net@npm:1.11.3"
   dependencies:
     jquery: ">=1.7"
   checksum: 0bed39cee15d00d6776f5c1aba31fafcb7351863683a656d168699297d2c5c5d0e97bfb690393a0a0393fc27b9e6c4ea8f8701190d746ab59d33e60441c6434b
+  languageName: node
+  linkType: hard
+
+"datatables.net@npm:>=1.12.1, datatables.net@npm:^1.10.11, datatables.net@npm:^1.10.12":
+  version: 1.13.1
+  resolution: "datatables.net@npm:1.13.1"
+  dependencies:
+    jquery: ">=1.7"
+  checksum: 0b473bf2b869a11389549b8073b53806a0a6844a203d56af39a2f40b23e1d99543b51e0512db65b203b1372c862f56624caf991ffcd7906a174dc82aeb1022de
   languageName: node
   linkType: hard
 
@@ -6478,9 +6508,9 @@ __metadata:
   linkType: hard
 
 "extsprintf@npm:^1.2.0":
-  version: 1.4.0
-  resolution: "extsprintf@npm:1.4.0"
-  checksum: 184dc8a413eb4b1ff16bdce797340e7ded4d28511d56a1c9afa5a95bcff6ace154063823eaf0206dbbb0d14059d74f382a15c34b7c0636fa74a7e681295eb67e
+  version: 1.4.1
+  resolution: "extsprintf@npm:1.4.1"
+  checksum: a2f29b241914a8d2bad64363de684821b6b1609d06ae68d5b539e4de6b28659715b5bea94a7265201603713b7027d35399d10b0548f09071c5513e65e8323d33
   languageName: node
   linkType: hard
 
@@ -7267,7 +7297,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1, glob@npm:^7.1.2, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.7":
+"glob@npm:^7.0.0, glob@npm:^7.0.3, glob@npm:^7.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.7":
   version: 7.2.0
   resolution: "glob@npm:7.2.0"
   dependencies:
@@ -7278,6 +7308,20 @@ fsevents@~2.3.2:
     once: ^1.3.0
     path-is-absolute: ^1.0.0
   checksum: 78a8ea942331f08ed2e055cb5b9e40fe6f46f579d7fd3d694f3412fe5db23223d29b7fee1575440202e9a7ff9a72ab106a39fee39934c7bedafe5e5f8ae20134
+  languageName: node
+  linkType: hard
+
+"glob@npm:^7.1.2":
+  version: 7.2.3
+  resolution: "glob@npm:7.2.3"
+  dependencies:
+    fs.realpath: ^1.0.0
+    inflight: ^1.0.4
+    inherits: 2
+    minimatch: ^3.1.1
+    once: ^1.3.0
+    path-is-absolute: ^1.0.0
+  checksum: 29452e97b38fa704dabb1d1045350fb2467cf0277e155aa9ff7077e90ad81d1ea9d53d3ee63bd37c05b09a065e90f16aec4a65f5b8de401d1dac40bc5605d133
   languageName: node
   linkType: hard
 
@@ -8689,10 +8733,17 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"jquery@npm:>=1.10, jquery@npm:>=1.11.0, jquery@npm:>=1.7, jquery@npm:>=1.7.0, jquery@npm:>=1.7.1, jquery@npm:>=1.7.1 <4.0.0, jquery@npm:>=1.8, jquery@npm:>=1.9.0, jquery@npm:>=3.1.x, jquery@npm:^3.4.1, jquery@npm:^3.5.1":
+"jquery@npm:>=1.10, jquery@npm:>=1.7, jquery@npm:>=1.7.0, jquery@npm:>=1.7.1, jquery@npm:>=1.7.1 <4.0.0, jquery@npm:>=1.8, jquery@npm:>=1.9.0, jquery@npm:>=3.1.x, jquery@npm:^3.4.1, jquery@npm:^3.5.1":
   version: 3.6.0
   resolution: "jquery@npm:3.6.0"
   checksum: 8fd5fef4aa48fd374ec716dd1c1df1af407814a228e15c1260ca140de3a697c2a77c30c54ff1d238b6a3ab4ddc445ddeef9adce6c6d28e4869d85eb9d3951c0e
+  languageName: node
+  linkType: hard
+
+"jquery@npm:>=1.11.0":
+  version: 3.6.3
+  resolution: "jquery@npm:3.6.3"
+  checksum: 0fd366bdcaa0c84a7a8751ce20f8192290141913978b5059574426d9b01f4365daa675f95aab3eec94fd794d27b08d32078a2236bef404b8ba78073009988ce6
   languageName: node
   linkType: hard
 
@@ -8801,10 +8852,10 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"json-schema@npm:0.2.3":
-  version: 0.2.3
-  resolution: "json-schema@npm:0.2.3"
-  checksum: bbc2070988fb5f2a2266a31b956f1b5660e03ea7eaa95b33402901274f625feb586ae0c485e1df854fde40a7f0dc679f3b3ca8e5b8d31f8ea07a0d834de785c7
+"json-schema@npm:0.4.0":
+  version: 0.4.0
+  resolution: "json-schema@npm:0.4.0"
+  checksum: 66389434c3469e698da0df2e7ac5a3281bcff75e797a5c127db7c5b56270e01ae13d9afa3c03344f76e32e81678337a8c912bdbb75101c62e487dc3778461d72
   languageName: node
   linkType: hard
 
@@ -8914,14 +8965,14 @@ fsevents@~2.3.2:
   linkType: hard
 
 "jsprim@npm:^1.2.2":
-  version: 1.4.1
-  resolution: "jsprim@npm:1.4.1"
+  version: 1.4.2
+  resolution: "jsprim@npm:1.4.2"
   dependencies:
     assert-plus: 1.0.0
     extsprintf: 1.3.0
-    json-schema: 0.2.3
+    json-schema: 0.4.0
     verror: 1.10.0
-  checksum: 6bcb20ec265ae18bb48e540a6da2c65f9c844f7522712d6dfcb01039527a49414816f4869000493363f1e1ea96cbad00e46188d5ecc78257a19f152467587373
+  checksum: 2ad1b9fdcccae8b3d580fa6ced25de930eaa1ad154db21bbf8478a4d30bbbec7925b5f5ff29b933fba9412b16a17bd484a8da4fdb3663b5e27af95dd693bab2a
   languageName: node
   linkType: hard
 
@@ -9551,7 +9602,7 @@ fsevents@~2.3.2:
     clean-webpack-plugin: ~3.0.0
     copy-webpack-plugin: ~6.3.0
     coverage-istanbul-loader: ~3.0.5
-    coveralls: ~3.1.0
+    coveralls: ~3.1.1
     css-loader: ~5.0.1
     d3: ~7.6.1
     ejs: ~3.1.7
@@ -9759,21 +9810,21 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.19, mime-types@npm:~2.1.24":
-  version: 2.1.33
-  resolution: "mime-types@npm:2.1.33"
-  dependencies:
-    mime-db: 1.50.0
-  checksum: 05f2a0b3f169fbc51d79bdc7674ceb379dd07dbeadb0143059a7def865224686ee9f9051aeb340e98b6c11dbc06794ce0122181db4312cb1ad054fd90b0d510e
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:~2.1.17, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:~2.1.17, mime-types@npm:~2.1.19, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: 1.52.0
   checksum: 89a5b7f1def9f3af5dad6496c5ed50191ae4331cc5389d7c521c8ad28d5fdad2d06fd81baf38fed813dc4e46bb55c8145bb0ff406330818c9cf712fb2e9b3836
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.27, mime-types@npm:~2.1.24":
+  version: 2.1.33
+  resolution: "mime-types@npm:2.1.33"
+  dependencies:
+    mime-db: 1.50.0
+  checksum: 05f2a0b3f169fbc51d79bdc7674ceb379dd07dbeadb0143059a7def865224686ee9f9051aeb340e98b6c11dbc06794ce0122181db4312cb1ad054fd90b0d510e
   languageName: node
   linkType: hard
 
@@ -9838,6 +9889,15 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "minimatch@npm:3.1.2"
+  dependencies:
+    brace-expansion: ^1.1.7
+  checksum: c154e566406683e7bcb746e000b84d74465b3a832c45d59912b9b55cd50dee66e5c4b1e5566dba26154040e51672f9aa450a9aef0c97cfc7336b78b7afb9540a
+  languageName: node
+  linkType: hard
+
 "minimist@npm:1.1.x":
   version: 1.1.3
   resolution: "minimist@npm:1.1.3"
@@ -9845,17 +9905,17 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.1.3, minimist@npm:^1.2, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "minimist@npm:1.2.5"
-  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
-  languageName: node
-  linkType: hard
-
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.1.3, minimist@npm:^1.2.6":
   version: 1.2.7
   resolution: "minimist@npm:1.2.7"
   checksum: 7346574a1038ca23c32e02252f603801f09384dd1d78b69a943a4e8c2c28730b80e96193882d3d3b22a063445f460e48316b29b8a25addca2d7e5e8f75478bec
+  languageName: node
+  linkType: hard
+
+"minimist@npm:^1.2, minimist@npm:^1.2.0, minimist@npm:^1.2.3, minimist@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "minimist@npm:1.2.5"
+  checksum: 86706ce5b36c16bfc35c5fe3dbb01d5acdc9a22f2b6cc810b6680656a1d2c0e44a0159c9a3ba51fb072bb5c203e49e10b51dcd0eec39c481f4c42086719bae52
   languageName: node
   linkType: hard
 
@@ -9946,18 +10006,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:^0.5.5":
-  version: 0.5.5
-  resolution: "mkdirp@npm:0.5.5"
-  dependencies:
-    minimist: ^1.2.5
-  bin:
-    mkdirp: bin/cmd.js
-  checksum: 3bce20ea525f9477befe458ab85284b0b66c8dc3812f94155af07c827175948cdd8114852ac6c6d82009b13c1048c37f6d98743eb019651ee25c39acc8aabe7d
-  languageName: node
-  linkType: hard
-
-"mkdirp@npm:^0.5.6":
+"mkdirp@npm:>=0.5 0, mkdirp@npm:^0.5.6":
   version: 0.5.6
   resolution: "mkdirp@npm:0.5.6"
   dependencies:
@@ -9965,6 +10014,17 @@ fsevents@~2.3.2:
   bin:
     mkdirp: bin/cmd.js
   checksum: 0c91b721bb12c3f9af4b77ebf73604baf350e64d80df91754dc509491ae93bf238581e59c7188360cec7cb62fc4100959245a42cfe01834efedc5e9d068376c2
+  languageName: node
+  linkType: hard
+
+"mkdirp@npm:^0.5.0, mkdirp@npm:^0.5.1, mkdirp@npm:^0.5.3, mkdirp@npm:^0.5.5":
+  version: 0.5.5
+  resolution: "mkdirp@npm:0.5.5"
+  dependencies:
+    minimist: ^1.2.5
+  bin:
+    mkdirp: bin/cmd.js
+  checksum: 3bce20ea525f9477befe458ab85284b0b66c8dc3812f94155af07c827175948cdd8114852ac6c6d82009b13c1048c37f6d98743eb019651ee25c39acc8aabe7d
   languageName: node
   linkType: hard
 
@@ -10106,21 +10166,12 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.12.1":
+"nan@npm:^2.12.1, nan@npm:^2.13.2":
   version: 2.17.0
   resolution: "nan@npm:2.17.0"
   dependencies:
     node-gyp: latest
   checksum: ec609aeaf7e68b76592a3ba96b372aa7f5df5b056c1e37410b0f1deefbab5a57a922061e2c5b369bae9c7c6b5e6eecf4ad2dac8833a1a7d3a751e0a7c7f849ed
-  languageName: node
-  linkType: hard
-
-"nan@npm:^2.13.2":
-  version: 2.15.0
-  resolution: "nan@npm:2.15.0"
-  dependencies:
-    node-gyp: latest
-  checksum: 33e1bb4dfca447fe37d4bb5889be55de154828632c8d38646db67293a21afd61ed9909cdf1b886214a64707d935926c4e60e2b09de9edfc2ad58de31d6ce8f39
   languageName: node
   linkType: hard
 
@@ -11628,9 +11679,9 @@ fsevents@~2.3.2:
   linkType: hard
 
 "psl@npm:^1.1.28":
-  version: 1.8.0
-  resolution: "psl@npm:1.8.0"
-  checksum: 6150048ed2da3f919478bee8a82f3828303bc0fc730fb015a48f83c9977682c7b28c60ab01425a72d82a2891a1681627aa530a991d50c086b48a3be27744bde7
+  version: 1.9.0
+  resolution: "psl@npm:1.9.0"
+  checksum: 20c4277f640c93d393130673f392618e9a8044c6c7bf61c53917a0fddb4952790f5f362c6c730a9c32b124813e173733f9895add8d26f566ed0ea0654b2e711d
   languageName: node
   linkType: hard
 
@@ -11682,9 +11733,9 @@ fsevents@~2.3.2:
   linkType: hard
 
 "qs@npm:~6.5.2":
-  version: 6.5.2
-  resolution: "qs@npm:6.5.2"
-  checksum: 24af7b9928ba2141233fba2912876ff100403dba1b08b20c3b490da9ea6c636760445ea2211a079e7dfa882a5cf8f738337b3748c8bdd0f93358fa8881d2db8f
+  version: 6.5.3
+  resolution: "qs@npm:6.5.3"
+  checksum: 6f20bf08cabd90c458e50855559539a28d00b2f2e7dddcb66082b16a43188418cb3cb77cbd09268bcef6022935650f0534357b8af9eeb29bf0f27ccb17655692
   languageName: node
   linkType: hard
 
@@ -13162,8 +13213,8 @@ fsevents@~2.3.2:
   linkType: hard
 
 "sshpk@npm:^1.7.0":
-  version: 1.16.1
-  resolution: "sshpk@npm:1.16.1"
+  version: 1.17.0
+  resolution: "sshpk@npm:1.17.0"
   dependencies:
     asn1: ~0.2.3
     assert-plus: ^1.0.0
@@ -13178,7 +13229,7 @@ fsevents@~2.3.2:
     sshpk-conv: bin/sshpk-conv
     sshpk-sign: bin/sshpk-sign
     sshpk-verify: bin/sshpk-verify
-  checksum: 5e76afd1cedc780256f688b7c09327a8a650902d18e284dfeac97489a735299b03c3e72c6e8d22af03dbbe4d6f123fdfd5f3c4ed6bedbec72b9529a55051b857
+  checksum: ba109f65c8e6c35133b8e6ed5576abeff8aa8d614824b7275ec3ca308f081fef483607c28d97780c1e235818b0f93ed8c8b56d0a5968d5a23fd6af57718c7597
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Relates to https://github.com/ManageIQ/manageiq-ui-service/pull/1817

Using `yarn why <package-name>` I was able to track down which packages had `qs` as a dependancy 
```
"angular-patternfly": "~5.0.3",
"coveralls": "~3.1.0",
"karma": "~6.3.14",
"mocha": "~8.2.1",
"sass": "~1.34.0",
"webpack-dev-server": "~3.11.0",
```

`"angular-patternfly": "~5.0.3",` and `"coveralls": "~3.1.0",` specifically depend on `qs: ~6.5.2`. 

To simplify the PR I've split up the `qs` upgrade into two, this one focuses on taking qs from ~6.5.2 to 6.5.3. To do this I've bumped coveralls to ~3.1.1 (as this is the latest available) and bumped all of angular-patternfly's dependencies (to do this I had to remove angular-patternfly and then re-add it).

https://github.com/ManageIQ/manageiq-ui-service/pull/1821 will focus on upgrading qs from 6.7.0 to 6.11.0. 

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @Fryguy
@miq-bot assign @Fryguy
@miq-bot add-label security fix