### PR TITLE
Update patternfly

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "moment": "~2.29.4",
     "node-sass": "^9.0.0",
     "nth-check": "^2.1.1",
+    "patternfly": "~3.59.5",
     "sinon": "~19.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3222,15 +3222,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-datepicker@npm:~1.6.4":
-  version: 1.6.4
-  resolution: "bootstrap-datepicker@npm:1.6.4"
-  dependencies:
-    jquery: "npm:>=1.7.1"
-  checksum: 10/8d07e86a11e3e5af344d7699785b23fe0ff640343f5642137b27d16b518f0917575ba114fa47a58037109979e0cd78ae11f4eca83a2ceae3915243392c5d2e05
-  languageName: node
-  linkType: hard
-
 "bootstrap-datepicker@npm:~1.9.0":
   version: 1.9.0
   resolution: "bootstrap-datepicker@npm:1.9.0"
@@ -3283,16 +3274,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-switch@npm:~3.3.4":
-  version: 3.3.5
-  resolution: "bootstrap-switch@npm:3.3.5"
-  peerDependencies:
-    bootstrap: ^3.3.7
-    jquery: ">=1.12.4"
-  checksum: 10/105c326e7fbe57a8b559e087912c740b244228f48fb0a695de08888af9df1036a931713e8c30320d13337cae2db17979b0c1893136622052d24c0eaf9b8865f3
-  languageName: node
-  linkType: hard
-
 "bootstrap-switch@npm:~3.4.0":
   version: 3.4.0
   resolution: "bootstrap-switch@npm:3.4.0"
@@ -3323,13 +3304,6 @@ __metadata:
   peerDependencies:
     "@popperjs/core": ^2.11.8
   checksum: 10/f05183948b00b496400cc13df5798ecab7a85975e7d9a77b314a763b574a990aec0f1bbf1913c648a93b5d8cc82e73bc05f5ec1161d2932aad7ef7f316d9c82d
-  languageName: node
-  linkType: hard
-
-"bootstrap@npm:~3.3.7":
-  version: 3.3.7
-  resolution: "bootstrap@npm:3.3.7"
-  checksum: 10/bc978de5b63ea67e21eb6a23de91a1b761c13f77715e4887293f304d03bb449aa44e2ecacfc32309502cdb9e4c542fd5ec1a230f667f4d611c7fa855fe37d731
   languageName: node
   linkType: hard
 
@@ -5164,16 +5138,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"datatables.net-colreorder@npm:~1.3.2":
-  version: 1.3.3
-  resolution: "datatables.net-colreorder@npm:1.3.3"
-  dependencies:
-    datatables.net: "npm:>=1.10.9"
-    jquery: "npm:>=1.7"
-  checksum: 10/b7cd56dde56e8346d5410aa353bbf099b9775bfb807e4eeb069d11c0e82f87cd6b318dedbc6093bc268f0b391adcbce7c613682c1f3af21770fc484368d049e0
-  languageName: node
-  linkType: hard
-
 "datatables.net-dt@npm:^1.10.11":
   version: 1.13.11
   resolution: "datatables.net-dt@npm:1.13.11"
@@ -5203,7 +5167,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"datatables.net@npm:2.1.7, datatables.net@npm:>=1.10.9, datatables.net@npm:^2":
+"datatables.net@npm:2.1.7, datatables.net@npm:^2":
   version: 2.1.7
   resolution: "datatables.net@npm:2.1.7"
   dependencies:
@@ -9001,7 +8965,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jquery@npm:1.8 - 4, jquery@npm:>=1.10, jquery@npm:>=1.11.0, jquery@npm:>=1.7, jquery@npm:>=1.7.0, jquery@npm:>=1.7.1, jquery@npm:>=1.7.1 <4.0.0, jquery@npm:>=1.8.0 <4.0.0, jquery@npm:>=1.9.0, jquery@npm:>=3.1.x, jquery@npm:>=3.4.0 <4.0.0, jquery@npm:^3.4.1, jquery@npm:^3.5.1, jquery@npm:~3.7.0":
+"jquery@npm:1.8 - 4, jquery@npm:>=1.10, jquery@npm:>=1.11.0, jquery@npm:>=1.7, jquery@npm:>=1.7.0, jquery@npm:>=1.7.1 <4.0.0, jquery@npm:>=1.8.0 <4.0.0, jquery@npm:>=1.9.0, jquery@npm:>=3.1.x, jquery@npm:>=3.4.0 <4.0.0, jquery@npm:^3.4.1, jquery@npm:^3.5.1, jquery@npm:~3.7.0":
   version: 3.7.1
   resolution: "jquery@npm:3.7.1"
   checksum: 10/17be9929f5fa37697d9848284f0d108c543318ef79ec794e130cd0c49f6c050d60c803a69e8cfa16fa19f5ff7cdb814a6905cceab0831186560c65ed113cd579
@@ -9012,13 +8976,6 @@ __metadata:
   version: 3.4.1
   resolution: "jquery@npm:3.4.1"
   checksum: 10/c40dcf94f6d1427b8d28b8f6b9d32f368b01e77cc24095c66c02de146faf0e633ef7c7f5d5815c52367b400f32d7c7f9c87e66d372488ffdd3276b4aeb6e0cef
-  languageName: node
-  linkType: hard
-
-"jquery@npm:~3.2.1":
-  version: 3.2.1
-  resolution: "jquery@npm:3.2.1"
-  checksum: 10/88aa997c1a0770e28ca4c0309dd1b44df0e141f389d651b5b5e5a83e1dc059235a8f96b9cf845599fbb75c137f28391fc224c14ab254fea339627290a3bf9835
   languageName: node
   linkType: hard
 
@@ -11415,7 +11372,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"patternfly-bootstrap-treeview@npm:~2.1.0, patternfly-bootstrap-treeview@npm:~2.1.10":
+"patternfly-bootstrap-treeview@npm:~2.1.10":
   version: 2.1.10
   resolution: "patternfly-bootstrap-treeview@npm:2.1.10"
   dependencies:
@@ -11435,7 +11392,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"patternfly@npm:^3.59.4, patternfly@npm:~3.59.5":
+"patternfly@npm:~3.59.5":
   version: 3.59.5
   resolution: "patternfly@npm:3.59.5"
   dependencies:
@@ -11510,72 +11467,6 @@ __metadata:
     patternfly-bootstrap-treeview:
       optional: true
   checksum: 10/80ce728bba8e0e50cdf65dd1e1dd1f2a6893fd4686c7596607ef18da8b095e56b896b01e605ec4add9ea77c92f2ab1da3c709b0725e35fe77d71cbba6832e52c
-  languageName: node
-  linkType: hard
-
-"patternfly@npm:~3.25.0":
-  version: 3.25.1
-  resolution: "patternfly@npm:3.25.1"
-  dependencies:
-    bootstrap: "npm:~3.3.7"
-    bootstrap-datepicker: "npm:~1.6.4"
-    bootstrap-select: "npm:^1.12.2"
-    bootstrap-switch: "npm:~3.3.4"
-    bootstrap-touchspin: "npm:~3.1.1"
-    c3: "npm:~0.4.11"
-    d3: "npm:~3.5.17"
-    datatables.net: "npm:^1.10.15"
-    datatables.net-colreorder: "npm:~1.3.2"
-    datatables.net-colreorder-bs: "npm:~1.3.2"
-    datatables.net-select: "npm:~1.2.0"
-    drmonty-datatables-colvis: "npm:~1.1.2"
-    eonasdan-bootstrap-datetimepicker: "npm:^4.17.47"
-    font-awesome: "npm:^4.7.0"
-    google-code-prettify: "npm:~1.0.5"
-    jquery: "npm:~3.2.1"
-    jquery-match-height: "npm:^0.7.2"
-    moment: "npm:~2.14.1"
-    moment-timezone: "npm:^0.4.1"
-    patternfly-bootstrap-combobox: "npm:~1.1.7"
-    patternfly-bootstrap-treeview: "npm:~2.1.0"
-  dependenciesMeta:
-    bootstrap-datepicker:
-      optional: true
-    bootstrap-select:
-      optional: true
-    bootstrap-switch:
-      optional: true
-    bootstrap-touchspin:
-      optional: true
-    c3:
-      optional: true
-    d3:
-      optional: true
-    datatables.net:
-      optional: true
-    datatables.net-colreorder:
-      optional: true
-    datatables.net-colreorder-bs:
-      optional: true
-    datatables.net-select:
-      optional: true
-    drmonty-datatables-colvis:
-      optional: true
-    eonasdan-bootstrap-datetimepicker:
-      optional: true
-    google-code-prettify:
-      optional: true
-    jquery-match-height:
-      optional: true
-    moment:
-      optional: true
-    moment-timezone:
-      optional: true
-    patternfly-bootstrap-combobox:
-      optional: true
-    patternfly-bootstrap-treeview:
-      optional: true
-  checksum: 10/9f6f388997779af80e167ffb5c423353c45e88ab6ef11563a2aaa6320cb67295be401233087f55b9653167910fdf5368ac37877db736f40e4966eb62ad67f070
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update patternfly to ~3.59.5 using resolutions. Need to use resolutions because patternfly-timeline is no longer receiving updates and is stuck on patternfly ~3.25.0: https://github.com/patternfly/patternfly-timeline/blob/master/package.json. By forcing patternfly to be on version ~3.59.5 it will allow bootstrap to update to version 3.4.1.