### PR TITLE
Fix menu item order

### DIFF
--- a/client/app/core/navigation.service.js
+++ b/client/app/core/navigation.service.js
@@ -32,6 +32,23 @@ export function NavigationFactory (RBAC, Polling, POLLING_INTERVAL, CollectionsA
         permissions: true
       },
       {
+        title: __('Service Catalog'),
+        originalTitle: 'Service Catalog',
+        state: 'catalogs',
+        iconClass: 'fa fa-folder-open-o',
+        badgeQuery: {
+          'field': 'service_templates',
+          'filter': 'display=true'
+        },
+        badges: [
+          {
+            count: service.navCount.catalogs,
+            tooltip: __('The total number of available catalogs')
+          }
+        ],
+        permissions: false
+      },
+      {
         title: __('My Services'),
         state: 'services',
         iconClass: 'pficon pficon-service',
@@ -60,23 +77,6 @@ export function NavigationFactory (RBAC, Polling, POLLING_INTERVAL, CollectionsA
           {
             count: service.navCount.orders,
             tooltip: __('Total orders submitted')
-          }
-        ],
-        permissions: false
-      },
-      {
-        title: __('Service Catalog'),
-        originalTitle: 'Service Catalog',
-        state: 'catalogs',
-        iconClass: 'fa fa-folder-open-o',
-        badgeQuery: {
-          'field': 'service_templates',
-          'filter': 'display=true'
-        },
-        badges: [
-          {
-            count: service.navCount.catalogs,
-            tooltip: __('The total number of available catalogs')
           }
         ],
         permissions: false


### PR DESCRIPTION
Fixed the side nav menu item order.

Before:
<img width="253" alt="Screenshot 2024-06-26 at 11 45 42 AM" src="https://github.com/ManageIQ/manageiq-ui-service/assets/32444791/c6b822b9-8b0e-4453-b67b-1dd0e98ba39c">

After:
<img width="263" alt="Screenshot 2024-06-26 at 12 35 49 PM" src="https://github.com/ManageIQ/manageiq-ui-service/assets/32444791/3791f87f-8bd9-4994-8373-803297e7f9c0">
