### PR TITLE
[Morphy] Update bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
   ],
   "resolutions": {
     "ansi-regex": "~4.1.1",
+    "bootstrap": "~3.4.1",
     "bootstrap-select": "~1.13.18",
     "cross-spawn": "~7.0.6",
     "d3-color": "~3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2225,20 +2225,10 @@ bootstrap-touchspin@~3.1.1:
   resolved "https://registry.yarnpkg.com/bootstrap-touchspin/-/bootstrap-touchspin-3.1.1.tgz#9779deac72aaf577e5e762b8512c747c871d9597"
   integrity sha1-l3nerHKq9Xfl52K4USx0fIcdlZc=
 
-bootstrap@3.4.1, bootstrap@^3.3, bootstrap@^3.4.1, bootstrap@~3.4.1:
+bootstrap@3.4.1, bootstrap@>=2.3.2, bootstrap@>=3, bootstrap@^3.3, bootstrap@^3.4.1, bootstrap@~3.3.7, bootstrap@~3.4.1:
   version "3.4.1"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  resolved "https://npm.manageiq.org/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
   integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
-
-bootstrap@>=2.3.2, bootstrap@>=3:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.6.0.tgz#97b9f29ac98f98dfa43bf7468262d84392552fd7"
-  integrity sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==
-
-bootstrap@~3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
-  integrity sha1-WjiTlFSfIzMIdaOxUGVldPip63E=
 
 brace-expansion@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Update bootstrap to ~3.4.1. Bootstrap 4.0.0 is not working on morphy so this is latest version we can get to on this branch.