### PR TITLE
Ignore sass warnings from dependencies

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -159,6 +159,7 @@ module.exports = {
                   `${nodeModules}/font-awesome/scss`,
                   `${nodeModules}/@manageiq/font-fabulous/assets/stylesheets`,
                 ],
+                quietDeps: true,
               },
             },
           },

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "postcss-loader": "~4.0.4",
     "raw-loader": "~4.0.2",
     "resolve-url-loader": "~5.0.0",
-    "sass": "~1.34.1",
+    "sass": "~1.35.1",
     "sass-lint": "~1.13.1",
     "sass-loader": "^11.1.1",
     "save-remote-file-webpack-plugin": "^1.1.0",
@@ -146,7 +146,7 @@
     "jquery": "~3.7.1",
     "moment-timezone": "^0.5.41",
     "moment": "~2.29.4",
-    "node-sass": "npm:sass@~1.34.1",
+    "node-sass": "npm:sass@~1.35.1",
     "patternfly": "~3.59.5",
     "request": "npm:@cypress/request@^3.0.9"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9477,7 +9477,7 @@ __metadata:
     postcss-loader: "npm:~4.0.4"
     raw-loader: "npm:~4.0.2"
     resolve-url-loader: "npm:~5.0.0"
-    sass: "npm:~1.34.1"
+    sass: "npm:~1.35.1"
     sass-lint: "npm:~1.13.1"
     sass-loader: "npm:^11.1.1"
     save-remote-file-webpack-plugin: "npm:^1.1.0"
@@ -10149,14 +10149,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-sass@npm:sass@~1.34.1, sass@npm:~1.34.1":
-  version: 1.34.1
-  resolution: "sass@npm:1.34.1"
+"node-sass@npm:sass@~1.35.1, sass@npm:~1.35.1":
+  version: 1.35.2
+  resolution: "sass@npm:1.35.2"
   dependencies:
     chokidar: "npm:>=3.0.0 <4.0.0"
   bin:
     sass: sass.js
-  checksum: 10/0a67dd5f8500dfbb0fb8bd768e33bd597b6db429a3106c3ad0d17e107e3efc9702150c1f54628b2e328144d04277a0bd80e48c8b49cad29f2adaf14cb69f0210
+  checksum: 10/8651a42ee04d3595bb8a5997709e0e770d1d5ba34b7034cfd421eab4bea4d1a0c85f377c9d641fda98b6eb542b2d998e4ca8d97bba683b2c62a2bca815a5b598
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This drops all of the output from the webpack build, which is not actionable. Specifically, we can't upgrade patternfly, so this removes all of the warnings related to patternfly.

@asirvadAbrahamVarghese Please review. Similar to https://github.com/ManageIQ/manageiq-ui-classic/pull/10009.
