### PR TITLE
Lock nth-check to ^2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   },
   "packageManager": "yarn@3.0.2",
   "resolutions": {
+    "nth-check": "^2.1.1",
     "moment": "~2.29.4",
     "moment-timezone": "^0.5.41"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10646,21 +10646,12 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"nth-check@npm:^2.0.1":
+"nth-check@npm:^2.1.1":
   version: 2.1.1
   resolution: "nth-check@npm:2.1.1"
   dependencies:
     boolbase: ^1.0.0
   checksum: 5afc3dafcd1573b08877ca8e6148c52abd565f1d06b1eb08caf982e3fa289a82f2cae697ffb55b5021e146d60443f1590a5d6b944844e944714a5b549675bcd3
-  languageName: node
-  linkType: hard
-
-"nth-check@npm:~1.0.1":
-  version: 1.0.2
-  resolution: "nth-check@npm:1.0.2"
-  dependencies:
-    boolbase: ~1.0.0
-  checksum: 59e115fdd75b971d0030f42ada3aac23898d4c03aa13371fa8b3339d23461d1badf3fde5aad251fb956aaa75c0a3b9bfcd07c08a34a83b4f9dadfdce1d19337c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq-ui-service/issues/1738. 

Dependency tree for `nth-check`

```
➜  manageiq-ui-service git:(master) ✗ yarn why nth-check
├─ css-select@npm:1.2.0
│  └─ nth-check@npm:1.0.2 (via npm:~1.0.1)
└─ css-select@npm:4.3.0
   └─ nth-check@npm:2.1.1 (via npm:^2.0.1)
   
➜  manageiq-ui-service git:(master) ✗ yarn why css-select
├─ cheerio@npm:0.22.0
│  └─ css-select@npm:1.2.0 (via npm:~1.2.0)
└─ renderkid@npm:2.0.7
   └─ css-select@npm:4.3.0 (via npm:^4.1.3)
   
➜  manageiq-ui-service git:(master) ✗ yarn why cheerio
└─ angular-gettext-tools@npm:2.5.3
   └─ cheerio@npm:0.22.0 (via npm:^0.22.0)
   
➜  manageiq-ui-service git:(master) ✗ yarn why angular-gettext-tools
└─ angular-gettext-cli@npm:1.2.0
   └─ angular-gettext-tools@npm:2.5.3 (via npm:^2)
   
➜  manageiq-ui-service git:(master) ✗ yarn why angular-gettext-cli
└─ manageiq-ui-service@workspace:.
   └─ angular-gettext-cli@npm:1.2.0 (via npm:~1.2.0)
```

As you can see the outdated version of `nth-check` is brought in by `angular-gettext-cli` which we have already updated to it's [latest version](https://www.npmjs.com/package/angular-gettext-cli). The way to solve this CVE would be to remove the package (which we will once we've completely removed all angular code), but in the meantime we'll use a yarn [selective dependency resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/). 

@miq-bot add_reviewer @jeffibm
@miq-bot add_reviewer @DavidResende0
@miq-bot add_reviewer @akhilkr128
@miq-bot add_reviewer @Fryguy
@miq-bot add-label security fix 
@miq-bot assign @Fryguy