### PR TITLE
Remove nth-check resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
     "moment-timezone": "^0.5.41",
     "moment": "~2.29.4",
     "node-sass": "npm:sass@~1.34.1",
-    "nth-check": "^2.1.1",
     "patternfly": "~3.59.5",
     "request": "npm:@cypress/request@^3.0.9",
     "sinon": "~19.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10275,7 +10275,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nth-check@npm:^2.1.1":
+"nth-check@npm:^2.0.1":
   version: 2.1.1
   resolution: "nth-check@npm:2.1.1"
   dependencies:


### PR DESCRIPTION
Remove the nth-check resolution as the resolution isn't required. Deleting the resolution doesn't change the version in the yarn.lock meaning it is safe to delete this resolution. 