### PR TITLE
Read the node version from package.json in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version:
-        - 20
         test-suite:
         - test
         - test:security
@@ -23,7 +21,7 @@ jobs:
     - name: Set up Node
       uses: actions/setup-node@v5
       with:
-        node-version: "${{ matrix.node-version }}"
+        node-version-file: package.json
         cache: "${{ !env.ACT && 'yarn' || '' }}"
         registry-url: https://npm.manageiq.org/
     - name: Prepare tests

--- a/package.json
+++ b/package.json
@@ -135,8 +135,8 @@
     "> 5%"
   ],
   "engines": {
-    "node": ">= 20.19.1",
-    "npm": ">= 10.8.2"
+    "node": "^20.19.5",
+    "npm": "^10.8.2"
   },
   "packageManager": "yarn@4.10.3",
   "resolutions": {


### PR DESCRIPTION
@jrafanie Please review.

Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/9671

Note the yarn lock action inherits its changes from https://github.com/ManageIQ/.github/pull/17