### PR TITLE
Bumping moment-timezone to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jquery-ui-bundle": "~1.12.1-migrate",
     "lodash": "~4.17.20",
     "moment": "~2.29.4",
-    "moment-timezone": "^0.5.37",
+    "moment-timezone": "^0.5.41",
     "ngprogress": "~1.1.3",
     "ngstorage": "~0.3.11",
     "numeral": "~2.0.6",
@@ -139,9 +139,10 @@
   },
   "packageManager": "yarn@3.0.2",
   "resolutions": {
-    "terser": "~4.8.1",
-    "socket.io-parser": "~4.0.5",
     "decode-uri-component": "^0.2.2",
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "socket.io-parser": "~4.0.5",
+    "terser": "~4.8.1",
+    "moment-timezone": "^0.5.41"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9812,7 +9812,7 @@ fsevents@~2.3.2:
     mini-css-extract-plugin: ~1.2.1
     mocha: ~8.2.1
     moment: ~2.29.4
-    moment-timezone: ^0.5.37
+    moment-timezone: ^0.5.41
     ng-annotate-loader: ~0.7.0
     ng-annotate-patched: ~1.12.0
     ngprogress: ~1.1.3
@@ -10237,16 +10237,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"moment-timezone@npm:^0.4.0, moment-timezone@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "moment-timezone@npm:0.4.1"
-  dependencies:
-    moment: ">= 2.6.0"
-  checksum: 854adeb83be48716f59f4a0ee96863270dd8ff94d319f13c546ecc47408e67c59b35a720aeffaae6c4ad986e8eb7af0a5352621c327cedc1dbee9c6bcc596f94
-  languageName: node
-  linkType: hard
-
-"moment-timezone@npm:^0.5.37":
+"moment-timezone@npm:^0.5.41":
   version: 0.5.41
   resolution: "moment-timezone@npm:0.5.41"
   dependencies:
@@ -10255,7 +10246,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"moment@npm:>= 2.6.0, moment@npm:^2.10, moment@npm:^2.19.1, moment@npm:^2.29.4, moment@npm:~2.29.4":
+"moment@npm:^2.10, moment@npm:^2.19.1, moment@npm:^2.29.4, moment@npm:~2.29.4":
   version: 2.29.4
   resolution: "moment@npm:2.29.4"
   checksum: 0ec3f9c2bcba38dc2451b1daed5daded747f17610b92427bebe1d08d48d8b7bdd8d9197500b072d14e326dd0ccf3e326b9e3d07c5895d3d49e39b6803b76e80e


### PR DESCRIPTION
Fixes https://github.com/ManageIQ/manageiq-ui-service/issues/1803

Similar to what we've seen in [ui-classic](https://github.com/ManageIQ/manageiq-ui-classic/pull/8592), `moment-timezone` at versions `^0.4.0` and `^0.4.1` are brought in by `paternfly` and `patternfly-timeline`. To ensure the package resolves to its latest secure version we added the package and its secure version to the [selective dependency resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/) bracket. 

Also sorted the `resolutions` dependencies alphabetically. 

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @DavidResende0 
@miq-bot add_reviewer @akhilkr128 
@miq-bot add_reviewer @Fryguy
@miq-bot assign @Fryguy
@miq-bot add-label security fix