### PR TITLE
Use npmAuditExcludePackages instead of npmAuditIgnoreAdvisories

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,25 +4,32 @@ enableGlobalCache: true
 
 nodeLinker: node-modules
 
-npmAuditIgnoreAdvisories:
-- "1089210" # pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0             | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1093574" # pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3             | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1094512" # pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3             | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1094513" # pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3             | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1094514" # pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3             | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1097291" # pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3     | 1.8.3 brought in by manageiq-ui-service@workspace:.
-- "1091717" # pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0            | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1091861" # pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0            | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1094984" # pending | moderate | GHSA-9v3m-8fp8-mj99 | bootstrap >=3.0.0 <3.4.1    | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1095421" # pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0    | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1095492" # pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0    | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1095494" # pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0    | 3.3.7 brought in by patternfly@npm:3.25.1
-- "1086501" # pending | high     | GHSA-9r7h-6639-v5mw | bootstrap-select <1.13.6    | 1.12.2, 1.12.4 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.59.5
-- "1089856" # pending | moderate | GHSA-7c82-mp33-r854 | bootstrap-select <1.13.6    | 1.12.2, 1.12.4 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.59.5
-- "1094185" # pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0       | 3.2.1, 3.4.1 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.25.1
-- "1097145" # pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0       | 3.2.1 brought in by patternfly@npm:3.25.1
-- "1097311" # pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0       | 3.2.1, 3.4.1 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.25.1
-- "1096303" # pending | high     | GHSA-p6mc-m468-83gw | lodash.pick >=4.0.0 <=4.4.0 | 4.4.0 brought in by cheerio@npm:0.22.0
-- "1094544" # pending | moderate | GHSA-7fh5-64p2-3v2j | postcss <8.4.31             | 7.0.39 brought in by autoprefixer@npm:9.8.8
+npmAuditExcludePackages:
+- angular
+# pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0         | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3         | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3         | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3         | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3         | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3 | 1.8.3 brought in by manageiq-ui-service@workspace:.
+- bootstrap
+# pending | moderate | GHSA-9v3m-8fp8-mj99 | bootstrap >=3.0.0 <3.4.1  | 3.3.7 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.3.7, 3.4.1 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.25.1
+# pending | moderate | GHSA-3mgp-fx93-9xv5 | bootstrap <3.4.0          | 3.3.7 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-ph58-4vrj-w6hr | bootstrap <3.4.0          | 3.3.7 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-3wqf-4x89-9g79 | bootstrap >=2.3.0 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-7mvr-5x2g-wfc8 | bootstrap >=2.3.0 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-4p24-vmcr-4gqj | bootstrap >=2.0.4 <3.4.0  | 3.3.7 brought in by patternfly@npm:3.25.1
+- bootstrap-select
+# pending | high     | GHSA-9r7h-6639-v5mw | bootstrap-select <1.13.6 | 1.12.2, 1.12.4 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.59.5
+# pending | moderate | GHSA-7c82-mp33-r854 | bootstrap-select <1.13.6 | 1.12.2, 1.12.4 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.59.5
+- jquery
+# pending | moderate | GHSA-gxr4-xjj5-5px2 | jquery >=1.2.0 <3.5.0 | 3.2.1, 3.4.1 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.25.1
+# pending | moderate | GHSA-6c3j-c64m-qhgq | jquery >=1.1.4 <3.4.0 | 3.2.1 brought in by patternfly@npm:3.25.1
+# pending | moderate | GHSA-jpcq-cgw6-v4j6 | jquery >=1.0.3 <3.5.0 | 3.2.1, 3.4.1 brought in by angular-patternfly@npm:5.0.3, patternfly@npm:3.25.1
+- lodash.pick
+# pending | high | GHSA-p6mc-m468-83gw | lodash.pick >=4.0.0 <=4.4.0 | 4.4.0 brought in by cheerio@npm:0.22.0
+- postcss
+# pending | moderate | GHSA-7fh5-64p2-3v2j | postcss <8.4.31 | 7.0.39 brought in by autoprefixer@npm:9.8.8
 
 yarnPath: .yarn/releases/yarn-4.3.1.cjs


### PR DESCRIPTION
Similar change to ManageIQ/manageiq-ui-classic#9241

@jrafanie Please review.