### PR TITLE
[Morphy] Update trim-newlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,8 @@
     "json-schema": "~0.4.0",
     "minimist": "~1.2.6",
     "moment-timezone": "^0.5.41",
-    "tough-cookie": "~4.1.3"
+    "tough-cookie": "~4.1.3",
+    "trim-newlines": "~4.0.1"
   },
   "engines": {
     "node": ">= 12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9249,10 +9249,10 @@ tough-cookie@~2.5.0, tough-cookie@~4.1.3:
     universalify "^0.2.0"
     url-parse "^1.5.3"
 
-trim-newlines@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
-  integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+trim-newlines@^1.0.0, trim-newlines@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-4.0.2.tgz#d6aaaf6a0df1b4b536d183879a6b939489808c7c"
+  integrity sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
Update trim-newlines to ~4.0.1 using resolutions. Since we can't update node-sass on the morphy branch, which pulls in this package, we need to update the trim-newlines package using the resolutions.