### PR TITLE
Remove the path-to-regexp package.json resolution version

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,6 @@
     "cheerio": "1.0.0-rc.12",
     "cross-spawn": "~7.0.6",
     "d3-color": "~3.1.0",
-    "express/path-to-regexp": "~0.1.10",
     "jquery": "~3.7.1",
     "moment-timezone": "^0.5.41",
     "moment": "~2.29.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10861,7 +10861,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:~0.1.10":
+"path-to-regexp@npm:~0.1.12":
   version: 0.1.12
   resolution: "path-to-regexp@npm:0.1.12"
   checksum: 10/2e30f6a0144679c1f95c98e166b96e6acd1e72be9417830fefc8de7ac1992147eb9a4c7acaa59119fb1b3c34eec393b2129ef27e24b2054a3906fc4fb0d1398e


### PR DESCRIPTION
Remove the path-to-regexp resolution as it is not needed. By removing the resolution it doesn't actually change what version we are using to the resolution is not needed.