### PR TITLE
Update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "express/path-to-regexp": "~0.1.10",
     "moment-timezone": "^0.5.41",
     "moment": "~2.29.4",
-    "node-sass": "^8.0.0",
+    "node-sass": "^9.0.0",
     "nth-check": "^2.1.1",
     "sinon": "~19.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10687,9 +10687,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-sass@npm:^8.0.0":
-  version: 8.0.0
-  resolution: "node-sass@npm:8.0.0"
+"node-sass@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "node-sass@npm:9.0.0"
   dependencies:
     async-foreach: "npm:^0.1.3"
     chalk: "npm:^4.1.2"
@@ -10707,7 +10707,7 @@ __metadata:
     true-case-path: "npm:^2.2.1"
   bin:
     node-sass: bin/node-sass
-  checksum: 10/9dc04024e7e1dbca8261d07e5ba284616b1a4e2d9b799a294dcff9ad97ce9f87f22606c4dec5e05948126081333a243cbca4575216b459515e436da830a82ca0
+  checksum: 10/614abdcadb3f3112ab8f68d10abcc5abdd87285865c1ffca031071338a40ecb3055e842ab2bc509c50ca389948da8bba3ff6c31c704b4a71349b7fdd67eb98e4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update node-sass to latest version ^9.0.0. Node-sass has archived and this is the latest version for this package.