### PR TITLE
Exclude bootstrap-sass from yarn audit

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,15 +7,17 @@ nodeLinker: node-modules
 npmAuditExcludePackages:
 - angular
 # pending | high     | GHSA-4w4v-5hc9-xrr2 | angular >=1.3.0 <=1.8.3      | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
+# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
 # pending | moderate | GHSA-m2h2-264f-f486 | angular >=1.7.0              | 1.8.3 brought in by manageiq-ui-service@workspace:.
 # pending | moderate | GHSA-prc3-vjfx-vhm9 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
-# pending | moderate | GHSA-2vrf-hf26-jrp5 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
-# pending | moderate | GHSA-2qqx-w9hr-q5gx | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
 # pending | moderate | GHSA-qwqh-hm9m-p5hr | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
 # pending | low      | GHSA-m9gf-397r-hwpg | angular >=1.3.0-rc.4 <=1.8.3 | 1.8.3 brought in by manageiq-ui-service@workspace:.
 # pending | low      | GHSA-mqm9-c95h-x2p6 | angular <=1.8.3              | 1.8.3 brought in by manageiq-ui-service@workspace:.
 - bootstrap
 # pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap >=2.0.0 <=3.4.1 | 3.4.1 brought in by angular-patternfly@npm:5.0.3
+- bootstrap-sass
+# pending | moderate | GHSA-9mvj-f7w8-pvh2 | bootstrap-sass >=2.0.0 <=3.4.3 | 3.4.3 brought in by patternfly@npm:3.59.5
 - lodash.pick
 # pending | high | GHSA-p6mc-m468-83gw | lodash.pick >=4.0.0 <=4.4.0 | 4.4.0 brought in by cheerio@npm:0.22.0
 


### PR DESCRIPTION
This package is being brought in by patternfly, and we are already at the latest version. We need to upgrade patternfly or replace it completely to be off of this package.

This is related to CVE-2024-6484

Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/9333

@GilbertCherrie Please review.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
