### PR TITLE
Add Slack webhook URL for failures on update-yarn-lock

### DIFF
--- a/.github/workflows/update_yarn_lock.yaml
+++ b/.github/workflows/update_yarn_lock.yaml
@@ -14,4 +14,5 @@ jobs:
     with:
       pr_repository: miq-bot/manageiq-ui-service
     secrets:
-      pr_token: "${{ secrets.PR_TOKEN }}"
+      GHA_STATUS_SLACK_WEBHOOK_URL: "${{ secrets.GHA_STATUS_SLACK_WEBHOOK_URL }}"
+      PR_TOKEN: "${{ secrets.PR_TOKEN }}"


### PR DESCRIPTION
Depends on 
- [x] https://github.com/ManageIQ/.github/pull/29