### PR TITLE
Get exact novnc version from node_modules

### DIFF
--- a/config/download-novnc-plugin.js
+++ b/config/download-novnc-plugin.js
@@ -4,8 +4,7 @@ const path = require('path');
 
 class DownloadNoVNCPlugin {
   constructor(options = {}) {
-    const packageJson = require('../package.json');
-    const novncVersion = packageJson.dependencies['@novnc/novnc'].replace(/[~^]/, '');
+    const novncVersion = require('@novnc/novnc/package.json')?.version;
     
     this.targetFile = 'vnc_lite.html';
     this.url = options.url || `https://raw.githubusercontent.com/novnc/noVNC/v${novncVersion}/${this.targetFile}`;


### PR DESCRIPTION
Follow up to https://github.com/ManageIQ/manageiq-ui-service/pull/2109

PR to update the version lookup as mentioned in [this comment](https://github.com/ManageIQ/manageiq-ui-service/pull/2109#discussion_r3560468840)
>The only downside to this is since we use ~, if they ever release, say, a 1.2.1, we'd pull 1.2.0. Ideally we'd want to pull the value from the lockfile instead which is more accurate. That being say, novnc is up to 1.7.0 and it's very unlikely a 1.2.1 will ever be released so it's fine for now, but if we update to 1.7+ we might run into issues.
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
