### PR TITLE
More package lockdowns for s390x

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ngprogress": "~1.1.3",
     "ngstorage": "~0.3.11",
     "numeral": "~2.0.6",
-    "object.values": "~1.1.1",
+    "object.values": "1.1.6",
     "patternfly": "~3.59.5",
     "patternfly-timeline": "patternfly/patternfly-timeline#master-dist",
     "spice-html5-bower": "~1.7.3",
@@ -139,10 +139,15 @@
   },
   "packageManager": "yarn@3.5.0",
   "resolutions": {
+    "array.prototype.reduce": "1.0.5",
     "es-abstract": "~1.21.2",
-    "nth-check": "^2.1.1",
-    "node-sass": "^8.0.0",
+    "function.prototype.name": "1.1.5",
     "moment": "~2.29.4",
-    "moment-timezone": "^0.5.41"
+    "moment-timezone": "^0.5.41",
+    "node-sass": "^8.0.0",
+    "nth-check": "^2.1.1",
+    "object.entries": "1.1.6",
+    "object.values": "1.1.6",
+    "string.prototype.padstart": "3.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "ngprogress": "~1.1.3",
     "ngstorage": "~0.3.11",
     "numeral": "~2.0.6",
-    "object.values": "1.1.6",
     "patternfly": "~3.59.5",
     "patternfly-timeline": "patternfly/patternfly-timeline#master-dist",
     "spice-html5-bower": "~1.7.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9749,7 +9749,6 @@ fsevents@~2.3.2:
     ngprogress: ~1.1.3
     ngstorage: ~0.3.11
     numeral: ~2.0.6
-    object.values: 1.1.6
     patternfly: ~3.59.5
     patternfly-timeline: "patternfly/patternfly-timeline#master-dist"
     postcss-loader: ~4.0.4

--- a/yarn.lock
+++ b/yarn.lock
@@ -2879,7 +2879,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"array.prototype.reduce@npm:^1.0.5":
+"array.prototype.reduce@npm:1.0.5":
   version: 1.0.5
   resolution: "array.prototype.reduce@npm:1.0.5"
   dependencies:
@@ -7163,7 +7163,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"function.prototype.name@npm:^1.1.5":
+"function.prototype.name@npm:1.1.5":
   version: 1.1.5
   resolution: "function.prototype.name@npm:1.1.5"
   dependencies:
@@ -9749,7 +9749,7 @@ fsevents@~2.3.2:
     ngprogress: ~1.1.3
     ngstorage: ~0.3.11
     numeral: ~2.0.6
-    object.values: ~1.1.1
+    object.values: 1.1.6
     patternfly: ~3.59.5
     patternfly-timeline: "patternfly/patternfly-timeline#master-dist"
     postcss-loader: ~4.0.4
@@ -10753,7 +10753,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.0.3":
+"object.entries@npm:1.1.6":
   version: 1.1.6
   resolution: "object.entries@npm:1.1.6"
   dependencies:
@@ -10785,7 +10785,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"object.values@npm:^1.0.3, object.values@npm:^1.1.1, object.values@npm:~1.1.1":
+"object.values@npm:1.1.6":
   version: 1.1.6
   resolution: "object.values@npm:1.1.6"
   dependencies:
@@ -13389,7 +13389,7 @@ fsevents@~2.3.2:
   languageName: node
   linkType: hard
 
-"string.prototype.padstart@npm:^3.0.0":
+"string.prototype.padstart@npm:3.1.4":
   version: 3.1.4
   resolution: "string.prototype.padstart@npm:3.1.4"
   dependencies:


### PR DESCRIPTION
Newer patch versions of these packages require es-abstract 1.22.1 which is incompatible with yarn 1.22 on s390x

Error:
```
---> yarn run build␛[0m␛[0m
yarn run v1.22.18
$ yarn build:git-hash && NODE_ENV="production" webpack --bail --progress --profile --config config/webpack.prod.js $ node config/githash.js
Successfully wrote Git hash - f07194ebaf9ff6c694230c970ac1b1b6c5f25519 [webpack-cli] Failed to load '/root/BUILD/manageiq-ui-service/config/webpack.prod.js' config [webpack-cli] Error: Cannot find module 'es-abstract/2023/RequireObjectCoercible' Require stack:
- /root/BUILD/manageiq-ui-service/node_modules/array.prototype.reduce/index.js
- /root/BUILD/manageiq-ui-service/node_modules/object.getownpropertydescriptors/implementation.js
- /root/BUILD/manageiq-ui-service/node_modules/object.getownpropertydescriptors/index.js
- /root/BUILD/manageiq-ui-service/node_modules/util.promisify/implementation.js
- /root/BUILD/manageiq-ui-service/node_modules/util.promisify/index.js
- /root/BUILD/manageiq-ui-service/node_modules/html-webpack-plugin/index.js
- /root/BUILD/manageiq-ui-service/config/webpack.prod.js
- /root/BUILD/manageiq-ui-service/node_modules/webpack-cli/lib/webpack-cli.js
- /root/BUILD/manageiq-ui-service/node_modules/webpack-cli/lib/bootstrap.js
- /root/BUILD/manageiq-ui-service/node_modules/webpack-cli/bin/cli.js
- /root/BUILD/manageiq-ui-service/node_modules/webpack/bin/webpack.js at Module._resolveFilename (node:internal/modules/cjs/loader:1077:15) at Module._load (node:internal/modules/cjs/loader:922:27) at Module.require (node:internal/modules/cjs/loader:1143:19) at require (node:internal/modules/cjs/helpers:110:18) at Object.<anonymous> (/root/BUILD/manageiq-ui-service/node_modules/array.prototype.reduce/index.js:4:30) at Module._compile (node:internal/modules/cjs/loader:1256:14) at Module._extensions..js (node:internal/modules/cjs/loader:1310:10) at Module.load (node:internal/modules/cjs/loader:1119:32) at Module._load (node:internal/modules/cjs/loader:960:12) at Module.require (node:internal/modules/cjs/loader:1143:19) { code: 'MODULE_NOT_FOUND', requireStack: [ '/root/BUILD/manageiq-ui-service/node_modules/array.prototype.reduce/index.js', '/root/BUILD/manageiq-ui-service/node_modules/object.getownpropertydescriptors/implementation.js', '/root/BUILD/manageiq-ui-service/node_modules/object.getownpropertydescriptors/index.js', '/root/BUILD/manageiq-ui-service/node_modules/util.promisify/implementation.js', '/root/BUILD/manageiq-ui-service/node_modules/util.promisify/index.js', '/root/BUILD/manageiq-ui-service/node_modules/html-webpack-plugin/index.js', '/root/BUILD/manageiq-ui-service/config/webpack.prod.js', '/root/BUILD/manageiq-ui-service/node_modules/webpack-cli/lib/webpack-cli.js', '/root/BUILD/manageiq-ui-service/node_modules/webpack-cli/lib/bootstrap.js', '/root/BUILD/manageiq-ui-service/node_modules/webpack-cli/bin/cli.js', '/root/BUILD/manageiq-ui-service/node_modules/webpack/bin/webpack.js' ] }
error Command failed with exit code 2.
```

Same issue as https://github.com/ManageIQ/manageiq-ui-classic/pull/8906