### PR TITLE
Fixed custom logo on order page

### DIFF
--- a/client/app/states/orders/details/details.html
+++ b/client/app/states/orders/details/details.html
@@ -18,7 +18,10 @@
             <div class="col-md-12">
               <div class="ss-details-header__title-img">
                 <span class="ss-details-header__title-img__center"></span>
-                <img class="ss-details-header__title-img__logo" src="images/brand_transparent.png"/>
+                <img class="ss-details-header__title-img__logo" ng-if="!vm.serviceTemplate.picture.image_href"
+                alt="{{ ::vm.order.name }}" src="images/service.png"/>
+                <img class="ss-details-header__title-img__logo" ng-if="vm.serviceTemplate.picture.image_href "
+                alt="{{ ::vm.order.name }}" ng-src="{{ ::vm.serviceTemplate.picture.image_href }}"/>
               </div>
               <div class="ss-details-header__title">
                 <h2>{{'Order #' |translate}}{{vm.order.id}}</h2>

--- a/client/app/states/orders/details/details.state.js
+++ b/client/app/states/orders/details/details.state.js
@@ -14,7 +14,8 @@ function getStates (RBAC) {
       controllerAs: 'vm',
       title: __('Order Details'),
       resolve: {
-        order: resolveOrder
+        order: resolveOrder,
+        serviceTemplate: resolveServiceTemplate
       },
       data: {
         authorization: RBAC.has('miq_request_show')
@@ -31,9 +32,24 @@ function resolveOrder ($stateParams, CollectionsApi) {
 }
 
 /** @ngInject */
-function StateController (order, $state) {
+function resolveServiceTemplate ($stateParams, CollectionsApi) {
+  return CollectionsApi.get('service_orders', $stateParams.serviceOrderId, {
+    expand: ['resources', 'service_requests']
+  }).then((ServiceOrder) => {
+    const serviceTemplateId = ServiceOrder.service_requests[0].source_id;
+    return CollectionsApi.get('service_templates', serviceTemplateId, {
+      expand: ['resources'],
+      attributes: ['picture', 'resource_actions', 'picture.image_href'],
+    })
+  })
+}
+
+/** @ngInject */
+function StateController (order, serviceTemplate, $state) {
   const vm = this
   vm.order = order
+  vm.serviceTemplate = serviceTemplate
+
   vm.requestListConfig = {
     showSelectBox: false,
     selectionMatchProp: 'id'

--- a/client/app/states/orders/details/details.state.spec.js
+++ b/client/app/states/orders/details/details.state.spec.js
@@ -14,7 +14,8 @@ describe('State: orders.details', () => {
       $stateParams: {
         serviceOrderId: 213
       },
-      order: {name: 'test order'}
+      order: {name: 'test order'},
+      serviceTemplate: {name: 'test template'}
     })
   })
 


### PR DESCRIPTION
Fixed the logo on the order page so that when a custom logo is uploaded that is displayed instead of the Manage IQ logo.

After creating a catalog item and uploading a custom logo for it on Manage IQ UI-Classic, then ordering a service you can log in to the service ui and view the order on My Orders > click on order. The order summary page currently always shows the Manage IQ logo but this pr fixes this issue to show the custom logo when present and the Manage IQ logo when there is no custom logo uploaded.

Before:
<img width="1168" alt="Screenshot 2024-06-26 at 11 33 18 AM" src="https://github.com/ManageIQ/manageiq-ui-service/assets/32444791/49aad0da-2400-4366-9a75-e44df0bbf1e3">

After:
<img width="1169" alt="Screenshot 2024-06-26 at 11 31 25 AM" src="https://github.com/ManageIQ/manageiq-ui-service/assets/32444791/cbb99eac-7fc1-4b6e-b01e-5fb003d10a28">
