### PR TITLE
[Morphy] Update moment-timezone

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jquery-ui-bundle": "~1.12.1-migrate",
     "lodash": "~4.17.20",
     "moment": "~2.28.0",
-    "moment-timezone": "~0.5.31",
+    "moment-timezone": "^0.5.41",
     "ngprogress": "~1.1.3",
     "ngstorage": "~0.3.11",
     "numeral": "~2.0.6",
@@ -133,6 +133,9 @@
     "last 2 versions",
     "> 5%"
   ],
+  "resolutions": {
+    "moment-timezone": "^0.5.41"
+  },
   "engines": {
     "node": ">= 12.0.0",
     "npm": ">= 6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6734,24 +6734,22 @@ mocha@~8.2.1:
     yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
 
-moment-timezone@^0.4.0, moment-timezone@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.4.1.tgz#81f598c3ad5e22cdad796b67ecd8d88d0f5baa06"
-  integrity sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=
+moment-timezone@^0.4.0, moment-timezone@^0.4.1, moment-timezone@^0.5.41:
+  version "0.5.45"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.45.tgz#cb685acd56bac10e69d93c536366eb65aa6bcf5c"
+  integrity sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==
   dependencies:
-    moment ">= 2.6.0"
+    moment "^2.29.4"
 
-moment-timezone@~0.5.31:
-  version "0.5.33"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.33.tgz#b252fd6bb57f341c9b59a5ab61a8e51a73bbd22c"
-  integrity sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==
-  dependencies:
-    moment ">= 2.9.0"
-
-"moment@>= 2.6.0", "moment@>= 2.9.0", moment@^2.10, moment@^2.19.1:
+moment@^2.10, moment@^2.19.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
+moment@^2.29.4:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 moment@~2.14.1:
   version "2.14.1"


### PR DESCRIPTION
Pin moment-timezone to ^0.5.41, similar to this pr on the master branch: https://github.com/ManageIQ/manageiq-ui-service/pull/1828